### PR TITLE
Removing platform header from config

### DIFF
--- a/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
+++ b/deploy/crds/operator.ibm.com_v1alpha1_operandconfig_cr.yaml
@@ -35,7 +35,6 @@ spec:
   - name: ibm-commonui-operator
     spec:
       commonWebUI: {}
-      legacyHeader: {}
   - name: ibm-management-ingress-operator
     spec:
       managementIngress: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
We are deprecating platform header and it doesn't need to be created when the commonui operator is deployed
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/ibmprivatecloud/roadmap/issues/37289

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
If a consumer is using the service named `platform-header` they will need to start using the new service `common-web-ui` to get the updated header api.
2. If no release note is required, just write "NONE".
-->
```release-note

```
