### PR TITLE
Move csv status checking out of get csv function

### DIFF
--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -94,6 +94,13 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 				continue
 			}
 
+			if csv.Status.Phase == olmv1alpha1.CSVPhaseFailed {
+				klog.Errorf("The ClusterServiceVersion for Subscription %s is Failed", opdConfig.Name)
+				merr.Add(fmt.Errorf("the ClusterServiceVersion for Subscription %s is Failed", opdConfig.Name))
+				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "")
+				continue
+			}
+
 			klog.V(3).Info("Generating customresource base on ClusterServiceVersion: ", csv.ObjectMeta.Name)
 			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, "")
 
@@ -171,11 +178,6 @@ func (r *ReconcileOperandRequest) getClusterServiceVersion(subName, subNamespace
 		}
 		klog.Errorf("Failed to get ClusterServiceVersion %s in the namespace %s: %s", csvName, csvNamespace, getCSVErr)
 		return nil, getCSVErr
-	}
-
-	if csv.Status.Phase == olmv1alpha1.CSVPhaseFailed {
-		klog.Errorf("The ClusterServiceVersion for Subscription %s is Failed", subName)
-		return nil, fmt.Errorf("the ClusterServiceVersion for Subscription %s is Failed", subName)
 	}
 
 	klog.V(3).Infof("Get ClusterServiceVersion %s in the namespace %s", csvName, csvNamespace)


### PR DESCRIPTION
**What this PR does / why we need it**:

Move the CSV status out of the getClusterServiceVersion function to unblock deleting the failed CSV.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #442

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
