### PR TITLE
add default namespace for OperandRegistry & OperandConfigs seed CRs 

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
@@ -2,6 +2,7 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
   name: common-service
+  namespace: ibm-common-services
 spec:
   operators:
   - name: ibm-metering-operator

--- a/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
@@ -2,6 +2,7 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRequest
 metadata:
   name: common-service
+  namespace: ibm-common-services
 spec:
   services:
   - name: ibm-cert-manager-operator

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
@@ -117,7 +117,8 @@ metadata:
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandRegistry",
           "metadata": {
-            "name": "common-service"
+            "name": "common-service",
+            "namespace": "ibm-common-services"
           },
           "spec": {
             "operators": [
@@ -231,7 +232,7 @@ metadata:
               },
               {
                 "channel": "alpha",
-                "description": "Operator for managing deployment of helm API service.",
+                "description": "Operator for managing deployment of helm api service.",
                 "name": "ibm-helm-api-operator",
                 "namespace": "ibm-common-services",
                 "packageName": "ibm-helm-api-operator-app",
@@ -263,7 +264,8 @@ metadata:
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandRequest",
           "metadata": {
-            "name": "common-service"
+            "name": "common-service",
+            "namespace": "ibm-common-services"
           },
           "spec": {
             "services": [


### PR DESCRIPTION
**What this PR does / why we need it**:

based on Mike's comment, the OperandRegistry & OperandConfigs CRs should be deployed in the `ibm-common-services` namespace. 

 https://github.ibm.com/IBMPrivateCloud/roadmap/issues/34718#issuecomment-18154542


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
