### PR TITLE
Add default handle logic for registryNamespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,7 @@ code-dev: ## Run the default dev commands which are the go tidy, fmt, vet then e
 	- make build
 
 run: ## Run against the configured Kubernetes cluster in ~/.kube/config
-	WATCH_NAMESPACE= go run ./cmd/manager/main.go --zap-level=5 --zap-encoder=console
+	WATCH_NAMESPACE= go run ./cmd/manager/main.go -v=3 --zap-encoder=console
 
 ifeq ($(BUILD_LOCALLY),0)
     export CONFIG_DOCKER_TARGET = config-docker

--- a/pkg/apis/operator/v1alpha1/operandrequest_types.go
+++ b/pkg/apis/operator/v1alpha1/operandrequest_types.go
@@ -284,6 +284,15 @@ func (r *OperandRequest) SetClusterPhase(p ClusterPhase) {
 	r.Status.Phase = p
 }
 
+// SetDefaultsRequest Set the default value for Request spec
+func (r *OperandRequest) SetDefaultsRequest() {
+	for i, req := range r.Spec.Requests {
+		if req.RegistryNamespace == "" {
+			r.Spec.Requests[i].RegistryNamespace = r.Namespace
+		}
+	}
+}
+
 func init() {
 	SchemeBuilder.Register(&OperandRequest{}, &OperandRequestList{})
 }

--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -163,6 +163,13 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
+	// Set default for OperandRequest instance
+	requestInstance.SetDefaultsRequest()
+	err := r.client.Update(context.TODO(), requestInstance)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Add finalizer
 	if requestInstance.GetFinalizers() == nil {
 		if err := r.addFinalizer(requestInstance); err != nil {
@@ -202,7 +209,7 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 	}
 
 	// Fetch Subscriptions and check the status of install plan
-	err := r.waitForInstallPlan(requestInstance, request)
+	err = r.waitForInstallPlan(requestInstance, request)
 	if err != nil {
 		if err.Error() == "timed out waiting for the condition" {
 			return reconcile.Result{Requeue: true}, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
The registryNamespace is an optional property inside of OperandRequest, if user don't set this value when creating an OperandRequest CR, OperandRequest controller will set a default value is the current namespace in which the request is defined

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #191

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
