### PR TITLE
Update operandrequest member status with new phase

### DIFF
--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -222,11 +222,7 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, merr
 	}
 
-	if err := r.updateMemberStatus(requestInstance); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if err := r.updateClusterPhase(requestInstance); err != nil {
+	if err := r.UpdateMemberStatus(requestInstance); err != nil {
 		return reconcile.Result{}, err
 	}
 	// Check if all csv deploy successed

--- a/pkg/controller/operandrequest/operandrequest_controller_test.go
+++ b/pkg/controller/operandrequest/operandrequest_controller_test.go
@@ -94,7 +94,7 @@ func retrieveOperandRequest(t *testing.T, r ReconcileOperandRequest, req reconci
 	assert.NoError(err)
 	assert.Equal(expectedMemNum, len(requestInstance.Status.Members), "operands member list should have two elements")
 	for _, m := range requestInstance.Status.Members {
-		assert.Equalf(olmv1alpha1.CSVPhaseSucceeded, m.Phase.OperatorPhase, "operator(%s) phase should be Running", m.Name)
+		assert.Equalf(v1alpha1.OperatorRunning, m.Phase.OperatorPhase, "operator(%s) phase should be Running", m.Name)
 		assert.Equalf(v1alpha1.ServiceRunning, m.Phase.OperandPhase, "operand(%s) phase should be Running", m.Name)
 	}
 	assert.Equal(v1alpha1.ClusterPhaseRunning, requestInstance.Status.Phase, "cluster phase should be Running")
@@ -138,11 +138,8 @@ func presentOperand(t *testing.T, r ReconcileOperandRequest, req reconcile.Reque
 	assert.NoError(err)
 	multiErr := r.reconcileOperand(requestInstance)
 	assert.Empty(multiErr.errors, "all the operands reconcile should not be error")
-	err = r.updateMemberStatus(requestInstance)
+	err = r.UpdateMemberStatus(requestInstance)
 	assert.NoError(err)
-	err = r.updateClusterPhase(requestInstance)
-	assert.NoError(err)
-
 	retrieveOperandRequest(t, r, req, requestInstance, 2)
 }
 

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -97,10 +97,7 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 		}
 	}
 
-	if err := r.updateMemberStatus(requestInstance); err != nil {
-		return err
-	}
-	if err := r.updateClusterPhase(requestInstance); err != nil {
+	if err := r.UpdateMemberStatus(requestInstance); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/controller/operandrequest/request_status.go
+++ b/pkg/controller/operandrequest/request_status.go
@@ -19,15 +19,12 @@ package operandrequest
 import (
 	"context"
 
-	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog"
 
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
 )
 
-func (r *ReconcileOperandRequest) updateMemberStatus(cr *operatorv1alpha1.OperandRequest) error {
+func (r *ReconcileOperandRequest) UpdateMemberStatus(cr *operatorv1alpha1.OperandRequest) error {
 	klog.V(3).Info("Updating OperandRequest member status")
 	for _, req := range cr.Spec.Requests {
 		registryInstance, err := r.getRegistryInstance(req.Registry, req.RegistryNamespace)
@@ -40,8 +37,7 @@ func (r *ReconcileOperandRequest) updateMemberStatus(cr *operatorv1alpha1.Operan
 		}
 
 		for _, ro := range req.Operands {
-			opt := r.getOperatorFromRegistryInstance(ro.Name, registryInstance)
-			operatorPhase, err := r.getOperatorPhase(opt.Name, opt.Namespace)
+			operatorPhase := registryInstance.Status.OperatorsStatus[ro.Name].Phase
 			operandPhase := getOperandPhase(configInstance.Status.ServiceStatus[ro.Name].CrStatus)
 			if err != nil {
 				return err
@@ -49,35 +45,11 @@ func (r *ReconcileOperandRequest) updateMemberStatus(cr *operatorv1alpha1.Operan
 			cr.SetMemberStatus(ro.Name, operatorPhase, operandPhase)
 		}
 	}
+	cr.UpdateClusterPhase()
 	if err := r.client.Status().Update(context.TODO(), cr); err != nil {
 		return err
 	}
 	return nil
-}
-
-func (r *ReconcileOperandRequest) getOperatorPhase(name, namespace string) (olmv1alpha1.ClusterServiceVersionPhase, error) {
-	klog.V(3).Info("Get OperatorPhase for OperandRequest member status")
-	sub, err := r.olmClient.OperatorsV1alpha1().Subscriptions(namespace).Get(name, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	var operatorPhase olmv1alpha1.ClusterServiceVersionPhase
-	csvName := sub.Status.InstalledCSV
-	if csvName != "" {
-		csv, err := r.olmClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).Get(csvName, metav1.GetOptions{})
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return operatorPhase, nil
-			}
-			return operatorPhase, err
-		}
-		if csv.Status.Phase == "" {
-			operatorPhase = "Pending"
-		} else {
-			operatorPhase = csv.Status.Phase
-		}
-	}
-	return operatorPhase, nil
 }
 
 func getOperandPhase(sp map[string]operatorv1alpha1.ServicePhase) operatorv1alpha1.ServicePhase {
@@ -112,58 +84,4 @@ func getOperandPhase(sp map[string]operatorv1alpha1.ServicePhase) operatorv1alph
 
 	}
 	return operandPhase
-}
-
-func (r *ReconcileOperandRequest) updateClusterPhase(cr *operatorv1alpha1.OperandRequest) error {
-	klog.V(3).Info("Update OperandRequest phase status")
-	clusterStatusStat := struct {
-		creatingNum int
-		runningNum  int
-		failedNum   int
-	}{
-		creatingNum: 0,
-		runningNum:  0,
-		failedNum:   0,
-	}
-
-	for _, m := range cr.Status.Members {
-		switch m.Phase.OperatorPhase {
-		case olmv1alpha1.CSVPhasePending, olmv1alpha1.CSVPhaseInstalling,
-			olmv1alpha1.CSVPhaseInstallReady, olmv1alpha1.CSVPhaseReplacing,
-			olmv1alpha1.CSVPhaseDeleting:
-			clusterStatusStat.creatingNum++
-		case olmv1alpha1.CSVPhaseFailed, olmv1alpha1.CSVPhaseUnknown:
-			clusterStatusStat.failedNum++
-		case olmv1alpha1.CSVPhaseSucceeded:
-			clusterStatusStat.runningNum++
-		default:
-		}
-
-		switch m.Phase.OperandPhase {
-		case operatorv1alpha1.ServiceReady:
-			clusterStatusStat.creatingNum++
-		case operatorv1alpha1.ServiceRunning:
-			clusterStatusStat.runningNum++
-		case operatorv1alpha1.ServiceFailed:
-			clusterStatusStat.failedNum++
-		default:
-		}
-	}
-
-	var clusterPhase operatorv1alpha1.ClusterPhase
-	if clusterStatusStat.failedNum > 0 {
-		clusterPhase = operatorv1alpha1.ClusterPhaseFailed
-	} else if clusterStatusStat.creatingNum > 0 {
-		clusterPhase = operatorv1alpha1.ClusterPhaseCreating
-	} else if clusterStatusStat.runningNum > 0 {
-		clusterPhase = operatorv1alpha1.ClusterPhaseRunning
-	} else {
-		clusterPhase = operatorv1alpha1.ClusterPhaseNone
-	}
-	cr.SetClusterPhase(clusterPhase)
-
-	if err := r.client.Status().Update(context.TODO(), cr); err != nil {
-		return err
-	}
-	return nil
 }

--- a/pkg/controller/operandrequest/request_status.go
+++ b/pkg/controller/operandrequest/request_status.go
@@ -39,9 +39,6 @@ func (r *ReconcileOperandRequest) UpdateMemberStatus(cr *operatorv1alpha1.Operan
 		for _, ro := range req.Operands {
 			operatorPhase := registryInstance.Status.OperatorsStatus[ro.Name].Phase
 			operandPhase := getOperandPhase(configInstance.Status.ServiceStatus[ro.Name].CrStatus)
-			if err != nil {
-				return err
-			}
 			cr.SetMemberStatus(ro.Name, operatorPhase, operandPhase)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Move Cluster Phase update code logic to OperandRequest API
2. Remove getOperatorPhase func, to use the phase from OperandRegistry instance status.
3. Update OperandRequest UT
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
