### PR TITLE
Move some methods to api

### DIFF
--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -116,6 +116,16 @@ func init() {
 	SchemeBuilder.Register(&OperandConfig{}, &OperandConfigList{})
 }
 
+// GetService obtain the service definition with the operand name
+func (r *OperandConfig) GetService(operandName string) *ConfigService {
+	for _, s := range r.Spec.Services {
+		if s.Name == operandName {
+			return &s
+		}
+	}
+	return nil
+}
+
 //InitConfigStatus OperandConfig status
 func (r *OperandConfig) InitConfigStatus() {
 	if (reflect.DeepEqual(r.Status, OperandConfigStatus{})) {

--- a/pkg/apis/operator/v1alpha1/operandregistry_types.go
+++ b/pkg/apis/operator/v1alpha1/operandregistry_types.go
@@ -224,6 +224,16 @@ func (r *OperandRegistry) CleanOperatorStatus(name string, request reconcile.Req
 	r.UpdateOperatorPhase()
 }
 
+// GetOperator obtain the operator definition with the operand name
+func (r *OperandRegistry) GetOperator(operandName string) *Operator {
+	for _, o := range r.Spec.Operators {
+		if o.Name == operandName {
+			return &o
+		}
+	}
+	return nil
+}
+
 func init() {
 	SchemeBuilder.Register(&OperandRegistry{}, &OperandRegistryList{})
 }

--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -233,7 +233,7 @@ func (r *ReconcileOperandRequest) waitForInstallPlan(requestInstance *operatorv1
 			}
 			for _, operand := range req.Operands {
 				// Check the requested Operand if exist in specific OperandRegistry
-				opt := r.getOperatorFromRegistryInstance(operand.Name, registryInstance)
+				opt := registryInstance.GetOperator(operand.Name)
 				if opt != nil {
 					// Check subscription if exist
 					found, err := r.olmClient.OperatorsV1alpha1().Subscriptions(opt.Namespace).Get(opt.Name, metav1.GetOptions{})

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -50,7 +50,7 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 				continue
 			}
 			// Check the requested Service Config if exist in specific OperandConfig
-			svc := r.getServiceFromConfigInstance(operand.Name, configInstance)
+			svc := configInstance.GetService(operand.Name)
 			if svc != nil {
 				klog.V(3).Info("Reconciling custom resource: ", svc.Name)
 				// Looking for the CSV
@@ -181,7 +181,7 @@ func (r *ReconcileOperandRequest) reconcileCr(service *operatorv1alpha1.ConfigSe
 // deleteAllCustomResource remove custome resource base on OperandConfig and CSV alm-examples
 func (r *ReconcileOperandRequest) deleteAllCustomResource(csv *olmv1alpha1.ClusterServiceVersion, csc *operatorv1alpha1.OperandConfig, operandName string) error {
 
-	service := r.getServiceFromConfigInstance(operandName, csc)
+	service := csc.GetService(operandName)
 	if service == nil {
 		return nil
 	}
@@ -261,16 +261,6 @@ func (r *ReconcileOperandRequest) getConfigInstance(name, namespace string) (*op
 		return nil, err
 	}
 	return config, nil
-}
-
-func (r *ReconcileOperandRequest) getServiceFromConfigInstance(operandName string, configInstance *operatorv1alpha1.OperandConfig) *operatorv1alpha1.ConfigService {
-	klog.V(3).Info("Get ConfigService from the OperandConfig instance: ", configInstance.ObjectMeta.Name, " and operand name: ", operandName)
-	for _, s := range configInstance.Spec.Services {
-		if s.Name == operandName {
-			return &s
-		}
-	}
-	return nil
 }
 
 func (r *ReconcileOperandRequest) compareConfigandExample(unstruct unstructured.Unstructured, service *operatorv1alpha1.ConfigService, namespace string, csc *operatorv1alpha1.OperandConfig, csv *olmv1alpha1.ClusterServiceVersion) error {


### PR DESCRIPTION
1. Move getOperatorFromRegistryInstance method to OperandRegistry api
2. Move getServiceFromConfigInstance method to OperandConfig api

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #303 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
