### PR TITLE
Update operator deletion check

### DIFF
--- a/pkg/controller/operandregistry/operandregistry_controller.go
+++ b/pkg/controller/operandregistry/operandregistry_controller.go
@@ -64,7 +64,7 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	// Watch for changes to primary resource OperandRegistry
-	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandRegistry{}}, &handler.EnqueueRequestForObject{})
+	err = c.Watch(&source.Kind{Type: &operatorv1alpha1.OperandRegistry{}}, &handler.EnqueueRequestForObject{}, predicate.GenerationChangedPredicate{})
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -183,7 +183,7 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 	if !requestInstance.ObjectMeta.DeletionTimestamp.IsZero() {
 
 		// Check and clean up the subscriptions
-		err := r.checkFinalizer(requestInstance, request)
+		err := r.checkFinalizer(requestInstance)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
@@ -196,7 +196,7 @@ func (r *ReconcileOperandRequest) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.reconcileOperator(requestInstance, request); err != nil {
+	if err := r.reconcileOperator(requestInstance); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -229,7 +229,7 @@ func (r *ReconcileOperandRequest) addFinalizer(cr *operatorv1alpha1.OperandReque
 	return nil
 }
 
-func (r *ReconcileOperandRequest) checkFinalizer(requestInstance *operatorv1alpha1.OperandRequest, request reconcile.Request) error {
+func (r *ReconcileOperandRequest) checkFinalizer(requestInstance *operatorv1alpha1.OperandRequest) error {
 	klog.V(2).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
 	existingSub, err := r.olmClient.OperatorsV1alpha1().Subscriptions(metav1.NamespaceAll).List(metav1.ListOptions{
 		LabelSelector: "operator.ibm.com/opreq-control",
@@ -253,7 +253,7 @@ func (r *ReconcileOperandRequest) checkFinalizer(requestInstance *operatorv1alph
 			return err
 		}
 		for _, operand := range req.Operands {
-			if err := r.deleteSubscription(operand.Name, requestInstance, registryInstance, configInstance, request); err != nil {
+			if err := r.deleteSubscription(operand.Name, requestInstance, registryInstance, configInstance); err != nil {
 				klog.Error("Failed to delete subscriptions during the uninstall: ", err)
 				klog.Error(err)
 				return err


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR is for decoupling the OperandRegistry reconciliation with the OperandRegistry to avoid the race condition.
Then it can fix the deletion detects mentioned in #434 and #435.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #434 #435 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
