### PR TITLE
Support present operator for the  operand request unit test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ endif
 ##@ Test
 
 test: ## Run unit test
-	@go test ${TESTARGS} ./pkg/...
+	@go test ${TESTARGS} ./pkg/controller/...
 
 test-e2e: ## Run integration e2e tests with different options.
 	@echo ... Running the same e2e tests with different args ...
@@ -167,7 +167,7 @@ test-e2e: ## Run integration e2e tests with different options.
 	# - operator-sdk test local ./test/e2e --namespace=${NAMESPACE}
 
 coverage: ## Run code coverage test
-	@common/scripts/codecov.sh ${BUILD_LOCALLY}
+	@common/scripts/codecov.sh ${BUILD_LOCALLY} "pkg/controller"
 
 scorecard: ## Run scorecard test
 	@echo ... Running the scorecard test

--- a/pkg/controller/operandrequest/config_status.go
+++ b/pkg/controller/operandrequest/config_status.go
@@ -57,8 +57,7 @@ func (r *ReconcileOperandRequest) deleteServiceStatus(cr *operatorv1alpha1.Opera
 			return false, err
 		}
 
-		delete(configInstance.Status.ServiceStatus[operatorName].CrStatus, serviceName)
-
+		configInstance.Status.ServiceStatus[operatorName].CrStatus[serviceName] = operatorv1alpha1.ServiceReady
 		if err := r.client.Status().Update(context.TODO(), configInstance); err != nil {
 			klog.V(3).Info("Waiting for OperandConfig instance status ready ...")
 			return false, nil

--- a/pkg/controller/operandrequest/request_status.go
+++ b/pkg/controller/operandrequest/request_status.go
@@ -65,7 +65,10 @@ func (r *ReconcileOperandRequest) getOperatorPhase(name, namespace string) (olmv
 	csvName := sub.Status.InstalledCSV
 	if csvName != "" {
 		csv, err := r.olmClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(csvName, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
+		if err != nil {
+			if errors.IsNotFound(err) {
+				return operatorPhase, nil
+			}
 			return operatorPhase, err
 		}
 		if csv.Status.Phase == "" {


### PR DESCRIPTION
1. add present operator for unit test
2. only run unit test for controller
3. fix some status issue

**What this PR does / why we need it**:
```console
# make coverage
go: github.com/jstemmer/go-junit-report upgrade => v0.9.1
Code coverage test (concurrency 6)
?   	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller	[no test files]
ok  	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/operandconfig	1.180s	coverage: 28.0% of statements
ok  	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/operandregistry	1.670s	coverage: 37.5% of statements
ok  	github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/operandrequest	2.078s	coverage: 64.6% of statements
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
