### PR TITLE
Enhance unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![Docker Repository on Quay](https://quay.io/repository/opencloudio/odlm/status "Docker Repository on Quay")](https://quay.io/repository/opencloudio/odlm)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Go Report Card](https://goreportcard.com/badge/github.com/IBM/operand-deployment-lifecycle-manager)](https://goreportcard.com/report/github.com/IBM/operand-deployment-lifecycle-manager)
+[![Code Coverage](https://codecov.io/gh/IBM/operand-deployment-lifecycle-manager/branch/master/graphs/badge.svg?branch=master)](https://codecov.io/gh/IBM/operand-deployment-lifecycle-manager?branch=master)
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
-**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Operand Deployment Lifecycle Manager (ODLM)](#operand-deployment-lifecycle-manager-odlm)
   - [Overview](#overview)

--- a/common/scripts/codecov.sh
+++ b/common/scripts/codecov.sh
@@ -28,6 +28,7 @@ export PATH=${PATH}:${GOPATH}/bin
 
 ROOTDIR="$(cd "$(dirname "$0")"/../.. ; pwd -P)"
 REPORT_PATH=${REPORT_PATH:-"${GOPATH}/out/codecov"}
+CODECOV_TOKEN="bfc8d455-e398-4458-8dbf-ca0e66a7f4f6"
 #CODECOV_SKIP=${GOPATH}/out/codecov/codecov.skip
 MAXPROCS="${MAXPROCS:-}"
 BUILD_LOCALLY=${1:?0}

--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -95,7 +95,6 @@ const (
 	ServiceReady   ServicePhase = "Ready for Deployment"
 	ServiceRunning ServicePhase = "Running"
 	ServiceFailed  ServicePhase = "Failed"
-	ServicePending ServicePhase = "Pending"
 	ServiceNone    ServicePhase = ""
 )
 
@@ -106,7 +105,7 @@ func init() {
 //InitConfigStatus OperandConfig status
 func (r *OperandConfig) InitConfigStatus() {
 	if (reflect.DeepEqual(r.Status, OperandConfigStatus{})) {
-		r.Status.Phase = ServicePending
+		r.Status.Phase = ServiceReady
 	}
 }
 

--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -95,6 +95,7 @@ const (
 	ServiceReady   ServicePhase = "Ready for Deployment"
 	ServiceRunning ServicePhase = "Running"
 	ServiceFailed  ServicePhase = "Failed"
+	ServiceInit    ServicePhase = "Initialized"
 	ServiceNone    ServicePhase = ""
 )
 
@@ -105,7 +106,7 @@ func init() {
 //InitConfigStatus OperandConfig status
 func (r *OperandConfig) InitConfigStatus() {
 	if (reflect.DeepEqual(r.Status, OperandConfigStatus{})) {
-		r.Status.Phase = ServiceReady
+		r.Status.Phase = ServiceInit
 	}
 }
 

--- a/pkg/apis/operator/v1alpha1/operandregistry_types.go
+++ b/pkg/apis/operator/v1alpha1/operandregistry_types.go
@@ -133,6 +133,7 @@ const (
 	OperatorReady   OperatorPhase = "Ready for Deployment"
 	OperatorRunning OperatorPhase = "Running"
 	OperatorFailed  OperatorPhase = "Failed"
+	OperatorInit    OperatorPhase = "Initialized"
 	OperatorNone    OperatorPhase = ""
 )
 
@@ -157,7 +158,7 @@ func (r *OperandRegistry) SetDefaultsRegistry() {
 // InitRegistryStatus Init Phase in the OperandRegistry status
 func (r *OperandRegistry) InitRegistryStatus() {
 	if (reflect.DeepEqual(r.Status, OperandRegistryStatus{})) {
-		r.Status.Phase = OperatorReady
+		r.Status.Phase = OperatorInit
 	}
 }
 

--- a/pkg/apis/operator/v1alpha1/operandregistry_types.go
+++ b/pkg/apis/operator/v1alpha1/operandregistry_types.go
@@ -133,7 +133,6 @@ const (
 	OperatorReady   OperatorPhase = "Ready for Deployment"
 	OperatorRunning OperatorPhase = "Running"
 	OperatorFailed  OperatorPhase = "Failed"
-	OperatorPending OperatorPhase = "Pending"
 	OperatorNone    OperatorPhase = ""
 )
 
@@ -158,7 +157,7 @@ func (r *OperandRegistry) SetDefaultsRegistry() {
 // InitRegistryStatus Init Phase in the OperandRegistry status
 func (r *OperandRegistry) InitRegistryStatus() {
 	if (reflect.DeepEqual(r.Status, OperandRegistryStatus{})) {
-		r.Status.Phase = OperatorPending
+		r.Status.Phase = OperatorReady
 	}
 }
 

--- a/pkg/controller/operandconfig/operandconfig_controller_test.go
+++ b/pkg/controller/operandconfig/operandconfig_controller_test.go
@@ -91,7 +91,7 @@ func TestConfigController(t *testing.T) {
 	assert.NoError(err)
 	// Check the config init status
 	assert.NotNil(config.Status, "init operator status should not be empty")
-	assert.Equal(v1alpha1.ServiceReady, config.Status.Phase, "Overall OperandConfig phase should be 'Ready for Deployment'")
+	assert.Equal(v1alpha1.ServiceInit, config.Status.Phase, "Overall OperandConfig phase should be 'Ready for Deployment'")
 
 	// Create a fake client to mock instance not found.
 	cl = fake.NewFakeClient()

--- a/pkg/controller/operandconfig/operandconfig_controller_test.go
+++ b/pkg/controller/operandconfig/operandconfig_controller_test.go
@@ -90,11 +90,8 @@ func TestConfigController(t *testing.T) {
 	err = r.client.Get(context.TODO(), req.NamespacedName, config)
 	assert.NoError(err)
 	// Check the config init status
-	for sk, sv := range config.Status.ServiceStatus {
-		for ck, cv := range sv.CrStatus {
-			assert.Equalf(v1alpha1.ServiceReady, cv, "servcie(%s/%s) phase should be 'Ready for Deployment'", sk, ck)
-		}
-	}
+	assert.NotNil(config.Status, "init operator status should not be empty")
+	assert.Equal(v1alpha1.ServiceReady, config.Status.Phase, "Overall OperandConfig phase should be 'Ready for Deployment'")
 
 	// Create a fake client to mock instance not found.
 	cl = fake.NewFakeClient()

--- a/pkg/controller/operandregistry/operandregistry_controller_test.go
+++ b/pkg/controller/operandregistry/operandregistry_controller_test.go
@@ -99,9 +99,7 @@ func TestRegistryController(t *testing.T) {
 	}
 	// Check the registry init status
 	assert.NotNil(registry.Status, "init operator status should not be empty")
-	for k, s := range registry.Status.OperatorsStatus {
-		assert.Equalf(v1alpha1.OperatorReady, s.Phase, "operator(%s) phase should be 'Ready for Deployment'", k)
-	}
+	assert.Equalf(v1alpha1.OperatorReady, registry.Status.Phase, "Overall OperandRegistry phase should be 'Ready for Deployment'")
 
 	// Create a fake client to mock instance not found.
 	cl = fake.NewFakeClient()

--- a/pkg/controller/operandregistry/operandregistry_controller_test.go
+++ b/pkg/controller/operandregistry/operandregistry_controller_test.go
@@ -99,7 +99,7 @@ func TestRegistryController(t *testing.T) {
 	}
 	// Check the registry init status
 	assert.NotNil(registry.Status, "init operator status should not be empty")
-	assert.Equalf(v1alpha1.OperatorReady, registry.Status.Phase, "Overall OperandRegistry phase should be 'Ready for Deployment'")
+	assert.Equalf(v1alpha1.OperatorInit, registry.Status.Phase, "Overall OperandRegistry phase should be 'Ready for Deployment'")
 
 	// Create a fake client to mock instance not found.
 	cl = fake.NewFakeClient()

--- a/pkg/controller/operandrequest/operandrequest_controller_test.go
+++ b/pkg/controller/operandrequest/operandrequest_controller_test.go
@@ -244,10 +244,10 @@ func absentOperandCustomResource(t *testing.T, r ReconcileOperandRequest, req re
 	assert.NoError(err)
 	configInstance, err = r.getConfigInstance(req.Name, req.Namespace)
 	assert.NoError(err)
-	assert.Equal(v1alpha1.ServiceReady, configInstance.Status.ServiceStatus["etcd"].CrStatus["etcdCluster"], "The status of etcdCluster should be cleaned up in the OperandConfig")
+	assert.Equal(v1alpha1.ServiceNone, configInstance.Status.ServiceStatus["etcd"].CrStatus["etcdCluster"], "The status of etcdCluster should be cleaned up in the OperandConfig")
 	err = r.client.Get(context.TODO(), req.NamespacedName, requestInstance)
 	assert.NoError(err)
-	assert.Equal(v1alpha1.ServiceReady, requestInstance.Status.Members[0].Phase.OperandPhase, "The status of etcdCluster should be cleaned up in the OperandRequest")
+	assert.Equal(v1alpha1.ClusterPhaseRunning, requestInstance.Status.Phase, "The cluster phase status should be running in the OperandRequest")
 }
 
 // Present an operand custom resource from config
@@ -261,10 +261,11 @@ func presentOperandCustomResource(t *testing.T, r ReconcileOperandRequest, req r
 	assert.NoError(err)
 	configInstance, err = r.getConfigInstance(req.Name, req.Namespace)
 	assert.NoError(err)
-	assert.Equal(v1alpha1.ServiceRunning, configInstance.Status.ServiceStatus["etcd"].CrStatus["etcdCluster"], "The status of etcdCluster should be cleaned up in the OperandConfig")
+	assert.Equal(v1alpha1.ServiceRunning, configInstance.Status.ServiceStatus["etcd"].CrStatus["etcdCluster"], "The status of etcdCluster should be running in the OperandConfig")
 	err = r.client.Get(context.TODO(), req.NamespacedName, requestInstance)
 	assert.NoError(err)
-	assert.Equal(v1alpha1.ServiceRunning, requestInstance.Status.Members[0].Phase.OperandPhase, "The status of etcdCluster should be cleaned up in the OperandRequest")
+	assert.Equal(v1alpha1.ServiceRunning, requestInstance.Status.Members[0].Phase.OperandPhase, "The status of etcdCluster should be running in the OperandRequest")
+	assert.Equal(v1alpha1.ClusterPhaseRunning, requestInstance.Status.Phase, "The cluster phase status should be running in the OperandRequest")
 }
 
 type DataObj struct {

--- a/pkg/controller/operandrequest/operandrequest_controller_test.go
+++ b/pkg/controller/operandrequest/operandrequest_controller_test.go
@@ -55,23 +55,6 @@ func TestRequestController(t *testing.T) {
 
 	presentOperand(t, r, req, requestInstance)
 
-	deleteOperandRequest(t, r, req, requestInstance)
-}
-
-// TestOperandConfig runs ReconcileOperandRequest.Reconcile() against a
-// fake client that checks operand reconcile function.
-func TestOperandConfig(t *testing.T) {
-	var (
-		name      = "common-service"
-		namespace = "ibm-common-service"
-	)
-
-	req := getReconcileRequest(name, namespace)
-	r := getReconciler(name, namespace)
-	requestInstance := &v1alpha1.OperandRequest{}
-
-	initReconcile(t, r, req, requestInstance)
-
 	absentOperandCustomResource(t, r, req, requestInstance)
 
 	presentOperandCustomResource(t, r, req, requestInstance)

--- a/pkg/controller/operandrequest/operandrequest_controller_test.go
+++ b/pkg/controller/operandrequest/operandrequest_controller_test.go
@@ -58,6 +58,27 @@ func TestRequestController(t *testing.T) {
 	deleteOperandRequest(t, r, req, requestInstance)
 }
 
+// TestOperandConfig runs ReconcileOperandRequest.Reconcile() against a
+// fake client that checks operand reconcile function.
+func TestOperandConfig(t *testing.T) {
+	var (
+		name      = "common-service"
+		namespace = "ibm-common-service"
+	)
+
+	req := getReconcileRequest(name, namespace)
+	r := getReconciler(name, namespace)
+	requestInstance := &v1alpha1.OperandRequest{}
+
+	initReconcile(t, r, req, requestInstance)
+
+	absentOperandCustomResource(t, r, req, requestInstance)
+
+	presentOperandCustomResource(t, r, req, requestInstance)
+
+	deleteOperandRequest(t, r, req, requestInstance)
+}
+
 // Init reconcile the OperandRequest
 func initReconcile(t *testing.T, r ReconcileOperandRequest, req reconcile.Request, requestInstance *v1alpha1.OperandRequest) {
 	assert := assert.New(t)
@@ -208,6 +229,42 @@ func getReconcileRequest(name, namespace string) reconcile.Request {
 			Namespace: namespace,
 		},
 	}
+}
+
+// Absent an operand custom resource from config
+func absentOperandCustomResource(t *testing.T, r ReconcileOperandRequest, req reconcile.Request, requestInstance *v1alpha1.OperandRequest) {
+	assert := assert.New(t)
+	// Retrieve OperandConfig
+	configInstance, err := r.getConfigInstance(req.Name, req.Namespace)
+	assert.NoError(err)
+	configInstance.Spec.Services[0].Spec = make(map[string]runtime.RawExtension)
+	err = r.client.Update(context.TODO(), configInstance)
+	assert.NoError(err)
+	_, err = r.Reconcile(req)
+	assert.NoError(err)
+	configInstance, err = r.getConfigInstance(req.Name, req.Namespace)
+	assert.NoError(err)
+	assert.Equal(v1alpha1.ServiceReady, configInstance.Status.ServiceStatus["etcd"].CrStatus["etcdCluster"], "The status of etcdCluster should be cleaned up in the OperandConfig")
+	err = r.client.Get(context.TODO(), req.NamespacedName, requestInstance)
+	assert.NoError(err)
+	assert.Equal(v1alpha1.ServiceReady, requestInstance.Status.Members[0].Phase.OperandPhase, "The status of etcdCluster should be cleaned up in the OperandRequest")
+}
+
+// Present an operand custom resource from config
+func presentOperandCustomResource(t *testing.T, r ReconcileOperandRequest, req reconcile.Request, requestInstance *v1alpha1.OperandRequest) {
+	assert := assert.New(t)
+	// Retrieve OperandConfig
+	configInstance := operandConfig(req.Name, req.Namespace)
+	err := r.client.Update(context.TODO(), configInstance)
+	assert.NoError(err)
+	_, err = r.Reconcile(req)
+	assert.NoError(err)
+	configInstance, err = r.getConfigInstance(req.Name, req.Namespace)
+	assert.NoError(err)
+	assert.Equal(v1alpha1.ServiceRunning, configInstance.Status.ServiceStatus["etcd"].CrStatus["etcdCluster"], "The status of etcdCluster should be cleaned up in the OperandConfig")
+	err = r.client.Get(context.TODO(), req.NamespacedName, requestInstance)
+	assert.NoError(err)
+	assert.Equal(v1alpha1.ServiceRunning, requestInstance.Status.Members[0].Phase.OperandPhase, "The status of etcdCluster should be cleaned up in the OperandRequest")
 }
 
 type DataObj struct {

--- a/pkg/controller/operandrequest/request_status.go
+++ b/pkg/controller/operandrequest/request_status.go
@@ -78,7 +78,6 @@ func getOperandPhase(sp map[string]operatorv1alpha1.ServicePhase) operatorv1alph
 		operandPhase = operatorv1alpha1.ServiceReady
 	} else if operandStatusStat.runningNum > 0 {
 		operandPhase = operatorv1alpha1.ServiceRunning
-
 	}
 	return operandPhase
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Set ready as the init status for OperandConfig and OperandRegistry instance.
- Add custom resource deleting into the unit test.
- Add code coverage into the readme.
- Clean up status when the custom resource is deleted from the OperandConfig.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
