### PR TITLE
Add label into Operandbindinfo instance

### DIFF
--- a/deploy/crds/operator.ibm.com_operandbindinfos_crd.yaml
+++ b/deploy/crds/operator.ibm.com_operandbindinfos_crd.yaml
@@ -82,6 +82,10 @@ spec:
               description: The registry identifies the name of the name of the OperandRegistry
                 CR from which this operand deployment is being requested.
               type: string
+            registryNamespace:
+              description: Specifies the namespace in which the OperandRegistry reside.
+                The default is the current namespace in which the request is defined.
+              type: string
           required:
           - operand
           - registry

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operator.ibm.com_operandbindinfos_crd.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operator.ibm.com_operandbindinfos_crd.yaml
@@ -82,6 +82,10 @@ spec:
               description: The registry identifies the name of the name of the OperandRegistry
                 CR from which this operand deployment is being requested.
               type: string
+            registryNamespace:
+              description: Specifies the namespace in which the OperandRegistry reside.
+                The default is the current namespace in which the request is defined.
+              type: string
           required:
           - operand
           - registry

--- a/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
+++ b/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
@@ -126,3 +126,11 @@ func (r *OperandBindInfo) SetDefaultsRequestSpec() {
 		r.Spec.RegistryNamespace = r.Namespace
 	}
 }
+
+// AddLabels set the labels for the OperandConfig and OperandRegistry used by this OperandRequest
+func (r *OperandBindInfo) AddLabels() {
+	if r.Labels == nil {
+		r.Labels = make(map[string]string)
+	}
+	r.Labels[r.Spec.RegistryNamespace+"."+r.Spec.Registry+"/registry"] = "true"
+}

--- a/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
+++ b/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
@@ -43,6 +43,10 @@ type OperandBindInfoSpec struct {
 	Operand string `json:"operand"`
 	// The registry identifies the name of the name of the OperandRegistry CR from which this operand deployment is being requested.
 	Registry string `json:"registry"`
+	// Specifies the namespace in which the OperandRegistry reside.
+	// The default is the current namespace in which the request is defined.
+	// +optional
+	RegistryNamespace string `json:"registryNamespace,omitempty"`
 	// +optional
 	Description string `json:"description,omitempty"`
 	// The bindings section is used to specify information about the access/configuration data that is to be shared.
@@ -114,4 +118,11 @@ func (r *OperandBindInfo) InitBindInfoStatus() {
 // SetUpdatingBindInfoPhase sets the Phase status as Updating
 func (r *OperandBindInfo) SetUpdatingBindInfoPhase() {
 	r.Status.Phase = BindInfoUpdating
+}
+
+// SetDefaultsRequestSpec Set the default value for OperandBindInfo spec
+func (r *OperandBindInfo) SetDefaultsRequestSpec() {
+	if r.Spec.RegistryNamespace == "" {
+		r.Spec.RegistryNamespace = r.Namespace
+	}
 }

--- a/pkg/apis/operator/v1alpha1/operandrequest_types.go
+++ b/pkg/apis/operator/v1alpha1/operandrequest_types.go
@@ -322,6 +322,8 @@ func (r *OperandRequest) SetUpdatingClusterPhase() {
 	r.Status.Phase = ClusterPhaseUpdating
 }
 
+// UpdateClusterPhase will collect the phase of all the operators and operands.
+// Then summarize the cluster phase of the OperandRequest.
 func (r *OperandRequest) UpdateClusterPhase() {
 	clusterStatusStat := struct {
 		creatingNum int
@@ -384,6 +386,7 @@ func (r *OperandRequest) SetDefaultRequestStatus() {
 	}
 }
 
+// AddLabels set the labels for the OperandConfig and OperandRegistry used by this OperandRequest
 func (r *OperandRequest) AddLabels() {
 	if r.Labels == nil {
 		r.Labels = make(map[string]string)
@@ -391,11 +394,6 @@ func (r *OperandRequest) AddLabels() {
 	for _, req := range r.Spec.Requests {
 		r.Labels[req.RegistryNamespace+"."+req.Registry+"/registry"] = "true"
 		r.Labels[req.RegistryNamespace+"."+req.Registry+"/config"] = "true"
-		for _, operand := range req.Operands {
-			if len(operand.Bindings) != 0 {
-				r.Labels[req.RegistryNamespace+"."+req.Registry+"/bindinfo"] = "true"
-			}
-		}
 	}
 }
 

--- a/pkg/controller/operandregistry/operandregistry_controller.go
+++ b/pkg/controller/operandregistry/operandregistry_controller.go
@@ -155,7 +155,7 @@ func (r *ReconcileOperandRegistry) updateOperandBindInfoStatus(request reconcile
 	bindInfoList := &operatorv1alpha1.OperandBindInfoList{}
 
 	opts := []client.ListOption{
-		client.MatchingLabels(map[string]string{request.Namespace + "." + request.Name + "/bindinfo": "true"}),
+		client.MatchingLabels(map[string]string{request.Namespace + "." + request.Name + "/registry": "true"}),
 	}
 	if err := r.client.List(context.TODO(), bindInfoList, opts...); err != nil {
 		return err


### PR DESCRIPTION
**What this PR does / why we need it**:
- Add optional `registryNamespace` into the OperandBindinfo CRD.
- Add `OperandRegistry` label to the OperandBindInfo for #317 #322  


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #317 Fixes #323 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
