### PR TITLE
Check the operator generated from the OCP console

### DIFF
--- a/pkg/controller/common/fetch.go
+++ b/pkg/controller/common/fetch.go
@@ -19,6 +19,10 @@ package common
 import (
 	"context"
 
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	olmclient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -88,4 +92,22 @@ func FetchOperandRequest(c client.Client, key types.NamespacedName) (*apiv1alpha
 		}
 	}
 	return req, nil
+}
+
+// FetchSubscription fetch Subscription from name
+func FetchSubscription(olmClient olmclient.Interface, name, namespace string, packageName ...string) (*olmv1alpha1.Subscription, error) {
+	sub, err := olmClient.OperatorsV1alpha1().Subscriptions(namespace).Get(name, metav1.GetOptions{})
+
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if errors.IsNotFound(err) {
+		sub, err = olmClient.OperatorsV1alpha1().Subscriptions(namespace).Get(packageName[0], metav1.GetOptions{})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return sub, nil
 }

--- a/pkg/controller/operandrequest/reconcile_operand.go
+++ b/pkg/controller/operandrequest/reconcile_operand.go
@@ -135,21 +135,8 @@ func (r *ReconcileOperandRequest) reconcileOperand(requestKey types.NamespacedNa
 // getCSV retrieves the ClusterServiceVersion
 func (r *ReconcileOperandRequest) getClusterServiceVersion(subName, packageName, subNamespace string) (*olmv1alpha1.ClusterServiceVersion, error) {
 	klog.V(3).Infof("Looking for the ClusterServiceVersion for Subscription %s in the namespace %s", subName, subNamespace)
-	sub, err := r.olmClient.OperatorsV1alpha1().Subscriptions(subNamespace).Get(subName, metav1.GetOptions{})
 
-	if err != nil && !errors.IsNotFound(err) {
-		klog.Error("Failed to list Subscriptions: ", err)
-		return nil, err
-	}
-
-	if errors.IsNotFound(err) {
-		klog.V(3).Infof("There is no Subscription %s in the namespace %s", subName, subNamespace)
-		sub, err = r.olmClient.OperatorsV1alpha1().Subscriptions(subNamespace).Get(packageName, metav1.GetOptions{})
-		if err != nil && !errors.IsNotFound(err) {
-			klog.Error("Failed to list Subscriptions: ", err)
-			return nil, err
-		}
-	}
+	sub, err := fetch.FetchSubscription(r.olmClient, subName, subNamespace, packageName)
 
 	if errors.IsNotFound(err) {
 		klog.V(3).Infof("There is no Subscription %s or %s in the namespace %s", subName, packageName, subNamespace)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR Implement two main functions:

- Subscriptions (operators) generated from the OCP console use the operator package name as the subscription name.
ODLM will check if the subscription/operator deployed by OCP console, then it won't deploy the same operator in the same namespace.

- If the subscription deployed by OCP console has the label "operator.ibm.com/opreq-control", then ODLM should manage CRs for the operator.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #457 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
