### PR TITLE
Operandconfig delete

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
@@ -13,7 +13,7 @@ spec:
       IBMLicensing: {}
   - name: ibm-mongodb-operator
     spec:
-      mongodb: {}
+      mongoDB: {}
   - name: ibm-cert-manager-operator
     spec:
       certManager: {}

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
               {
                 "name": "ibm-mongodb-operator",
                 "spec": {
-                  "mongodb": {}
+                  "mongoDB": {}
                 }
               },
               {
@@ -62,7 +62,8 @@ metadata:
                 "name": "ibm-commonui-operator",
                 "spec": {
                   "commonWebUI": {},
-                  "legacyHeader": {}
+                  "legacyHeader": {},
+                  "navconfiguration": {}
                 }
               },
               {
@@ -470,14 +471,14 @@ spec:
           strategy: {}
           template:
             metadata:
+              annotations:
+                productID: 068a62892a1e4db39641342e592daa25
+                productMetric: FREE
+                productName: IBM Cloud Platform Common Services
+                productVersion: 3.3.0
               labels:
                 app.kubernetes.io/instance: operand-deployment-lifecycle-manager
                 name: operand-deployment-lifecycle-manager
-              annotations:
-                productName: "IBM Cloud Platform Common Services"
-                productID: "068a62892a1e4db39641342e592daa25"
-                productVersion: "3.3.0"
-                productMetric: "FREE"
             spec:
               containers:
               - args:

--- a/pkg/controller/operandrequest/config_status.go
+++ b/pkg/controller/operandrequest/config_status.go
@@ -35,7 +35,7 @@ func (r *ReconcileOperandRequest) updateServiceStatus(cr *operatorv1alpha1.Opera
 }
 
 func (r *ReconcileOperandRequest) deleteServiceStatus(cr *operatorv1alpha1.OperandConfig, operatorName, serviceName string) error {
-	klog.V(3).Infof("Deleting custom resouce %s from OperandConfig status", serviceName)
+	klog.V(3).Infof("Deleting custom resource %s from OperandConfig status", serviceName)
 
 	configInstance, err := r.getConfigInstance(cr.Name, cr.Namespace)
 	if err != nil {

--- a/pkg/controller/operandrequest/config_status.go
+++ b/pkg/controller/operandrequest/config_status.go
@@ -35,7 +35,7 @@ func (r *ReconcileOperandRequest) updateServiceStatus(cr *operatorv1alpha1.Opera
 }
 
 func (r *ReconcileOperandRequest) deleteServiceStatus(cr *operatorv1alpha1.OperandConfig, operatorName, serviceName string) error {
-	klog.V(3).Info("Deleting OperandConfig status")
+	klog.V(3).Infof("Deleting custom resouce %s from OperandConfig status", serviceName)
 
 	configInstance, err := r.getConfigInstance(cr.Name, cr.Namespace)
 	if err != nil {

--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -137,7 +137,7 @@ type multiErr struct {
 }
 
 func (mer *multiErr) Error() string {
-	return "Operand Deleployment Lifecycle Manager reconcile errors : " + strings.Join(mer.errors, ":")
+	return "Operand Deleployment Lifecycle Manager reconcile error list : " + strings.Join(mer.errors, " # ")
 }
 
 func (mer *multiErr) Add(err error) {

--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -137,7 +137,7 @@ type multiErr struct {
 }
 
 func (mer *multiErr) Error() string {
-	return "Operand Deleployment Lifecycle Manager reconcile error list : " + strings.Join(mer.errors, " # ")
+	return "Operand reconcile error list : " + strings.Join(mer.errors, " # ")
 }
 
 func (mer *multiErr) Add(err error) {

--- a/pkg/util/lcFirst.go
+++ b/pkg/util/lcFirst.go
@@ -20,10 +20,10 @@ import (
 	"unicode"
 )
 
-// Lcfirst changes the first charactor to lower case
+// Lcfirst changes the first character to lower case
 func Lcfirst(str string) string {
-    for i, v := range str {
-        return string(unicode.ToLower(v)) + str[i+1:]
-    }
-    return ""
+	for i, v := range str {
+		return string(unicode.ToLower(v)) + str[i+1:]
+	}
+	return ""
 }

--- a/pkg/util/lcFirst.go
+++ b/pkg/util/lcFirst.go
@@ -1,0 +1,29 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package util
+
+import (
+	"unicode"
+)
+
+// Lcfirst changes the first charactor to lower case
+func Lcfirst(str string) string {
+    for i, v := range str {
+        return string(unicode.ToLower(v)) + str[i+1:]
+    }
+    return ""
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #199 

This PR is used to implement the function when the CR is removed from the operandconfig ODLM can remove the CR from the cluster.
 
Moreover, expose more error messages in the logs.
  
**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
