### PR TITLE
Add event when operandregistry not found

### DIFF
--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -40,6 +40,9 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 	for _, req := range requestInstance.Spec.Requests {
 		registryInstance, err := r.getRegistryInstance(req.Registry, req.RegistryNamespace)
 		if err != nil {
+			if errors.IsNotFound(err) {
+				r.recorder.Eventf(requestInstance, corev1.EventTypeWarning, "NotFound", "NotFound OperandRegistry %s from the namespace %s", req.Registry, req.RegistryNamespace)
+			}
 			return err
 		}
 		for _, operand := range req.Operands {


### PR DESCRIPTION
**What this PR does / why we need it**:
When creating an operand request, if the registry or registrynamespace not correct, there is no error message or event for it.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
