### PR TITLE
Restruct the bindinfo controller

### DIFF
--- a/pkg/controller/operandbindinfo/operandbindinfo_controller.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller.go
@@ -206,10 +206,9 @@ func (r *ReconcileOperandBindInfo) copySecret(secName, sourceNs, targetNs string
 			klog.Errorf("Secret %s is not found from the namespace %s", secName, sourceNs)
 			r.recorder.Eventf(bindInfoInstance, corev1.EventTypeWarning, "NotFound", "No Secret %s in the namespace %s", secName, sourceNs)
 			return nil
-		} else {
-			klog.Errorf("Failed to get Secret %s from the namespace %s : %s", secName, sourceNs, err)
-			return err
 		}
+		klog.Errorf("Failed to get Secret %s from the namespace %s : %s", secName, sourceNs, err)
+		return err
 	}
 	// Create the Secret to the OperandRequest namespace
 	secretCopy := &corev1.Secret{
@@ -268,10 +267,9 @@ func (r *ReconcileOperandBindInfo) copyConfigmap(cmName, sourceNs, targetNs stri
 			klog.Errorf("Configmap %s is not found from the namespace %s", cmName, sourceNs)
 			r.recorder.Eventf(bindInfoInstance, corev1.EventTypeWarning, "NotFound", "No Configmap %s in the namespace %s", cmName, sourceNs)
 			return nil
-		} else {
-			klog.Errorf("Failed tp get Configmap %s from the namespace %s : %s", cmName, sourceNs, err)
-			return err
 		}
+		klog.Errorf("Failed tp get Configmap %s from the namespace %s : %s", cmName, sourceNs, err)
+		return err
 	}
 	// Create the ConfigMap to the OperandRequest namespace
 	cmCopy := &corev1.ConfigMap{


### PR DESCRIPTION
**What this PR does / why we need it**:
Reconcile method too long, split copyconfigmap and copysecret as separate methods

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
