### PR TITLE
Use multiErr when delete

### DIFF
--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
+	util "github.com/IBM/operand-deployment-lifecycle-manager/pkg/util"
 )
 
 /**
@@ -252,12 +253,16 @@ func (r *ReconcileOperandRequest) checkFinalizer(requestInstance *operatorv1alph
 			klog.Error("Failed to get OperandConfig: ", err)
 			return err
 		}
+
+		merr := &util.MultiErr{}
 		for _, operand := range req.Operands {
 			if err := r.deleteSubscription(operand.Name, requestInstance, registryInstance, configInstance); err != nil {
 				klog.Error("Failed to delete subscriptions during the uninstall: ", err)
-				klog.Error(err)
-				return err
+				merr.Add(err)
 			}
+		}
+		if len(merr.Errors) != 0 {
+			return merr
 		}
 	}
 	return nil

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -99,6 +99,10 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 				merr.Add(fmt.Errorf("the ClusterServiceVersion for Subscription %s is Failed", opdConfig.Name))
 				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "")
 				continue
+			} else if csv.Status.Phase != olmv1alpha1.CSVPhaseSucceeded {
+				klog.Errorf("The ClusterServiceVersion for Subscription %s is not Ready", opdConfig.Name)
+				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorInstalling, "")
+				continue
 			}
 
 			klog.V(3).Info("Generating customresource base on ClusterServiceVersion: ", csv.ObjectMeta.Name)

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -99,7 +99,8 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 				merr.Add(fmt.Errorf("the ClusterServiceVersion for Subscription %s is Failed", opdConfig.Name))
 				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "")
 				continue
-			} else if csv.Status.Phase != olmv1alpha1.CSVPhaseSucceeded {
+			}
+			if csv.Status.Phase != olmv1alpha1.CSVPhaseSucceeded {
 				klog.Errorf("The ClusterServiceVersion for Subscription %s is not Ready", opdConfig.Name)
 				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorInstalling, "")
 				continue

--- a/pkg/controller/operandrequest/reconcile_operator.go
+++ b/pkg/controller/operandrequest/reconcile_operator.go
@@ -33,6 +33,7 @@ import (
 
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
 	constant "github.com/IBM/operand-deployment-lifecycle-manager/pkg/constant"
+	util "github.com/IBM/operand-deployment-lifecycle-manager/pkg/util"
 )
 
 func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1alpha1.OperandRequest) error {
@@ -122,11 +123,14 @@ func (r *ReconcileOperandRequest) reconcileOperator(requestInstance *operatorv1a
 		if err != nil {
 			return err
 		}
+		merr := &util.MultiErr{}
 		for o := range needDeletedOperands.Iter() {
-			fmt.Println(o)
 			if err := r.deleteSubscription(fmt.Sprintf("%v", o), requestInstance, registryInstance, configInstance); err != nil {
-				return err
+				merr.Add(err)
 			}
+		}
+		if len(merr.Errors) != 0 {
+			return merr
 		}
 	}
 	klog.V(1).Info("Finished reconciling Operators")


### PR DESCRIPTION
1. Use multiErr when to delete sub, if one operator delete failed, it will not block other
2. Set operator status is Installing when the CSV phase is not succeeded.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #444 #445 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
