### PR TITLE
Update status init for passing the rh certification

### DIFF
--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -17,6 +17,8 @@
 package v1alpha1
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -103,7 +105,9 @@ func init() {
 
 //InitConfigStatus OperandConfig status
 func (r *OperandConfig) InitConfigStatus() {
-	r.Status.Phase = ServicePending
+	if (reflect.DeepEqual(r.Status, OperandConfigStatus{})) {
+		r.Status.Phase = ServicePending
+	}
 }
 
 //InitConfigServiceStatus service status in the OperandConfig instance

--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -93,6 +93,7 @@ const (
 	ServiceReady   ServicePhase = "Ready for Deployment"
 	ServiceRunning ServicePhase = "Running"
 	ServiceFailed  ServicePhase = "Failed"
+	ServicePending ServicePhase = "Pending"
 	ServiceNone    ServicePhase = ""
 )
 
@@ -102,9 +103,12 @@ func init() {
 
 //InitConfigStatus OperandConfig status
 func (r *OperandConfig) InitConfigStatus() {
-	if r.Status.ServiceStatus == nil {
-		r.Status.ServiceStatus = make(map[string]CrStatus)
-	}
+	r.Status.Phase = ServicePending
+}
+
+//InitConfigServiceStatus service status in the OperandConfig instance
+func (r *OperandConfig) InitConfigServiceStatus() {
+	r.Status.ServiceStatus = make(map[string]CrStatus)
 	originalServiceStatus := r.Status.DeepCopy().ServiceStatus
 
 	for _, operator := range r.Spec.Services {

--- a/pkg/apis/operator/v1alpha1/operandregistry_types.go
+++ b/pkg/apis/operator/v1alpha1/operandregistry_types.go
@@ -131,6 +131,7 @@ const (
 	OperatorReady   OperatorPhase = "Ready for Deployment"
 	OperatorRunning OperatorPhase = "Running"
 	OperatorFailed  OperatorPhase = "Failed"
+	OperatorPending OperatorPhase = "Pending"
 	OperatorNone    OperatorPhase = ""
 )
 
@@ -152,18 +153,21 @@ func (r *OperandRegistry) SetDefaultsRegistry() {
 	}
 }
 
-// InitRegistryStatus Init OperandRegistry status
+// InitRegistryStatus Init Phase in the OperandRegistry status
 func (r *OperandRegistry) InitRegistryStatus() {
-	if r.Status.OperatorsStatus == nil {
-		r.Status.OperatorsStatus = make(map[string]OperatorStatus)
-		for _, opt := range r.Spec.Operators {
-			opratorStatus := OperatorStatus{
-				Phase: OperatorReady,
-			}
-			r.Status.OperatorsStatus[opt.Name] = opratorStatus
+	r.Status.Phase = OperatorPending
+}
+
+// InitRegistryOperatorStatus Init Operators status in the OperandRegistry instance
+func (r *OperandRegistry) InitRegistryOperatorStatus() {
+	r.Status.OperatorsStatus = make(map[string]OperatorStatus)
+	for _, opt := range r.Spec.Operators {
+		opratorStatus := OperatorStatus{
+			Phase: OperatorReady,
 		}
-		r.UpdateOperatorPhase()
+		r.Status.OperatorsStatus[opt.Name] = opratorStatus
 	}
+	r.UpdateOperatorPhase()
 }
 
 // GetReconcileRequest gets the position of request from OperandRegistry status

--- a/pkg/apis/operator/v1alpha1/operandregistry_types.go
+++ b/pkg/apis/operator/v1alpha1/operandregistry_types.go
@@ -17,6 +17,8 @@
 package v1alpha1
 
 import (
+	"reflect"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -155,7 +157,9 @@ func (r *OperandRegistry) SetDefaultsRegistry() {
 
 // InitRegistryStatus Init Phase in the OperandRegistry status
 func (r *OperandRegistry) InitRegistryStatus() {
-	r.Status.Phase = OperatorPending
+	if (reflect.DeepEqual(r.Status, OperandRegistryStatus{})) {
+		r.Status.Phase = OperatorPending
+	}
 }
 
 // InitRegistryOperatorStatus Init Operators status in the OperandRegistry instance

--- a/pkg/controller/operandregistry/operandregistry_controller_test.go
+++ b/pkg/controller/operandregistry/operandregistry_controller_test.go
@@ -98,7 +98,7 @@ func TestRegistryController(t *testing.T) {
 		assert.Equal(v1alpha1.ScopePrivate, o.Scope, "default operator("+o.Name+") scope should be private")
 	}
 	// Check the registry init status
-	assert.NotNil(registry.Status.OperatorsStatus, "init operator status should not be empty")
+	assert.NotNil(registry.Status, "init operator status should not be empty")
 	for k, s := range registry.Status.OperatorsStatus {
 		assert.Equal(v1alpha1.OperatorReady, s.Phase, "operator("+k+") phase should be 'Ready for Deployment'")
 	}

--- a/pkg/controller/operandrequest/config_status.go
+++ b/pkg/controller/operandrequest/config_status.go
@@ -27,6 +27,11 @@ import (
 )
 
 func (r *ReconcileOperandRequest) updateServiceStatus(cr *operatorv1alpha1.OperandConfig, operatorName, serviceName string, serviceStatus operatorv1alpha1.ServicePhase) error {
+	if cr.Status.ServiceStatus == nil {
+		klog.V(3).Info("Initializing OperandConfig status")
+		cr.InitConfigServiceStatus()
+	}
+
 	klog.V(3).Info("Updating OperandConfig status")
 
 	if err := wait.PollImmediate(time.Second*20, time.Minute*10, func() (done bool, err error) {

--- a/pkg/controller/operandrequest/registry_status.go
+++ b/pkg/controller/operandrequest/registry_status.go
@@ -26,6 +26,11 @@ import (
 )
 
 func (r *ReconcileOperandRequest) updateRegistryStatus(cr *operatorv1alpha1.OperandRegistry, reconcileReq reconcile.Request, optName string, optPhase operatorv1alpha1.OperatorPhase) error {
+	if cr.Status.OperatorsStatus == nil {
+		klog.V(3).Info("Initializing OperandRegistry status")
+		cr.InitRegistryOperatorStatus()
+	}
+
 	klog.V(3).Info("Updating OperandRegistry status")
 
 	cr.SetOperatorStatus(optName, optPhase, reconcileReq)


### PR DESCRIPTION
**What this PR does / why we need it**:

Scorecard needs every init status has a descriptor,  but the `serviceStatus` in the `operandConfig` and `operatorStatus` in the `operandRegistry` can't find suitable descriptor structure.  

So I update the ODLM to only init the phase in the `operandConfig` and `operatorStatus` instance and move `serviceStatus` and `operatorStatus` initialization to the `OperandRequest` reconcile.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Ref #44 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
