### PR TITLE
Update the unit test to increase coverage

### DIFF
--- a/pkg/controller/operandconfig/operandconfig_controller_test.go
+++ b/pkg/controller/operandconfig/operandconfig_controller_test.go
@@ -16,7 +16,10 @@
 package operandconfig
 
 import (
+	"context"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	v1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
 
@@ -28,13 +31,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// TestConfigConfig runs ReconcileOperandConfig.Reconcile() against a
+// TestConfigController runs ReconcileOperandConfig.Reconcile() against a
 // fake client that tracks a OperandConfig object.
 func TestConfigController(t *testing.T) {
-
+	assert := assert.New(t)
 	var (
-		name      = "operand-deployment-lifecycle-manager-config"
-		namespace = "common-service"
+		name      = "cs-config"
+		namespace = "ibm-common-service"
 	)
 	// Mock request to simulate Reconcile() being called on an event for a
 	// watched resource .
@@ -81,26 +84,22 @@ func TestConfigController(t *testing.T) {
 	// Create a ReconcileOperandConfig object with the scheme and fake client.
 	r := &ReconcileOperandConfig{client: cl, scheme: s}
 
-	res, err := r.Reconcile(req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-	// Check the result of reconciliation to make sure it has the desired state.
-	if res.Requeue {
-		t.Error("reconcile requeue which is not expected")
+	_, err := r.Reconcile(req)
+	assert.NoError(err)
+
+	err = r.client.Get(context.TODO(), req.NamespacedName, config)
+	assert.NoError(err)
+	// Check the config init status
+	for sk, sv := range config.Status.ServiceStatus {
+		for ck, cv := range sv.CrStatus {
+			assert.Equal(v1alpha1.ServiceReady, cv, "servcie("+sk+"/"+ck+") phase should be 'Ready for Deployment'")
+		}
 	}
 
 	// Create a fake client to mock instance not found.
 	cl = fake.NewFakeClient()
 	// Create a ReconcileOperandConfig object with the scheme and fake client.
 	r = &ReconcileOperandConfig{client: cl, scheme: s}
-
-	res, err = r.Reconcile(req)
-	if err != nil {
-		t.Fatalf("reconcile: (%v)", err)
-	}
-	// Check the result of reconciliation to make sure it has the desired state.
-	if res.Requeue {
-		t.Error("reconcile requeue which is not expected")
-	}
+	_, err = r.Reconcile(req)
+	assert.NoError(err)
 }

--- a/pkg/controller/operandregistry/operandregistry_controller.go
+++ b/pkg/controller/operandregistry/operandregistry_controller.go
@@ -86,7 +86,6 @@ type ReconcileOperandRegistry struct {
 	client   client.Client
 	recorder record.EventRecorder
 	scheme   *runtime.Scheme
-	// olmClient *olmclient.Clientset
 }
 
 // Reconcile reads that state of the cluster for a OperandRegistry object and makes changes based on the state read


### PR DESCRIPTION
**What this PR does / why we need it**:
```console
# make coverage
go: github.com/jstemmer/go-junit-report upgrade => v0.9.1
Code coverage test (concurrency 6)
?   	github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/cmd/manager	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/test/config	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/pkg/util	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/test/testgroups	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/test/helpers	[no test files]
?   	github.com/IBM/operand-deployment-lifecycle-manager/version	[no test files]
ok  	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/operandregistry	2.188s	coverage: 37.5% of statements
ok  	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/operandconfig	2.622s	coverage: 28.0% of statements
ok  	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/operandrequest	3.675s	coverage: 58.5% of statements
~/go/out/codecov ~/go/src/github.com/IBM/operand-deployment-lifecycle-manager
~/go/src/github.com/IBM/operand-deployment-lifecycle-manager
Intermediate files were written to /tmp/test_coverage.Hpu4mtUSna
Final reports are stored in /Users/danielxlee/go/out/codecov
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
