### PR TITLE
Enhance operandConfig reconcile

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
@@ -36,7 +36,6 @@ spec:
     spec:
       commonWebUI: {}
       legacyHeader: {}
-      navconfiguration: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operand-deployment-lifecycle-manager.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operand-deployment-lifecycle-manager.v1.2.0.clusterserviceversion.yaml
@@ -62,8 +62,7 @@ metadata:
                 "name": "ibm-commonui-operator",
                 "spec": {
                   "commonWebUI": {},
-                  "legacyHeader": {},
-                  "navconfiguration": {}
+                  "legacyHeader": {}
                 }
               },
               {

--- a/pkg/controller/operandconfig/operandconfig_controller.go
+++ b/pkg/controller/operandconfig/operandconfig_controller.go
@@ -27,6 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -64,7 +65,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource OperandConfig
-	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandConfig{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandConfig{}}, &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -383,6 +383,11 @@ func (r *ReconcileOperandRequest) updateCustomResource(unstruct unstructured.Uns
 
 		// If there is no change between custom resource specs, skip the update
 		if reflect.DeepEqual(existingCR.Object["spec"], mergedCR) {
+			stateUpdateErr := r.updateServiceStatus(csc, service.Name, crName, operatorv1alpha1.ServiceRunning)
+			if stateUpdateErr != nil {
+				klog.Error("Failed to update status")
+				return stateUpdateErr
+			}
 			return nil
 		}
 

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -36,7 +36,7 @@ import (
 )
 
 func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1alpha1.OperandRequest, reconcileReq reconcile.Request) error {
-	klog.V(1).Info("Reconciling Operator")
+	klog.V(1).Info("Reconciling Operators")
 	for _, req := range requestInstance.Spec.Requests {
 		registryInstance, err := r.getRegistryInstance(req.Registry, req.RegistryNamespace)
 		if err != nil {
@@ -106,6 +106,7 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 			}
 		}
 	}
+	klog.V(1).Info("Finished reconciling Operators")
 
 	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove `navconfiguration: {}` from OperandConfig
- When updating configmap and/or secret, compare the content of configmap and/or secret. If there is no change, then skip the update.
- When updating operand CR, only show `Updating` logs when the operand CR `spec` is updated.
- The OperandConfig controller will ignore the OperandConfig status changes.
- Add logs to clarify `Operator` and `Operand` reconcile finished.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #338 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
