### PR TITLE
Fix OperandBindInfo init stauts issue

### DIFF
--- a/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
+++ b/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
@@ -110,7 +110,7 @@ func init() {
 
 //InitBindInfoStatus OperandConfig status
 func (r *OperandBindInfo) InitBindInfoStatus() {
-	if (reflect.DeepEqual(r.Status, OperandConfigStatus{})) {
+	if (reflect.DeepEqual(r.Status, OperandBindInfoStatus{})) {
 		r.Status.Phase = BindInfoInit
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
BindInfo init status cannot be initialized

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
