### PR TITLE
adding navconfig to common-ui

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
@@ -36,6 +36,7 @@ spec:
     spec:
       commonWebUI: {}
       legacyHeader: {}
+      navconfiguration: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds the navconfiguration CRs to commonui-operator for providing default navItems.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/36315
