### PR TITLE
Add a check for operator scope

### DIFF
--- a/pkg/apis/operator/v1alpha1/operandrequest_types.go
+++ b/pkg/apis/operator/v1alpha1/operandrequest_types.go
@@ -68,11 +68,12 @@ type ResourceType string
 
 // Constants are used for state
 const (
-	ConditionCreating ConditionType = "Creating"
-	ConditionUpdating ConditionType = "Updating"
-	ConditionDeleting ConditionType = "Deleting"
-	ConditionNotFound ConditionType = "NotFound"
-	ConditionReady    ConditionType = "Ready"
+	ConditionCreating   ConditionType = "Creating"
+	ConditionUpdating   ConditionType = "Updating"
+	ConditionDeleting   ConditionType = "Deleting"
+	ConditionNotFound   ConditionType = "NotFound"
+	ConditionOutofScope ConditionType = "OutofScope"
+	ConditionReady      ConditionType = "Ready"
 
 	ClusterPhaseNone     ClusterPhase = "Pending"
 	ClusterPhaseCreating ClusterPhase = "Creating"
@@ -206,6 +207,12 @@ func (r *OperandRequest) SetDeletingCondition(name string, rt ResourceType, cs c
 // SetNotFoundOperatorFromRegistryCondition creates a NotFoundCondition
 func (r *OperandRequest) SetNotFoundOperatorFromRegistryCondition(name string, rt ResourceType, cs corev1.ConditionStatus) {
 	c := newCondition(ConditionNotFound, cs, "Not found "+string(rt), "Not found "+string(rt)+" "+name+" from registry")
+	r.setCondition(*c)
+}
+
+// SetOutofScopeCondition creates a NotFoundCondition
+func (r *OperandRequest) SetOutofScopeCondition(name string, rt ResourceType, cs corev1.ConditionStatus) {
+	c := newCondition(ConditionOutofScope, cs, string(rt)+" "+name+" is a private operator", string(rt)+" "+name+" is a private operator. It can only be request within the OperandRegistry namespace")
 	r.setCondition(*c)
 }
 

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -50,7 +50,7 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 			opt := registryInstance.GetOperator(operand.Name)
 			if opt != nil {
 				if opt.Scope == operatorv1alpha1.ScopePrivate && requestInstance.Namespace != registryInstance.Namespace {
-					klog.V(2).Infof("Operator %s is a private. It can't be requested from namespace %s", operand.Name, requestInstance.Namespace)
+					klog.Warningf("Operator %s is private. It can't be requested from namespace %s", operand.Name, requestInstance.Namespace)
 					requestInstance.SetOutofScopeCondition(operand.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionTrue)
 					if updateErr := r.client.Status().Update(context.TODO(), requestInstance); updateErr != nil {
 						return updateErr

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -49,6 +49,14 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 			// Check the requested Operand if exist in specific OperandRegistry
 			opt := registryInstance.GetOperator(operand.Name)
 			if opt != nil {
+				if opt.Scope == operatorv1alpha1.ScopePrivate && requestInstance.Namespace != registryInstance.Namespace {
+					klog.V(2).Infof("Operator %s is a private. It can't be requested from namespace %s", operand.Name, requestInstance.Namespace)
+					requestInstance.SetOutofScopeCondition(operand.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionTrue)
+					if updateErr := r.client.Status().Update(context.TODO(), requestInstance); updateErr != nil {
+						return updateErr
+					}
+					continue
+				}
 				// Check subscription if exist
 				found, err := r.olmClient.OperatorsV1alpha1().Subscriptions(opt.Namespace).Get(opt.Name, metav1.GetOptions{})
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR prevent users request private operator from the out of namespace of operandRegistry.

Hold it unit we get the list of public and private operators

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #337 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
