### PR TITLE
Move member status update after waiting for subscriptions ready

### DIFF
--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -211,6 +211,11 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
+	// Update request status after subscription ready
+	if err := r.updateMemberStatus(requestInstance); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Reconcile the Operand
 	merr := r.reconcileOperand(requestInstance)
 
@@ -218,7 +223,7 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, merr
 	}
 
-	if err := r.UpdateMemberStatus(requestInstance); err != nil {
+	if err := r.updateMemberStatus(requestInstance); err != nil {
 		return reconcile.Result{}, err
 	}
 	// Check if all csv deploy successed

--- a/pkg/controller/operandrequest/operandrequest_controller_test.go
+++ b/pkg/controller/operandrequest/operandrequest_controller_test.go
@@ -152,7 +152,7 @@ func presentOperand(t *testing.T, r ReconcileOperandRequest, req reconcile.Reque
 	assert.NoError(err)
 	multiErr := r.reconcileOperand(requestInstance)
 	assert.Empty(multiErr.errors, "all the operands reconcile should not be error")
-	err = r.UpdateMemberStatus(requestInstance)
+	err = r.updateMemberStatus(requestInstance)
 	assert.NoError(err)
 	retrieveOperandRequest(t, r, req, requestInstance, 2)
 }

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -104,9 +104,6 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 		}
 	}
 
-	if err := r.UpdateMemberStatus(requestInstance); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/pkg/controller/operandrequest/request_status.go
+++ b/pkg/controller/operandrequest/request_status.go
@@ -24,9 +24,9 @@ import (
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
 )
 
-func (r *ReconcileOperandRequest) UpdateMemberStatus(cr *operatorv1alpha1.OperandRequest) error {
+func (r *ReconcileOperandRequest) updateMemberStatus(requestInstance *operatorv1alpha1.OperandRequest) error {
 	klog.V(3).Info("Updating OperandRequest member status")
-	for _, req := range cr.Spec.Requests {
+	for _, req := range requestInstance.Spec.Requests {
 		registryInstance, err := r.getRegistryInstance(req.Registry, req.RegistryNamespace)
 		if err != nil {
 			return err
@@ -39,11 +39,11 @@ func (r *ReconcileOperandRequest) UpdateMemberStatus(cr *operatorv1alpha1.Operan
 		for _, ro := range req.Operands {
 			operatorPhase := registryInstance.Status.OperatorsStatus[ro.Name].Phase
 			operandPhase := getOperandPhase(configInstance.Status.ServiceStatus[ro.Name].CrStatus)
-			cr.SetMemberStatus(ro.Name, operatorPhase, operandPhase)
+			requestInstance.SetMemberStatus(ro.Name, operatorPhase, operandPhase)
 		}
 	}
-	cr.UpdateClusterPhase()
-	if err := r.client.Status().Update(context.TODO(), cr); err != nil {
+	requestInstance.UpdateClusterPhase()
+	if err := r.client.Status().Update(context.TODO(), requestInstance); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Enhance OperandRequest member status update:
- Waiting for Subscription is ready then update OperandRequest member status instead update the member status just after subscriptions are created.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
