### PR TITLE
Deduplicate namespace in the operandbindinfo status

### DIFF
--- a/pkg/controller/operandbindinfo/bindInfo_status.go
+++ b/pkg/controller/operandbindinfo/bindInfo_status.go
@@ -35,8 +35,12 @@ func (r *ReconcileOperandBindInfo) updateBindInfoPhase(cr *operatorv1alpha1.Oper
 		}
 		requestNsList := make([]string, len(requestNamespaces))
 		for index, ns := range requestNamespaces {
+			if ns.Namespace == bindInfoInstance.Namespace {
+				continue
+			}
 			requestNsList[index] = ns.Namespace
 		}
+		requestNsList = unique(requestNsList)
 		if bindInfoInstance.Status.Phase == phase && reflect.DeepEqual(requestNsList, bindInfoInstance.Status.RequestNamespaces) {
 			return true, nil
 		}
@@ -51,4 +55,16 @@ func (r *ReconcileOperandBindInfo) updateBindInfoPhase(cr *operatorv1alpha1.Oper
 		return err
 	}
 	return nil
+}
+
+func unique(stringSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range stringSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

- Don't add the namespace of bindinfo
- Deduplicate the namespace
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
