### PR TITLE
Skip reconcile bindinfo when requestNamespaces less than 2

### DIFF
--- a/pkg/controller/operandbindinfo/operandbindinfo_controller.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller.go
@@ -146,7 +146,7 @@ func (r *ReconcileOperandBindInfo) Reconcile(request reconcile.Request) (reconci
 	merr := &util.MultiErr{}
 	// Get the OperandRequest namespace
 	requestNamespaces := registryInstance.Status.OperatorsStatus[bindInfoInstance.Spec.Operand].ReconcileRequests
-	if len(requestNamespaces) == 0 {
+	if len(requestNamespaces) < 2 {
 		// There is no operand depend on the current bind info, nothing to do.
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/operandbindinfo/operandbindinfo_controller_test.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller_test.go
@@ -166,6 +166,10 @@ func operandRegistry(namespace, registryName, registryNamespace, requestName, re
 					Phase: v1alpha1.OperatorRunning,
 					ReconcileRequests: []v1alpha1.ReconcileRequest{
 						{
+							Name:      "request1",
+							Namespace: namespace,
+						},
+						{
 							Name:      requestName,
 							Namespace: requestNamespace,
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

If the `requestNamespaces` less than 2, means there is one request or not.
If not, we certainly do not have to
If there is one, the request namespace must be equal to the operand namespace, we also don't copy ....

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
