### PR TITLE
Skip operand update when specs are same

### DIFF
--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -19,6 +19,7 @@ package operandrequest
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"strings"
 	"time"
 
@@ -379,6 +380,10 @@ func (r *ReconcileOperandRequest) updateCustomResource(unstruct unstructured.Uns
 
 		// Merge CR template spec and OperandConfig spec
 		mergedCR := util.MergeCR(specJSONString, crConfig)
+
+		if reflect.DeepEqual(existingCR.Object["spec"], mergedCR) {
+			return nil
+		}
 
 		existingCR.Object["spec"] = mergedCR
 		if crUpdateErr := r.client.Update(context.TODO(), &existingCR); crUpdateErr != nil {

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -381,6 +381,7 @@ func (r *ReconcileOperandRequest) updateCustomResource(unstruct unstructured.Uns
 		// Merge CR template spec and OperandConfig spec
 		mergedCR := util.MergeCR(specJSONString, crConfig)
 
+		// If there is no change between custom resource specs, skip the update
 		if reflect.DeepEqual(existingCR.Object["spec"], mergedCR) {
 			return nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

ODLM will skip operand custom resource update when custom resource specs are deeply equal.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
