### PR TITLE
update bindinfo status

### DIFF
--- a/pkg/controller/operandbindinfo/bindInfo_status.go
+++ b/pkg/controller/operandbindinfo/bindInfo_status.go
@@ -33,18 +33,20 @@ func (r *ReconcileOperandBindInfo) updateBindInfoPhase(cr *operatorv1alpha1.Oper
 		if err != nil {
 			return false, err
 		}
-		requestNsList := make([]string, len(requestNamespaces))
-		for index, ns := range requestNamespaces {
+		var requestNsList []string
+		for _, ns := range requestNamespaces {
 			if ns.Namespace == bindInfoInstance.Namespace {
 				continue
 			}
-			requestNsList[index] = ns.Namespace
+			requestNsList =  append(requestNsList,ns.Namespace)
 		}
 		requestNsList = unique(requestNsList)
 		if bindInfoInstance.Status.Phase == phase && reflect.DeepEqual(requestNsList, bindInfoInstance.Status.RequestNamespaces) {
 			return true, nil
 		}
-		bindInfoInstance.Status.RequestNamespaces = requestNsList
+		if len(requestNsList) != 0 {
+			bindInfoInstance.Status.RequestNamespaces = requestNsList
+		}
 		bindInfoInstance.Status.Phase = phase
 		if err := r.client.Status().Update(context.TODO(), bindInfoInstance); err != nil {
 			klog.V(3).Info("Waiting for OperandBindInfo instance status ready ...")

--- a/pkg/controller/operandbindinfo/bindInfo_status.go
+++ b/pkg/controller/operandbindinfo/bindInfo_status.go
@@ -38,7 +38,7 @@ func (r *ReconcileOperandBindInfo) updateBindInfoPhase(cr *operatorv1alpha1.Oper
 			if ns.Namespace == bindInfoInstance.Namespace {
 				continue
 			}
-			requestNsList =  append(requestNsList,ns.Namespace)
+			requestNsList = append(requestNsList, ns.Namespace)
 		}
 		requestNsList = unique(requestNsList)
 		if bindInfoInstance.Status.Phase == phase && reflect.DeepEqual(requestNsList, bindInfoInstance.Status.RequestNamespaces) {

--- a/pkg/controller/operandbindinfo/operandbindinfo_controller.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller.go
@@ -177,7 +177,7 @@ func (r *ReconcileOperandBindInfo) Reconcile(request reconcile.Request) (reconci
 				klog.Errorf("Not found OperandRequest %s in the namespace %s: %s", bindRequest.Name, bindRequest.Namespace, err)
 				r.recorder.Eventf(bindInfoInstance, corev1.EventTypeWarning, "NotFound", "NotFound OperandRequest %s in the namespace %s", bindRequest.Name, bindRequest.Namespace)
 			}
-			return reconcile.Result{}, client.IgnoreNotFound(err)
+			merr.Add(err)
 		}
 		// Get binding information from OperandRequest
 		secretReq, cmReq := getBindingInfofromRequest(bindInfoInstance, requestInstance)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is for fixing the issue in the operandbindinfo status.

Issue: there is an empty namespace in bindinfo cr
```
root@zhiwei1:~# oc -n ibm-common-services get operandbindinfo management-ingress -o yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandBindInfo
metadata:
  creationTimestamp: "2020-05-17T08:15:58Z"
  generation: 2
  labels:
    ibm-common-services.common-service/registry: "true"
    operator.ibm.com/opreq-control: "true"
  name: management-ingress
  namespace: ibm-common-services
  resourceVersion: "2497030"
  selfLink: /apis/operator.ibm.com/v1alpha1/namespaces/ibm-common-services/operandbindinfos/management-ingress
  uid: a04fec8f-d07b-43ff-88f7-7953f4177071
spec:
  bindings:
    public:
      configmap: ibmcloud-cluster-info
      secret: ibmcloud-cluster-ca-cert
  operand: ibm-management-ingress-operator
  registry: common-service
  registryNamespace: ibm-common-services
status:
  phase: Updating
  requestNamespaces:
  - ""
  - ace
  - ace-cam
```

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
