### PR TITLE
set default phase to operandRequest

### DIFF
--- a/pkg/apis/operator/v1alpha1/operandrequest_types.go
+++ b/pkg/apis/operator/v1alpha1/operandrequest_types.go
@@ -96,7 +96,7 @@ const (
 	ConditionUpdating ConditionType = "Updating"
 	ConditionDeleting ConditionType = "Deleting"
 
-	ClusterPhaseNone     ClusterPhase = ""
+	ClusterPhaseNone     ClusterPhase = "Pending"
 	ClusterPhaseCreating ClusterPhase = "Creating"
 	ClusterPhaseRunning  ClusterPhase = "Running"
 	ClusterPhaseFailed   ClusterPhase = "Failed"


### PR DESCRIPTION
**What this PR does / why we need it**:

Ref #47 
Scorecard check needs a status field in the operandRequest instance when initializing.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
