### PR TITLE
update retry times and interval for multiarch image build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,7 @@ scorecard: ## Run scorecard test
 ##@ Release
 
 multiarch-image: $(CONFIG_DOCKER_TARGET)
-	@common/scripts/multiarch_image.sh $(IMAGE_REPO) $(IMAGE_NAME) $(VERSION)
+	@MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(IMAGE_REPO) $(IMAGE_NAME) $(VERSION)
 
 csv: ## Push CSV package to the catalog
 	@RELEASE=${CSV_VERSION} common/scripts/push-csv.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

update retry times and interval for multiarch image build,
to fix multi-arch build timeout failure: http://prow.purple-chesterfield.com/log?job=multiarch-image-operand-deployment-lifecycle-manager-postsubmit&id=1241909811491115008


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
