### PR TITLE
Revert 349 for Cloud Pak use case

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@
 
 ## Overview
 
-**Note:** Documents in this repo are in pre-release version. For the released version, you can refer to [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSHKN6/installer/1.x.x/index.html)
+**Note:** Documents in this repo are in active development. For the official documentation, see [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSHKN6/installer/1.x.x/index.html).
 
-Operand Deployment Lifecycle Manager is used to manage the lifecycle of a group of operands. Checkout design document at [here](./docs/design/operand-deployment-lifecycle-manager.md).
+Operand Deployment Lifecycle Manager is used to manage the lifecycle of a group of operands. Check the design document [here](./docs/design/operand-deployment-lifecycle-manager.md).
 
-Operand Deployment Lifecycle Manager has Three CRDs:
+Operand Deployment Lifecycle Manager has three CRDs:
 
 | Resource                 | Short Name | Description                                                                                |
 |--------------------------|------------|--------------------------------------------------------------------------------------------|

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
 
 ## Overview
 
+**Note:** Documents in this repo are in pre-release version. For the released version, you can refer to [IBM Knowledge Center](https://www.ibm.com/support/knowledgecenter/SSHKN6/installer/1.x.x/index.html)
+
 Operand Deployment Lifecycle Manager is used to manage the lifecycle of a group of operands. Checkout design document at [here](./docs/design/operand-deployment-lifecycle-manager.md).
 
 Operand Deployment Lifecycle Manager has Three CRDs:

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operand-deployment-lifecycle-manager.v1.2.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.2.0/operand-deployment-lifecycle-manager.v1.2.0.clusterserviceversion.yaml
@@ -61,8 +61,7 @@ metadata:
               {
                 "name": "ibm-commonui-operator",
                 "spec": {
-                  "commonWebUI": {},
-                  "legacyHeader": {}
+                  "commonWebUI": {}
                 }
               },
               {

--- a/pkg/controller/operandbindinfo/operandbindinfo_controller.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller.go
@@ -147,7 +147,7 @@ func (r *ReconcileOperandBindInfo) Reconcile(request reconcile.Request) (reconci
 	merr := &util.MultiErr{}
 	// Get the OperandRequest namespace
 	requestNamespaces := registryInstance.Status.OperatorsStatus[bindInfoInstance.Spec.Operand].ReconcileRequests
-	if len(requestNamespaces) < 2 {
+	if len(requestNamespaces) == 0 {
 		// There is no operand depend on the current bind info, nothing to do.
 		return reconcile.Result{}, nil
 	}

--- a/pkg/controller/operandbindinfo/operandbindinfo_controller_test.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller_test.go
@@ -166,10 +166,6 @@ func operandRegistry(namespace, registryName, registryNamespace, requestName, re
 					Phase: v1alpha1.OperatorRunning,
 					ReconcileRequests: []v1alpha1.ReconcileRequest{
 						{
-							Name:      "request1",
-							Namespace: namespace,
-						},
-						{
 							Name:      requestName,
 							Namespace: requestNamespace,
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

Revert #349 
In the Cloudpak scenario, there is only one OperandRequest and common services are not in the same namespace with Cloud Paks which require the bindinfo to copy secret and/or configmap.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
