### PR TITLE
onboard prometheus operator as crd dependency is deprecated by ODLM

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandregistry_cr.yaml
@@ -132,3 +132,11 @@ spec:
     scope: private
     sourceName: opencloud-operators
     sourceNamespace: openshift-marketplace
+  - channel: beta
+    description: Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.
+    name: prometheus-operator
+    namespace: ibm-common-services
+    packageName: prometheus-operator-app
+    scope: private
+    sourceName: opencloud-operators
+    sourceNamespace: openshift-marketplace

--- a/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandrequest_cr.yaml
@@ -12,6 +12,7 @@ spec:
     - name: ibm-monitoring-exporters-operator
     - name: ibm-monitoring-prometheusext-operator
     - name: ibm-monitoring-grafana-operator
+    - name: prometheus-operator
     - name: ibm-healthcheck-operator
     - name: ibm-management-ingress-operator
     - name: ibm-licensing-operator

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/0.0.1/operand-deployment-lifecycle-manager.v0.0.1.clusterserviceversion.yaml
@@ -307,6 +307,16 @@ metadata:
                 "scope": "private",
                 "sourceName": "opencloud-operators",
                 "sourceNamespace": "openshift-marketplace"
+              },
+              {
+                "channel": "beta",
+                "description": "Manage the full lifecycle of configuring and managing Prometheus and Alertmanager servers.",
+                "name": "prometheus-operator",
+                "namespace": "ibm-common-services",
+                "packageName": "prometheus-operator-app",
+                "scope": "private",
+                "sourceName": "opencloud-operators",
+                "sourceNamespace": "openshift-marketplace"
               }
             ]
           }
@@ -338,6 +348,9 @@ metadata:
                   },
                   {
                     "name": "ibm-monitoring-grafana-operator"
+                  },
+                  {
+                    "name": "prometheus-operator"
                   },
                   {
                     "name": "ibm-healthcheck-operator"


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
This is to onboard prometheus-operator to remove crd dependency. 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
This is to onboard prometheus-operator to remove crd dependency. 
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
