### PR TITLE
Add label to prevent subscription and CR uninstall

### DIFF
--- a/pkg/constant/constant.go
+++ b/pkg/constant/constant.go
@@ -16,4 +16,14 @@
 
 package constant
 
-const ClusterOperatorNamespace string = "openshift-operators"
+const (
+
+	//ClusterOperatorNamespace is the namespace of cluster operators
+	ClusterOperatorNamespace string = "openshift-operators"
+
+	//NotUninstallLabel is the label used to prevent subscription/CR from uninstall
+	NotUninstallLabel string = "operator.ibm.com/opreq-do-not-uninstall"
+
+	//OpreqLabel is the label used to label the subscription/CR managed by ODLM
+	OpreqLabel string = "operator.ibm.com/opreq-control"
+)

--- a/pkg/controller/operandrequest/operandrequest_controller.go
+++ b/pkg/controller/operandrequest/operandrequest_controller.go
@@ -40,6 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
+	constant "github.com/IBM/operand-deployment-lifecycle-manager/pkg/constant"
 	fetch "github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/common"
 	util "github.com/IBM/operand-deployment-lifecycle-manager/pkg/util"
 )
@@ -240,7 +241,7 @@ func (r *ReconcileOperandRequest) addFinalizer(cr *operatorv1alpha1.OperandReque
 func (r *ReconcileOperandRequest) checkFinalizer(requestInstance *operatorv1alpha1.OperandRequest) error {
 	klog.V(2).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
 	existingSub, err := r.olmClient.OperatorsV1alpha1().Subscriptions(metav1.NamespaceAll).List(metav1.ListOptions{
-		LabelSelector: "operator.ibm.com/opreq-control",
+		LabelSelector: constant.OpreqLabel,
 	})
 	if err != nil {
 		return err

--- a/pkg/controller/operandrequest/operandrequest_controller_test.go
+++ b/pkg/controller/operandrequest/operandrequest_controller_test.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/IBM/operand-deployment-lifecycle-manager/pkg/apis/operator/v1alpha1"
+	constant "github.com/IBM/operand-deployment-lifecycle-manager/pkg/constant"
 	fetch "github.com/IBM/operand-deployment-lifecycle-manager/pkg/controller/common"
 )
 
@@ -462,7 +463,7 @@ func operandRequest(name, namespace, registryName, registryNamespace string) *v1
 // Return Subscription obj
 func sub(name, namespace, csvVersion string) *olmv1alpha1.Subscription {
 	labels := map[string]string{
-		"operator.ibm.com/opreq-control": "true",
+		constant.OpreqLabel: "true",
 	}
 	return &olmv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION

**What this PR does / why we need it**:

Add label to prevent subscription and CR uninstall

ODLM won't delete operators/CRs with label   "operator.ibm.com/opreq-do-not-uninstall: 'true'"

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #457 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
