### PR TITLE
continue the loop when can't get request

### DIFF
--- a/pkg/controller/operandbindinfo/operandbindinfo_controller.go
+++ b/pkg/controller/operandbindinfo/operandbindinfo_controller.go
@@ -178,6 +178,7 @@ func (r *ReconcileOperandBindInfo) Reconcile(request reconcile.Request) (reconci
 				r.recorder.Eventf(bindInfoInstance, corev1.EventTypeWarning, "NotFound", "NotFound OperandRequest %s in the namespace %s", bindRequest.Name, bindRequest.Namespace)
 			}
 			merr.Add(err)
+			continue
 		}
 		// Get binding information from OperandRequest
 		secretReq, cmReq := getBindingInfofromRequest(bindInfoInstance, requestInstance)


### PR DESCRIPTION
**What this PR does / why we need it**:

It is a follow-up PR for the #390. It is to cover the case that there is an error when fetching the operandrequest. 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
