### PR TITLE
Operator Upgrade: Watch CSV version change on Subscription

### DIFF
--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -92,9 +92,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 				if reg.MatchString(label) {
 					lablelist := strings.Split(label, ".")
 					reqNamespace = lablelist[0]
-					klog.Info(reqNamespace)
 					reqName = strings.Split(lablelist[1], "/")[0]
-					klog.Info(reqName)
 				}
 			}
 			if reqNamespace == "" || reqName == "" {

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -163,6 +163,7 @@ func (r *ReconcileOperandRequest) reconcileCr(service *operatorv1alpha1.ConfigSe
 		} else {
 			if unstruct.Object["metadata"].(map[string]interface{})["labels"] != nil && unstruct.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
 				// Update or Delete Custom resource
+				unstruct.Object = crTemplate.(map[string]interface{})
 				if updateDeleteErr := r.existingCustomResource(unstruct, service, namespace, csc); updateDeleteErr != nil {
 					merr.Add(updateDeleteErr)
 					continue
@@ -376,7 +377,6 @@ func (r *ReconcileOperandRequest) updateCustomResource(unstruct unstructured.Uns
 	if existingCR.Object["metadata"].(map[string]interface{})["labels"] != nil && existingCR.Object["metadata"].(map[string]interface{})["labels"].(map[string]interface{})["operator.ibm.com/opreq-control"] == t {
 
 		specJSONString, _ := json.Marshal(unstruct.Object["spec"])
-
 		// Merge CR template spec and OperandConfig spec
 		mergedCR := util.MergeCR(specJSONString, crConfig)
 		CRgeneration := existingCR.Object["metadata"].(map[string]interface{})["generation"]

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -326,7 +326,7 @@ func (r *ReconcileOperandRequest) getDeployedOperands(requestInstance *operatorv
 }
 
 func generateClusterObjects(o *operatorv1alpha1.Operator, req *operatorv1alpha1.OperandRequest) *clusterObjects {
-	klog.V(1).Info("Generating Cluster Objects")
+	klog.V(3).Info("Generating Cluster Objects")
 	co := &clusterObjects{}
 	labels := map[string]string{"operator.ibm.com/opreq-control": "true", req.Namespace + "." + req.Name + "/request": "true"}
 

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -113,7 +113,7 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 
 func (r *ReconcileOperandRequest) createSubscription(cr *operatorv1alpha1.OperandRequest, opt *operatorv1alpha1.Operator) error {
 	klog.V(3).Info("Subscription Namespace: ", opt.Namespace)
-	co := generateClusterObjects(opt)
+	co := generateClusterObjects(opt, cr)
 
 	// Create required namespace
 	ns := co.namespace
@@ -288,7 +288,7 @@ func (r *ReconcileOperandRequest) deleteSubscription(operandName string, request
 }
 
 func (r *ReconcileOperandRequest) getNeedDeletedOperands(requestInstance *operatorv1alpha1.OperandRequest, reconcileReq reconcile.Request) (gset.Set, error) {
-	klog.V(3).Info("Getting the operater need to be delete")
+	klog.V(3).Info("Getting the operater need to be deleted")
 	requestOperands := gset.NewSet()
 	for _, req := range requestInstance.Spec.Requests {
 		for _, o := range req.Operands {
@@ -325,12 +325,10 @@ func (r *ReconcileOperandRequest) getDeployedOperands(requestInstance *operatorv
 	return deployedOperands, nil
 }
 
-func generateClusterObjects(o *operatorv1alpha1.Operator) *clusterObjects {
-	klog.V(3).Info("Generating Cluster Objects")
+func generateClusterObjects(o *operatorv1alpha1.Operator, req *operatorv1alpha1.OperandRequest) *clusterObjects {
+	klog.V(1).Info("Generating Cluster Objects")
 	co := &clusterObjects{}
-	labels := map[string]string{
-		"operator.ibm.com/opreq-control": "true",
-	}
+	labels := map[string]string{"operator.ibm.com/opreq-control": "true", req.Namespace + "." + req.Name + "/request": "true"}
 
 	klog.V(3).Info("Generating Namespace: ", o.Namespace)
 	// Namespace Object


### PR DESCRIPTION
**What this PR does / why we need it**:

When operators are upgraded by OLM, ODLM may need to reconcile to update the CR generated from alm-example.

Background:  When the operator is upgraded by OLM, the CR ODLM generate won't be refreshed. It may cause some issues if the `alm-example` of the operator is updated in the new version. Thus I want the ODLM can watch the operator version change in the subscription, then enqueue a reconcile. 

Solution: Watch all the Subscriptions with ODLM label, reconcile OperandRequest when `InstalledCSVversion` is changed. Add a label to the generated subscription for enqueue reconcile request. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #360 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
