### PR TITLE
remove ibm-common-services namespace

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
@@ -2,7 +2,6 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRegistry
 metadata:
   name: common-service
-  namespace: ibm-common-services
 spec:
   operators:
   - name: ibm-metering-operator

--- a/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
@@ -2,11 +2,9 @@ apiVersion: operator.ibm.com/v1alpha1
 kind: OperandRequest
 metadata:
   name: common-service
-  namespace: ibm-common-services
 spec:
   requests:
   - registry: common-service
-    registryNamespace: ibm-common-services
     operands:
     - name: ibm-cert-manager-operator
     - name: ibm-mongodb-operator

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
@@ -299,13 +299,14 @@ metadata:
                 "sourceNamespace": "openshift-marketplace"
               },
               {
+                "channel": "alpha",
+                "description": "Operator to deploy Grafana instances with RBAC enabled.",
                 "name": "ibm-monitoring-grafana-operator",
                 "namespace": "ibm-common-services",
-                "channel": "alpha",
                 "packageName": "ibm-monitoring-grafana-operator-app",
+                "scope": "private",
                 "sourceName": "opencloud-operators",
-                "sourceNamespace": "openshift-marketplace",
-                "description": "Operator to deploy Grafana instances with RBAC enabled."
+                "sourceNamespace": "openshift-marketplace"
               }
             ]
           }
@@ -314,8 +315,7 @@ metadata:
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandRequest",
           "metadata": {
-            "name": "common-service",
-            "namespace": "ibm-common-services"
+            "name": "common-service"
           },
           "spec": {
             "requests": [
@@ -337,14 +337,13 @@ metadata:
                     "name": "ibm-monitoring-prometheusext-operator"
                   },
                   {
-                    "name": "ibm-monitoring-grafana-operator"
+                    "name": "ibm-healthcheck-operator"
                   },
                   {
-                    "name": "ibm-healthcheck-operator"
+                    "name": "ibm-monitoring-grafana-operator"
                   }
                 ],
-                "registry": "common-service",
-                "registryNamespace": "ibm-common-services"
+                "registry": "common-service"
               }
             ]
           }

--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -91,8 +91,6 @@ const (
 	ServiceFailed  ServicePhase = "Failed"
 )
 
-const OperandConfigNamespace = "ibm-common-services"
-
 func init() {
 	SchemeBuilder.Register(&OperandConfig{}, &OperandConfigList{})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** 

This PR is for passing the RH certification.

RH certification will deploy the operator in their testing environment and do some tests, but their environment doesn't have `ibm-common-services` namespace. 
So, I make this PR to clear up the hard code namespace in the ODLM 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
