### PR TITLE
integrate IBM Monitoring Prometheus Operator Extension

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
@@ -60,3 +60,6 @@ spec:
   - name: ibm-monitoring-exporters-operator
     spec:
       exporter: {}
+  - name: ibm-monitoring-prometheusext-operator
+    spec:
+      prometheusExt: {}

--- a/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
@@ -117,3 +117,10 @@ spec:
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
     description: Operator to provision node-exporter, kube-state-metrics and collectd exporter with tls enabled.
+  - name: ibm-monitoring-prometheusext-operator
+    namespace: ibm-common-services
+    channel: alpha
+    packageName: ibm-monitoring-prometheusext-operator-app
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace
+    description: Operator to deploy Prometheus and Alertmanager instances with RBAC enabled. It will also enable Multicloud monitoring.

--- a/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
@@ -9,6 +9,7 @@ spec:
   - operand: ibm-mongodb-operator
   - operand: ibm-iam-operator
   - operand: ibm-monitoring-exporters-operator
+  - operand: ibm-monitoring-prometheusext-operator
   - operand: ibm-healthcheck-operator
   # - operand: ibm-management-ingress-operator
   # - operand: ibm-ingress-nginx-operator

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
@@ -115,6 +115,12 @@ metadata:
                 "spec": {
                   "exporter": {}
                 }
+              },
+              {
+                "name": "ibm-monitoring-prometheusext-operator",
+                "spec": {
+                  "prometheusExt": {}
+                }
               }
             ]
           }
@@ -271,6 +277,15 @@ metadata:
                 "packageName": "ibm-monitoring-exporters-operator-app",
                 "sourceName": "opencloud-operators",
                 "sourceNamespace": "openshift-marketplace"
+              },
+              {
+                "name": "ibm-monitoring-prometheusext-operator",
+                "namespace": "ibm-common-services",
+                "channel": "alpha",
+                "packageName": "ibm-monitoring-prometheusext-operator-app",
+                "sourceName": "opencloud-operators",
+                "sourceNamespace": "openshift-marketplace",
+                "description": "Operator to deploy Prometheus and Alertmanager instances with RBAC enabled. It will also enable Multicloud monitoring."
               }
             ]
           }
@@ -298,6 +313,9 @@ metadata:
               },
               {
                 "operand": "ibm-healthcheck-operator"
+              },
+              {
+                "operand": "ibm-monitoring-prometheusext-operator"
               }
             ]
           }


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR integrates IBM Monitoring Prometheus Operator Extension for easier to use and enhanced Prometheus deployment.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
