### PR TITLE
add operandconfig and bindinfo to licensing

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
@@ -11,6 +11,8 @@ spec:
   - name: ibm-licensing-operator
     spec:
       IBMLicensing: {}
+      OperandBindInfo: {}
+      OperandRequest: {}
   - name: ibm-mongodb-operator
     spec:
       mongoDB: {}

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operand-deployment-lifecycle-manager.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operand-deployment-lifecycle-manager.v1.2.0.clusterserviceversion.yaml
@@ -22,7 +22,9 @@ metadata:
               {
                 "name": "ibm-licensing-operator",
                 "spec": {
-                  "IBMLicensing": {}
+                  "IBMLicensing": {},
+                  "OperandBindInfo": {},
+                  "OperandRequest": {}
                 }
               },
               {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes adding bindinfo and dependency request for IBM Licensing as default in config.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #36969 for IBM Licensing

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
