### PR TITLE
Refactor operandConfig reconcile

### DIFF
--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
@@ -140,8 +140,7 @@ metadata:
           "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandRegistry",
           "metadata": {
-            "name": "common-service",
-            "namespace": "ibm-common-services"
+            "name": "common-service"
           },
           "spec": {
             "operators": [

--- a/pkg/controller/operandrequest/config_status.go
+++ b/pkg/controller/operandrequest/config_status.go
@@ -41,8 +41,10 @@ func (r *ReconcileOperandRequest) deleteServiceStatus(cr *operatorv1alpha1.Opera
 	if err != nil {
 		return err
 	}
+
 	delete(configInstance.Status.ServiceStatus[operatorName].CrStatus, serviceName)
-	if err := r.client.Status().Update(context.TODO(), cr); err != nil {
+
+	if err := r.client.Status().Update(context.TODO(), configInstance); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -44,20 +44,20 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 		for _, operand := range req.Operands {
 			configInstance, err := r.getConfigInstance(req.Registry, req.RegistryNamespace)
 			if err != nil {
-				klog.Error("Error when get Config Instance: ", err)
+				klog.Error("Failed to get Operand Config Instance: ", err)
 				merr.Add(err)
 				continue
 			}
 			// Check the requested Service Config if exist in specific OperandConfig
 			svc := r.getServiceFromConfigInstance(operand.Name, configInstance)
 			if svc != nil {
-				klog.V(4).Info("Reconciling custom resource: ", svc.Name)
+				klog.V(3).Info("Reconciling custom resource: ", svc.Name)
 				// Looking for the CSV
 				csv, err := r.getClusterServiceVersion(svc.Name)
 
 				// If can't get CSV, requeue the request
 				if err != nil {
-					klog.Error("Error when get Cluster Service Version: ", err)
+					klog.Error("Failed to get Cluster Service Version: ", err)
 					merr.Add(err)
 					continue
 				}
@@ -66,10 +66,10 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 					continue
 				}
 
-				klog.V(4).Info("Generating custom resource base on Cluster Service Version: ", csv.ObjectMeta.Name)
+				klog.V(3).Info("Generating custom resource base on Cluster Service Version: ", csv.ObjectMeta.Name)
 
 				// Merge and Generate CR
-				err = r.createUpdateCr(svc, csv, configInstance)
+				err = r.reconcileCr(svc, csv, configInstance)
 				if err != nil {
 					klog.Error("Error when get create or update custom resource: ", err)
 					merr.Add(err)
@@ -85,7 +85,7 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 
 // getCSV retrieves the Cluster Service Version
 func (r *ReconcileOperandRequest) getClusterServiceVersion(subName string) (*olmv1alpha1.ClusterServiceVersion, error) {
-	klog.V(2).Info("Looking for the Cluster Service Version ", "in Subscription: ", subName)
+	klog.V(3).Info("Looking for the Cluster Service Version ", "in Subscription: ", subName)
 	subs, listSubErr := r.olmClient.OperatorsV1alpha1().Subscriptions("").List(metav1.ListOptions{
 		LabelSelector: "operator.ibm.com/opreq-control",
 	})
@@ -97,7 +97,7 @@ func (r *ReconcileOperandRequest) getClusterServiceVersion(subName string) (*olm
 	for _, s := range subs.Items {
 		if s.Name == subName {
 			if s.Status.CurrentCSV == "" {
-				klog.V(4).Info("There is no Cluster Service Version for the Subscription: ", subName)
+				klog.V(3).Info("There is no Cluster Service Version for the Subscription: ", subName)
 				return nil, nil
 			}
 			csvName = s.Status.CurrentCSV
@@ -110,16 +110,16 @@ func (r *ReconcileOperandRequest) getClusterServiceVersion(subName string) (*olm
 				klog.Error("Fail to get Cluster Service Version: ", getCSVErr)
 				return nil, getCSVErr
 			}
-			klog.V(2).Info("Get Cluster Service Version: ", csvName, " in namespace: ", csvNamespace)
+			klog.V(3).Info("Get Cluster Service Version: ", csvName, " in namespace: ", csvNamespace)
 			return csv, nil
 		}
 	}
-	klog.V(2).Info("There is no Cluster Service Version for: ", subName)
+	klog.V(3).Info("There is no Cluster Service Version for: ", subName)
 	return nil, nil
 }
 
-// createUpdateCr merge and create custome resource base on OperandConfig and CSV alm-examples
-func (r *ReconcileOperandRequest) createUpdateCr(service *operatorv1alpha1.ConfigService, csv *olmv1alpha1.ClusterServiceVersion, csc *operatorv1alpha1.OperandConfig) error {
+// reconcileCr merge and create custome resource base on OperandConfig and CSV alm-examples
+func (r *ReconcileOperandRequest) reconcileCr(service *operatorv1alpha1.ConfigService, csv *olmv1alpha1.ClusterServiceVersion, csc *operatorv1alpha1.OperandConfig) error {
 	almExamples := csv.ObjectMeta.Annotations["alm-examples"]
 	namespace := csv.ObjectMeta.Namespace
 
@@ -142,127 +142,33 @@ func (r *ReconcileOperandRequest) createUpdateCr(service *operatorv1alpha1.Confi
 		var unstruct unstructured.Unstructured
 		unstruct.Object = crTemplate.(map[string]interface{})
 
-		// Get the kind of CR
-		kind := unstruct.Object["kind"].(string)
-		apiversion := unstruct.Object["apiVersion"].(string)
 		name := unstruct.Object["metadata"].(map[string]interface{})["name"].(string)
 
-		var found bool
-		for crdName, crConfig := range service.Spec {
-			// Compare the name of OperandConfig and CRD name
-			if strings.EqualFold(kind, crdName) {
-				klog.V(4).Info("Found OperandConfig spec for custom resource: " + kind)
-				found = true
-				//Convert CR template spec to string
-				specJSONString, _ := json.Marshal(unstruct.Object["spec"])
+		getError := r.client.Get(context.TODO(), types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		}, &unstruct)
 
-				// Merge CR template spec and OperandConfig spec
-				mergedCR := util.MergeCR(specJSONString, crConfig.Raw)
-
-				unstruct.Object["spec"] = mergedCR
-				unstruct.Object["metadata"].(map[string]interface{})["namespace"] = namespace
-				if unstruct.Object["metadata"].(map[string]interface{})["labels"] == nil {
-					klog.V(4).Info("Adding ODLM label in the custom resource")
-					unstruct.Object["metadata"].(map[string]interface{})["labels"] = make(map[string]interface{})
-				}
-				unstruct.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] = t
-				// Creat or Update the CR
-				crCreateErr := r.client.Create(context.TODO(), &unstruct)
-				if crCreateErr != nil && !errors.IsAlreadyExists(crCreateErr) {
-					stateUpdateErr := r.updateServiceStatus(csc, service.Name, crdName, operatorv1alpha1.ServiceFailed)
-					if stateUpdateErr != nil {
-						klog.Error("Fail to update status")
-						merr.Add(stateUpdateErr)
-					}
-					klog.Error("Fail to Create the Custom Resource: ", crdName, ". Error message: ", crCreateErr)
-					merr.Add(crCreateErr)
-				} else if errors.IsAlreadyExists(crCreateErr) {
-					existingCR := unstructured.Unstructured{
-						Object: map[string]interface{}{
-							"apiVersion": apiversion,
-							"kind":       kind,
-						},
-					}
-					crGetErr := r.client.Get(context.TODO(), types.NamespacedName{
-						Name:      name,
-						Namespace: namespace,
-					}, &existingCR)
-					if crGetErr != nil {
-						stateUpdateErr := r.updateServiceStatus(csc, service.Name, crdName, operatorv1alpha1.ServiceFailed)
-						if stateUpdateErr != nil {
-							klog.Error("Fail to update status")
-							merr.Add(stateUpdateErr)
-						}
-						klog.Error("Fail to Get the Custom Resource: ", crdName, ". Error message: ", crGetErr)
-						merr.Add(crGetErr)
-						continue
-					}
-					if existingCR.Object["metadata"].(map[string]interface{})["labels"] != nil && existingCR.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
-						existingCR.Object["spec"] = unstruct.Object["spec"]
-						if crUpdateErr := r.client.Update(context.TODO(), &existingCR); crUpdateErr != nil {
-							stateUpdateErr := r.updateServiceStatus(csc, service.Name, crdName, operatorv1alpha1.ServiceFailed)
-							if stateUpdateErr != nil {
-								klog.Error("Fail to update status")
-								merr.Add(stateUpdateErr)
-							}
-							klog.Error("Fail to Update the Custom Resource ", crdName, ". Error message: ", crUpdateErr)
-							merr.Add(crUpdateErr)
-							continue
-						}
-						klog.V(2).Info("Finish updating the Custom Resource: ", crdName)
-						stateUpdateErr := r.updateServiceStatus(csc, service.Name, crdName, operatorv1alpha1.ServiceRunning)
-						if stateUpdateErr != nil {
-							klog.Error("Fail to update status")
-							merr.Add(stateUpdateErr)
-						}
-					} else {
-						klog.V(3).Info("Skip the custom resource created by other users")
-					}
-				} else {
-					klog.V(2).Info("Finish creating the Custom Resource: ", crdName)
-					stateUpdateErr := r.updateServiceStatus(csc, service.Name, crdName, operatorv1alpha1.ServiceRunning)
-					if stateUpdateErr != nil {
-						klog.Error("Fail to update status")
-						merr.Add(stateUpdateErr)
-					}
-				}
-			}
-		}
-		if !found {
-			crShouldBeDeleted := &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": apiversion,
-					"kind":       kind,
-				},
-			}
-			getError := r.client.Get(context.TODO(), types.NamespacedName{
-				Name:      name,
-				Namespace: namespace,
-			}, crShouldBeDeleted)
-			if getError != nil && !errors.IsNotFound(getError) {
-				klog.Error("Failed to get the custom resource should be deleted: ", getError)
-				merr.Add(getError)
+		if getError != nil && !errors.IsNotFound(getError) {
+			klog.Error("Failed to get the custom resource should be deleted: ", getError)
+			merr.Add(getError)
+			continue
+		} else if errors.IsNotFound(getError) {
+			// Create Custom resource
+			if createErr := r.compareConfigandExample(unstruct, service, namespace, csc); createErr != nil {
+				merr.Add(createErr)
 				continue
 			}
-			if !errors.IsNotFound(getError) {
-				if crShouldBeDeleted.Object["metadata"].(map[string]interface{})["labels"] != nil && crShouldBeDeleted.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
-					klog.V(3).Infof("Deleting custom resource: %s from custom resource definition: %s", name, kind)
-					deleteErr := r.client.Delete(context.TODO(), crShouldBeDeleted)
-					if deleteErr != nil {
-						klog.Error("Failed to delete the custom resource should be deleted: ", deleteErr)
-						merr.Add(deleteErr)
-						continue
-					}
-					stateDeleteErr := r.deleteServiceStatus(csc, service.Name, util.Lcfirst(kind))
-					if stateDeleteErr != nil {
-						klog.Error("Failed to clean up the deleted service status in the operand config: ", stateDeleteErr)
-						merr.Add(stateDeleteErr)
-						continue
-					}
-					klog.V(3).Infof("Finish deleting custom resource: %s from custom resource definition: %s", name, kind)
+		} else {
+			if unstruct.Object["metadata"].(map[string]interface{})["labels"] != nil && unstruct.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
+				// Update or Delete Custom resource
+				if updateDeleteErr := r.existingCustomResource(unstruct, service, namespace, csc); updateDeleteErr != nil {
+					merr.Add(updateDeleteErr)
+					continue
 				}
+			} else {
+				klog.V(2).Info("Skip the custom resource created by other users")
 			}
-
 		}
 	}
 	if len(merr.errors) != 0 {
@@ -271,8 +177,8 @@ func (r *ReconcileOperandRequest) createUpdateCr(service *operatorv1alpha1.Confi
 	return nil
 }
 
-// deleteCr remove custome resource base on OperandConfig and CSV alm-examples
-func (r *ReconcileOperandRequest) deleteCr(csv *olmv1alpha1.ClusterServiceVersion, csc *operatorv1alpha1.OperandConfig, operandName string) error {
+// deleteAllCustomResource remove custome resource base on OperandConfig and CSV alm-examples
+func (r *ReconcileOperandRequest) deleteAllCustomResource(csv *olmv1alpha1.ClusterServiceVersion, csc *operatorv1alpha1.OperandConfig, operandName string) error {
 
 	service := r.getServiceFromConfigInstance(operandName, csc)
 
@@ -317,7 +223,7 @@ func (r *ReconcileOperandRequest) deleteCr(csv *olmv1alpha1.ClusterServiceVersio
 					continue
 				}
 				if errors.IsNotFound(getError) {
-					klog.V(4).Info("Deleted the CR: " + kind)
+					klog.V(2).Info("Finish Deleting the CR: " + kind)
 					stateDeleteErr := r.deleteServiceStatus(csc, service.Name, crdName)
 					if stateDeleteErr != nil {
 						klog.Error("Failed to clean up the deleted service status in the operand config: ", stateDeleteErr)
@@ -326,42 +232,13 @@ func (r *ReconcileOperandRequest) deleteCr(csv *olmv1alpha1.ClusterServiceVersio
 					continue
 				}
 				if unstruct.Object["metadata"].(map[string]interface{})["labels"] != nil && unstruct.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
-					crDeleteErr := r.client.Delete(context.TODO(), &unstruct)
-					if crDeleteErr != nil && !errors.IsNotFound(crDeleteErr) {
-						klog.Error("Failed to delete the custom resource: ", crDeleteErr)
-						merr.Add(crDeleteErr)
-						continue
+					deleteErr := r.deleteCustomResource(unstruct, service, namespace, csc)
+					if deleteErr != nil {
+						klog.Error("Failed to delete custom resource: ", deleteErr)
+						return deleteErr
 					}
-					klog.V(4).Info("Waiting for CR: " + kind + " is deleted")
-					err := wait.PollImmediate(time.Second*20, time.Minute*10, func() (bool, error) {
-						klog.V(4).Info("Checking for CR: " + kind + " is deleted")
-						err := r.client.Get(context.TODO(), types.NamespacedName{
-							Name:      name,
-							Namespace: namespace,
-						},
-							&unstruct)
-						if errors.IsNotFound(err) {
-							return true, nil
-						}
-						if err != nil {
-							klog.Error("Failed to get the custom resource: ", err)
-							return false, err
-						}
-						return false, nil
-					})
-					if err != nil {
-						klog.Error(err)
-						merr.Add(err)
-						continue
-					}
-					stateDeleteErr := r.deleteServiceStatus(csc, service.Name, crdName)
-					if stateDeleteErr != nil {
-						klog.Error("Failed to clean up the deleted service status in the operand config: ", stateDeleteErr)
-						merr.Add(stateDeleteErr)
-						continue
-					}
-					klog.V(4).Info("Deleted the CR: " + kind)
 				}
+
 			}
 
 		}
@@ -384,10 +261,211 @@ func (r *ReconcileOperandRequest) getConfigInstance(name, namespace string) (*op
 }
 
 func (r *ReconcileOperandRequest) getServiceFromConfigInstance(operandName string, configInstance *operatorv1alpha1.OperandConfig) *operatorv1alpha1.ConfigService {
-	klog.V(4).Info("Get ConfigService from the OperandConfig instance: ", configInstance.ObjectMeta.Name, " and operand name: ", operandName)
+	klog.V(3).Info("Get ConfigService from the OperandConfig instance: ", configInstance.ObjectMeta.Name, " and operand name: ", operandName)
 	for _, s := range configInstance.Spec.Services {
 		if s.Name == operandName {
 			return &s
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileOperandRequest) compareConfigandExample(unstruct unstructured.Unstructured, service *operatorv1alpha1.ConfigService, namespace string, csc *operatorv1alpha1.OperandConfig) error {
+	kind := unstruct.Object["kind"].(string)
+
+	for crName, crdConfig := range service.Spec {
+		// Compare the name of OperandConfig and CRD name
+		if strings.EqualFold(kind, crName) {
+			klog.V(3).Info("Found OperandConfig spec for custom resource: " + kind)
+			createErr := r.createCustomResource(unstruct, service, namespace, crName, csc, crdConfig.Raw)
+			if createErr != nil {
+				klog.Error("Failed to create custom resource: ", createErr)
+				return createErr
+			}
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileOperandRequest) createCustomResource(unstruct unstructured.Unstructured, service *operatorv1alpha1.ConfigService, namespace, crName string, csc *operatorv1alpha1.OperandConfig, crConfig []byte) error {
+
+	//Convert CR template spec to string
+	specJSONString, _ := json.Marshal(unstruct.Object["spec"])
+
+	// Merge CR template spec and OperandConfig spec
+	mergedCR := util.MergeCR(specJSONString, crConfig)
+
+	unstruct.Object["spec"] = mergedCR
+	unstruct.Object["metadata"].(map[string]interface{})["namespace"] = namespace
+	if unstruct.Object["metadata"].(map[string]interface{})["labels"] == nil {
+		klog.V(3).Info("Adding ODLM label in the custom resource")
+		unstruct.Object["metadata"].(map[string]interface{})["labels"] = make(map[string]interface{})
+	}
+	unstruct.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] = t
+	// Creat or Update the CR
+	crCreateErr := r.client.Create(context.TODO(), &unstruct)
+	if crCreateErr != nil && !errors.IsAlreadyExists(crCreateErr) {
+		stateUpdateErr := r.updateServiceStatus(csc, service.Name, crName, operatorv1alpha1.ServiceFailed)
+		if stateUpdateErr != nil {
+			klog.Error("Fail to update status")
+			return stateUpdateErr
+		}
+		klog.Error("Fail to Create the Custom Resource: ", crName, ". Error message: ", crCreateErr)
+		return crCreateErr
+	}
+
+	klog.V(2).Info("Finish creating the Custom Resource: ", crName)
+	stateUpdateErr := r.updateServiceStatus(csc, service.Name, crName, operatorv1alpha1.ServiceRunning)
+	if stateUpdateErr != nil {
+		klog.Error("Fail to update status")
+		return stateUpdateErr
+	}
+
+	return nil
+}
+
+func (r *ReconcileOperandRequest) existingCustomResource(unstruct unstructured.Unstructured, service *operatorv1alpha1.ConfigService, namespace string, csc *operatorv1alpha1.OperandConfig) error {
+	kind := unstruct.Object["kind"].(string)
+
+	var found bool
+	for crName, crdConfig := range service.Spec {
+		// Compare the name of OperandConfig and CRD name
+		if strings.EqualFold(kind, crName) {
+			found = true
+			klog.V(3).Info("Found OperandConfig spec for custom resource: " + kind)
+			updateErr := r.updateCustomResource(unstruct, service, namespace, crName, csc, crdConfig.Raw)
+			if updateErr != nil {
+				klog.Error("Failed to create custom resource: ", updateErr)
+				return updateErr
+			}
+		}
+	}
+	if !found {
+		deleteErr := r.deleteCustomResource(unstruct, service, namespace, csc)
+		if deleteErr != nil {
+			klog.Error("Failed to delete custom resource: ", deleteErr)
+			return deleteErr
+		}
+	}
+	return nil
+}
+
+func (r *ReconcileOperandRequest) updateCustomResource(unstruct unstructured.Unstructured, service *operatorv1alpha1.ConfigService, namespace, crName string, csc *operatorv1alpha1.OperandConfig, crConfig []byte) error {
+
+	kind := unstruct.Object["kind"].(string)
+	apiversion := unstruct.Object["apiVersion"].(string)
+	name := unstruct.Object["metadata"].(map[string]interface{})["name"].(string)
+
+	// Update the CR
+
+	existingCR := unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiversion,
+			"kind":       kind,
+		},
+	}
+
+	crGetErr := r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, &existingCR)
+
+	if crGetErr != nil {
+		stateUpdateErr := r.updateServiceStatus(csc, service.Name, crName, operatorv1alpha1.ServiceFailed)
+		if stateUpdateErr != nil {
+			klog.Error("Fail to update status")
+			return stateUpdateErr
+		}
+		klog.Error("Fail to Get the Custom Resource: ", crName, ". Error message: ", crGetErr)
+		return crGetErr
+	}
+
+	if existingCR.Object["metadata"].(map[string]interface{})["labels"] != nil && existingCR.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
+
+		specJSONString, _ := json.Marshal(unstruct.Object["spec"])
+
+		// Merge CR template spec and OperandConfig spec
+		mergedCR := util.MergeCR(specJSONString, crConfig)
+
+		existingCR.Object["spec"] = mergedCR
+		if crUpdateErr := r.client.Update(context.TODO(), &existingCR); crUpdateErr != nil {
+			stateUpdateErr := r.updateServiceStatus(csc, service.Name, crName, operatorv1alpha1.ServiceFailed)
+			if stateUpdateErr != nil {
+				klog.Error("Fail to update status")
+				return stateUpdateErr
+			}
+			klog.Error("Fail to Update the Custom Resource ", crName, ". Error message: ", crUpdateErr)
+			return crUpdateErr
+		}
+		klog.V(2).Info("Finish updating the Custom Resource: ", crName)
+		stateUpdateErr := r.updateServiceStatus(csc, service.Name, crName, operatorv1alpha1.ServiceRunning)
+		if stateUpdateErr != nil {
+			klog.Error("Fail to update status")
+			return stateUpdateErr
+		}
+	}
+
+	return nil
+}
+
+func (r *ReconcileOperandRequest) deleteCustomResource(unstruct unstructured.Unstructured, service *operatorv1alpha1.ConfigService, namespace string, csc *operatorv1alpha1.OperandConfig) error {
+
+	// Get the kind of CR
+	kind := unstruct.Object["kind"].(string)
+	apiversion := unstruct.Object["apiVersion"].(string)
+	name := unstruct.Object["metadata"].(map[string]interface{})["name"].(string)
+
+	crShouldBeDeleted := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiversion,
+			"kind":       kind,
+		},
+	}
+	getError := r.client.Get(context.TODO(), types.NamespacedName{
+		Name:      name,
+		Namespace: namespace,
+	}, crShouldBeDeleted)
+	if getError != nil && !errors.IsNotFound(getError) {
+		klog.Error("Failed to get the custom resource should be deleted: ", getError)
+		return getError
+	}
+	if errors.IsNotFound(getError) {
+		klog.V(3).Infof("There is no custom resource: %s from custom resource definition: %s", name, kind)
+	} else {
+		if crShouldBeDeleted.Object["metadata"].(map[string]interface{})["labels"] != nil && crShouldBeDeleted.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
+			klog.V(3).Infof("Deleting custom resource: %s from custom resource definition: %s", name, kind)
+			deleteErr := r.client.Delete(context.TODO(), crShouldBeDeleted)
+			if deleteErr != nil {
+				klog.Error("Failed to delete the custom resource should be deleted: ", deleteErr)
+				return deleteErr
+			}
+			klog.V(3).Info("Waiting for CR: " + kind + " is deleted")
+			err := wait.PollImmediate(time.Second*20, time.Minute*10, func() (bool, error) {
+				klog.V(3).Info("Checking for CR: " + kind + " is deleted")
+				err := r.client.Get(context.TODO(), types.NamespacedName{
+					Name:      name,
+					Namespace: namespace,
+				},
+					&unstruct)
+				if errors.IsNotFound(err) {
+					return true, nil
+				}
+				if err != nil {
+					klog.Error("Failed to get the custom resource: ", err)
+					return false, err
+				}
+				return false, nil
+			})
+			if err != nil {
+				klog.Error("Failed to delete the custom resource should be deleted: ", err)
+				return err
+			}
+			stateDeleteErr := r.deleteServiceStatus(csc, service.Name, util.Lcfirst(kind))
+			if stateDeleteErr != nil {
+				klog.Error("Failed to clean up the deleted service status in the operand config: ", stateDeleteErr)
+				return stateDeleteErr
+			}
+			klog.V(2).Infof("Finish deleting custom resource: %s from custom resource definition: %s", name, kind)
 		}
 	}
 	return nil

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -224,7 +224,7 @@ func (r *ReconcileOperandRequest) deleteSubscription(operandName string, request
 
 	if csv != nil {
 		klog.V(3).Info("Deleting a Custom Resource")
-		if err := r.deleteCr(csv, configInstance, operandName); err != nil {
+		if err := r.deleteAllCustomResource(csv, configInstance, operandName); err != nil {
 			klog.Error("Failed to Delete a Custom Resource: ", err)
 			return err
 		}

--- a/pkg/controller/operandrequest/request_status.go
+++ b/pkg/controller/operandrequest/request_status.go
@@ -144,8 +144,6 @@ func (r *ReconcileOperandRequest) updateClusterPhase(cr *operatorv1alpha1.Operan
 		}
 
 		switch m.Phase.OperandPhase {
-		case operatorv1alpha1.ServiceReady:
-			clusterStatusStat.creatingNum++
 		case operatorv1alpha1.ServiceRunning:
 			clusterStatusStat.runningNum++
 		case operatorv1alpha1.ServiceFailed:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**
Fixes #203  
Fixes #202 

This PR is used to refactoring Operand Config reconcile.
- Modularized reconcile to CRUD
- Adjust logging level in Operand Config reconcile.
- When there is no custom resource is required,  the cluster phase will be `running`, even is the operand phase is `ready`.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
