### PR TITLE
Add finalizers to operandRegistry and operandConfig

### DIFF
--- a/pkg/apis/operator/v1alpha1/finalizer.go
+++ b/pkg/apis/operator/v1alpha1/finalizer.go
@@ -1,0 +1,52 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EnsureFinalizer ensures that the object's finalizer is included
+// in the ObjectMeta Finalizers slice. If it already exists, no state change occurs.
+// If it doesn't, the finalizer is appended to the slice.
+func EnsureFinalizer(objectMeta *metav1.ObjectMeta, expectedFinalizer string) bool {
+	// First check if the finalizer is already included in the object.
+	for _, finalizer := range objectMeta.Finalizers {
+		if finalizer == expectedFinalizer {
+			return false
+		}
+	}
+
+	objectMeta.Finalizers = append(objectMeta.Finalizers, expectedFinalizer)
+	return true
+}
+
+// RemoveFinalizer removes the finalizer from the object's ObjectMeta.
+func RemoveFinalizer(objectMeta *metav1.ObjectMeta, deletingFinalizer string) bool {
+	outFinalizers := make([]string, 0)
+	var changed bool
+	for _, finalizer := range objectMeta.Finalizers {
+		if finalizer == deletingFinalizer {
+			changed = true
+			continue
+		}
+		outFinalizers = append(outFinalizers, finalizer)
+	}
+
+	objectMeta.Finalizers = outFinalizers
+	return changed
+}

--- a/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
+++ b/pkg/apis/operator/v1alpha1/operandbindinfo_types.go
@@ -28,6 +28,10 @@ type BindInfoPhase string
 
 // BindInfo status
 const (
+	// BindInfoFinalizer is the name for the finalizer to allow for deletion
+	// reconciliation when an OperandBindInfo is deleted.
+	BindInfoFinalizer = "finalizer.bindinfo.ibm.com"
+
 	BindInfoCompleted BindInfoPhase = "Completed"
 	BindInfoFailed    BindInfoPhase = "Failed"
 	BindInfoInit      BindInfoPhase = "Initialized"
@@ -158,4 +162,17 @@ func (r *OperandBindInfo) UpdateLabels() bool {
 		}
 	}
 	return isUpdated
+}
+
+// RemoveFinalizer removes the operator source finalizer from the
+// OperatorSource ObjectMeta.
+func (r *OperandBindInfo) RemoveFinalizer() bool {
+	return RemoveFinalizer(&r.ObjectMeta, BindInfoFinalizer)
+}
+
+// EnsureFinalizer ensures that the operator source finalizer is included
+// in the ObjectMeta.Finalizer slice. If it already exists, no state change occurs.
+// If it doesn't, the finalizer is appended to the slice.
+func (r *OperandBindInfo) EnsureFinalizer() bool {
+	return EnsureFinalizer(&r.ObjectMeta, BindInfoFinalizer)
 }

--- a/pkg/apis/operator/v1alpha1/operandconfig_types.go
+++ b/pkg/apis/operator/v1alpha1/operandconfig_types.go
@@ -106,6 +106,10 @@ type ServicePhase string
 
 // Service status
 const (
+	// ConfigFinalizer is the name for the finalizer to allow for deletion
+	// reconciliation when an OperandConfig is deleted.
+	ConfigFinalizer = "finalizer.config.ibm.com"
+
 	ServiceReady   ServicePhase = "Ready for Deployment"
 	ServiceRunning ServicePhase = "Running"
 	ServiceFailed  ServicePhase = "Failed"
@@ -182,4 +186,17 @@ func (r *OperandConfig) UpdateOperandPhase() {
 	} else {
 		r.Status.Phase = ServiceNone
 	}
+}
+
+// RemoveFinalizer removes the operator source finalizer from the
+// OperatorSource ObjectMeta.
+func (r *OperandConfig) RemoveFinalizer() bool {
+	return RemoveFinalizer(&r.ObjectMeta, ConfigFinalizer)
+}
+
+// EnsureFinalizer ensures that the operator source finalizer is included
+// in the ObjectMeta.Finalizer slice. If it already exists, no state change occurs.
+// If it doesn't, the finalizer is appended to the slice.
+func (r *OperandConfig) EnsureFinalizer() bool {
+	return EnsureFinalizer(&r.ObjectMeta, ConfigFinalizer)
 }

--- a/pkg/apis/operator/v1alpha1/operandregistry_types.go
+++ b/pkg/apis/operator/v1alpha1/operandregistry_types.go
@@ -154,6 +154,10 @@ type RegistryPhase string
 
 // Registry phase
 const (
+	// RegistryFinalizer is the name for the finalizer to allow for deletion
+	// reconciliation when an OperandRegistry is deleted.
+	RegistryFinalizer = "finalizer.registry.ibm.com"
+
 	RegistryReady    RegistryPhase = "Ready for Deployment"
 	RegistryRunning  RegistryPhase = "Running"
 	RegistryPending  RegistryPhase = "Pending"
@@ -249,4 +253,17 @@ func init() {
 // UpdateRegistryPhase sets the current Phase status
 func (r *OperandRegistry) UpdateRegistryPhase(phase RegistryPhase) {
 	r.Status.Phase = phase
+}
+
+// RemoveFinalizer removes the operator source finalizer from the
+// OperatorSource ObjectMeta.
+func (r *OperandRegistry) RemoveFinalizer() bool {
+	return RemoveFinalizer(&r.ObjectMeta, RegistryFinalizer)
+}
+
+// EnsureFinalizer ensures that the operator source finalizer is included
+// in the ObjectMeta.Finalizer slice. If it already exists, no state change occurs.
+// If it doesn't, the finalizer is appended to the slice.
+func (r *OperandRegistry) EnsureFinalizer() bool {
+	return EnsureFinalizer(&r.ObjectMeta, RegistryFinalizer)
 }

--- a/pkg/apis/operator/v1alpha1/operandrequest_types.go
+++ b/pkg/apis/operator/v1alpha1/operandrequest_types.go
@@ -73,6 +73,10 @@ type OperatorPhase string
 
 // Constants are used for state
 const (
+	// RequestFinalizer is the name for the finalizer to allow for deletion
+	// reconciliation when an OperandRequest is deleted.
+	RequestFinalizer = "finalizer.request.ibm.com"
+
 	ConditionCreating   ConditionType = "Creating"
 	ConditionUpdating   ConditionType = "Updating"
 	ConditionDeleting   ConditionType = "Deleting"
@@ -471,4 +475,17 @@ func (r *OperandRequest) GetAllReconcileRequest() []reconcile.Request {
 
 func init() {
 	SchemeBuilder.Register(&OperandRequest{}, &OperandRequestList{})
+}
+
+// RemoveFinalizer removes the operator source finalizer from the
+// OperatorSource ObjectMeta.
+func (r *OperandRequest) RemoveFinalizer() bool {
+	return RemoveFinalizer(&r.ObjectMeta, RequestFinalizer)
+}
+
+// EnsureFinalizer ensures that the operator source finalizer is included
+// in the ObjectMeta.Finalizer slice. If it already exists, no state change occurs.
+// If it doesn't, the finalizer is appended to the slice.
+func (r *OperandRequest) EnsureFinalizer() bool {
+	return EnsureFinalizer(&r.ObjectMeta, RequestFinalizer)
 }

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -104,7 +104,6 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestInstance *operatorv1al
 			if csv.Status.Phase != olmv1alpha1.CSVPhaseSucceeded {
 				klog.Errorf("The ClusterServiceVersion for Subscription %s is not Ready", opdConfig.Name)
 				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorInstalling, "")
-				continue
 			}
 
 			klog.V(3).Info("Generating customresource base on ClusterServiceVersion: ", csv.ObjectMeta.Name)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #395

This PR set finalized to OperandConfig and OperandRegistry, in case they are deleted by users accidentally before operandRequests are deleted.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
