### PR TITLE
sperate operandregistry into two controllers

### DIFF
--- a/pkg/controller/add_operandregistry.go
+++ b/pkg/controller/add_operandregistry.go
@@ -22,5 +22,5 @@ import (
 
 func init() {
 	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
-	AddToManagerFuncs = append(AddToManagerFuncs, operandregistry.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, operandregistry.AddBindInfoController, operandregistry.AddRequestController)
 }

--- a/pkg/controller/operandregistry/operandregistry_bindinfo_controller.go
+++ b/pkg/controller/operandregistry/operandregistry_bindinfo_controller.go
@@ -18,14 +18,17 @@ package operandregistry
 
 import (
 	"context"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
@@ -37,41 +40,58 @@ import (
 * business logic.  Delete these comments after modifying this file.*
  */
 
-// Add creates a new OperandRegistry Controller and adds it to the Manager. The Manager will set fields on the Controller
+// AddBindInfoController creates a new OperandRegistry Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
-func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+func AddBindInfoController(mgr manager.Manager) error {
+	return addBindinfoController(mgr, newReconcilerBindInfoController(mgr))
 }
 
-// newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileOperandRegistry{
+// newReconcilerBindInfoController returns a new reconcile.Reconciler
+func newReconcilerBindInfoController(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileOperandRegistryBindinfo{
 		client:   mgr.GetClient(),
 		recorder: mgr.GetEventRecorderFor("operandregistry"),
 		scheme:   mgr.GetScheme()}
 }
 
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+// addBindinfoController adds a new Controller to mgr with r as the reconcile.Reconciler
+func addBindinfoController(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New("operandregistry-controller", mgr, controller.Options{Reconciler: r})
+	c, err := controller.New("operandregistry-bindinfo-controller", mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}
 
+	predicatebindinfo := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldObject := e.ObjectOld.(*operatorv1alpha1.OperandRegistry)
+			newObject := e.ObjectNew.(*operatorv1alpha1.OperandRegistry)
+			return !reflect.DeepEqual(oldObject.Status, newObject.Status)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+	}
+
 	// Watch for changes to primary resource OperandRegistry
-	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandRegistry{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandRegistry{}}, &handler.EnqueueRequestForObject{}, predicatebindinfo)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-// blank assignment to verify that ReconcileOperandRegistry implements reconcile.Reconciler
-var _ reconcile.Reconciler = &ReconcileOperandRegistry{}
+// blank assignment to verify that ReconcileOperandRegistryBindinfo implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileOperandRegistryBindinfo{}
 
-// ReconcileOperandRegistry reconciles a OperandRegistry object
-type ReconcileOperandRegistry struct {
+// ReconcileOperandRegistryBindinfo reconciles a OperandRegistry object
+type ReconcileOperandRegistryBindinfo struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client   client.Client
@@ -84,7 +104,7 @@ type ReconcileOperandRegistry struct {
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-func (r *ReconcileOperandRegistry) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileOperandRegistryBindinfo) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 
 	// Fetch the OperandRegistry instance
 	instance := &operatorv1alpha1.OperandRegistry{}
@@ -92,23 +112,7 @@ func (r *ReconcileOperandRegistry) Reconcile(request reconcile.Request) (reconci
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
 
-	klog.V(1).Infof("Reconciling OperandRegistry %s", request.NamespacedName)
-
-	// Set the default scope for OperandRegistry instance
-	instance.SetDefaultsRegistry()
-	if err := r.client.Update(context.TODO(), instance); err != nil {
-		return reconcile.Result{}, err
-	}
-	// Set the default status for OperandRegistry instance
-	instance.InitRegistryStatus()
-	klog.V(3).Infof("Initializing the status of OperandRegistry %s in the namespace %s", request.Name, request.Namespace)
-	if err := r.client.Status().Update(context.TODO(), instance); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	if err := r.updateOperandRequestStatus(request); err != nil {
-		return reconcile.Result{}, err
-	}
+	klog.V(1).Infof("Reconciling OperandRegistry for OperandBindInfo %s", request.NamespacedName)
 
 	if err := r.updateOperandBindInfoStatus(request); err != nil {
 		return reconcile.Result{}, err
@@ -117,33 +121,10 @@ func (r *ReconcileOperandRegistry) Reconcile(request reconcile.Request) (reconci
 	return reconcile.Result{}, nil
 }
 
-// updateOperandRequestStatus update the cluster phase of OperandRequest
-// When the registry changed, query all the OperandRequests that use it, and then
-// update these OperandRequest's Phase to Updating, to trigger reconcile of these OperandRequests.
-func (r *ReconcileOperandRegistry) updateOperandRequestStatus(request reconcile.Request) error {
-	// Get the requests related with current registry
-	requestList := &operatorv1alpha1.OperandRequestList{}
-
-	opts := []client.ListOption{
-		client.MatchingLabels(map[string]string{request.Namespace + "." + request.Name + "/registry": "true"}),
-	}
-	if err := r.client.List(context.TODO(), requestList, opts...); err != nil {
-		return err
-	}
-
-	for _, req := range requestList.Items {
-		req.SetUpdatingClusterPhase()
-		if err := r.client.Status().Update(context.TODO(), &req); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // updateOperandBindInfoStatus update the phase of OperandBindInfo
 // When the registry changed, query all the OperandBindInfo that use it, and then
 // update these OperandBindInfo's Phase to Updating, to trigger reconcile of these OperandBindInfo.
-func (r *ReconcileOperandRegistry) updateOperandBindInfoStatus(request reconcile.Request) error {
+func (r *ReconcileOperandRegistryBindinfo) updateOperandBindInfoStatus(request reconcile.Request) error {
 	// Get the bindinfos related with current registry
 	bindInfoList := &operatorv1alpha1.OperandBindInfoList{}
 

--- a/pkg/controller/operandregistry/operandregistry_bindinfo_controller_test.go
+++ b/pkg/controller/operandregistry/operandregistry_bindinfo_controller_test.go
@@ -1,0 +1,102 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package operandregistry
+
+import (
+	"context"
+	"testing"
+
+	v1beta2 "github.com/coreos/etcd-operator/pkg/apis/etcd/v1beta2"
+	v1alpha2 "github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	v1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
+)
+
+// TestRegistryController runs ReconcileOperandRegistry.Reconcile() against a
+// fake client that tracks a OperandRegistry object.
+func TestRegistryBindInfoController(t *testing.T) {
+	var (
+		name              = "common-service"
+		namespace         = "ibm-common-service"
+		requestName       = "ibm-cloudpak-name"
+		requestNamespace  = "ibm-cloudpak"
+		operatorName      = "ibm-operator-name"
+		operatorNamespace = "ibm-operators"
+	)
+
+	req := getReconcileRequest(name, namespace)
+
+	r := getBindInfoReconciler(name, namespace, requestName, requestNamespace, operatorName, operatorNamespace)
+
+	initBindInfoReconcile(t, r, req, operatorName, operatorNamespace)
+}
+
+func initBindInfoReconcile(t *testing.T, r ReconcileOperandRegistryBindinfo, req reconcile.Request, operatorName, operatorNamespace string) {
+	assert := assert.New(t)
+
+	_, err := r.Reconcile(req)
+	assert.NoError(err)
+
+	registry := &v1alpha1.OperandRegistry{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, registry)
+	assert.NoError(err)
+
+	bindInfo := &v1alpha1.OperandBindInfo{}
+	err = r.client.Get(context.TODO(), types.NamespacedName{Name: operatorName, Namespace: operatorNamespace}, bindInfo)
+	assert.NoError(err)
+
+	// Check the OperandBindInfo status
+	assert.NotNil(bindInfo.Status, "init OperandBindInfo status should not be empty")
+	assert.Equalf(v1alpha1.BindInfoUpdating, bindInfo.Status.Phase, "Overall OperandBindInfo phase should be 'Updating'")
+}
+
+func getBindInfoReconciler(name, namespace, requestName, requestNamespace, operatorName, operatorNamespace string) ReconcileOperandRegistryBindinfo {
+	s := scheme.Scheme
+	v1alpha1.SchemeBuilder.AddToScheme(s)
+	corev1.SchemeBuilder.AddToScheme(s)
+	v1beta2.SchemeBuilder.AddToScheme(s)
+	v1alpha2.SchemeBuilder.AddToScheme(s)
+
+	initData := initBindInfoClientData(name, namespace, requestName, requestNamespace, operatorName, operatorNamespace)
+
+	// Create a fake client to mock API calls.
+	client := fake.NewFakeClient(initData.objs...)
+
+	// Return a ReconcileOperandRegistry object with the scheme and fake client.
+	return ReconcileOperandRegistryBindinfo{
+		scheme: s,
+		client: client,
+	}
+}
+
+func initBindInfoClientData(name, namespace, requestName, requestNamespace, operatorName, operatorNamespace string) *DataObj {
+	return &DataObj{
+		objs: []runtime.Object{
+			operandRegistry(name, namespace, operatorNamespace),
+			operandRequest(name, namespace, requestName, requestNamespace),
+			operandBindInfo(name, namespace, operatorName, operatorNamespace),
+			configmap("cm", operatorNamespace),
+			secret("secret", operatorNamespace),
+		},
+	}
+}

--- a/pkg/controller/operandregistry/operandregistry_request_controller.go
+++ b/pkg/controller/operandregistry/operandregistry_request_controller.go
@@ -1,0 +1,141 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package operandregistry
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// AddRequestController creates a new OperandRegistry Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func AddRequestController(mgr manager.Manager) error {
+	return addRequestController(mgr, newReconcilerRequestController(mgr))
+}
+
+// newReconcilerRequestController returns a new reconcile.Reconciler
+func newReconcilerRequestController(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileOperandRegistryRequest{
+		client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("operandregistry"),
+		scheme:   mgr.GetScheme()}
+}
+
+// addRequestController adds a new Controller to mgr with r as the reconcile.Reconciler
+func addRequestController(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("operandregistry-request-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource OperandRegistry
+	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandRegistry{}}, &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// blank assignment to verify that ReconcileOperandRegistryRequest implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileOperandRegistryRequest{}
+
+// ReconcileOperandRegistryRequest reconciles a OperandRegistry object
+type ReconcileOperandRegistryRequest struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client   client.Client
+	recorder record.EventRecorder
+	scheme   *runtime.Scheme
+}
+
+// Reconcile reads that state of the cluster for a OperandRegistry object and makes changes based on the state read
+// and what is in the OperandRegistry.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
+func (r *ReconcileOperandRegistryRequest) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+
+	// Fetch the OperandRegistry instance
+	instance := &operatorv1alpha1.OperandRegistry{}
+	if err := r.client.Get(context.TODO(), request.NamespacedName, instance); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	klog.V(1).Infof("Reconciling OperandRegistry %s", request.NamespacedName)
+
+	// Set the default scope for OperandRegistry instance
+	instance.SetDefaultsRegistry()
+	if err := r.client.Update(context.TODO(), instance); err != nil {
+		return reconcile.Result{}, err
+	}
+	// Set the default status for OperandRegistry instance
+	instance.InitRegistryStatus()
+	klog.V(3).Infof("Initializing the status of OperandRegistry %s in the namespace %s", request.Name, request.Namespace)
+	if err := r.client.Status().Update(context.TODO(), instance); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if err := r.updateOperandRequestStatus(request); err != nil {
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+// updateOperandRequestStatus update the cluster phase of OperandRequest
+// When the registry changed, query all the OperandRequests that use it, and then
+// update these OperandRequest's Phase to Updating, to trigger reconcile of these OperandRequests.
+func (r *ReconcileOperandRegistryRequest) updateOperandRequestStatus(request reconcile.Request) error {
+	// Get the requests related with current registry
+	requestList := &operatorv1alpha1.OperandRequestList{}
+
+	opts := []client.ListOption{
+		client.MatchingLabels(map[string]string{request.Namespace + "." + request.Name + "/registry": "true"}),
+	}
+	if err := r.client.List(context.TODO(), requestList, opts...); err != nil {
+		return err
+	}
+
+	for _, req := range requestList.Items {
+		if req.Status.Phase != operatorv1alpha1.ClusterPhaseRunning || !req.DeletionTimestamp.IsZero() {
+			continue
+		}
+		req.SetUpdatingClusterPhase()
+		if err := r.client.Status().Update(context.TODO(), &req); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is for separating the OperandRegistry controller into two controllers:
1. One operator watches the spec changes to trigger OperanRerigstry reconciliation.
1. One operator watches the status changes to trigger OperanBindInfo reconciliation.

I open an issue in the community to ask the best practice.

https://github.com/operator-framework/operator-sdk/issues/3182

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #405 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
