### PR TITLE
Add unit test for controllers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,11 @@ generate-all: manifests kustomize operator-sdk ## Generate bundle manifests, met
 ##@ Test
 
 test: ## Run unit test on prow
-	@echo good
+	@rm -rf olmcrds
+	- make fetch-olm-crds
+	@echo "Running unit tests for the controllers."
+	@go test ./controllers/... -coverprofile cover.out
+	@rm -rf olmcrds
 
 unit-test: generate code-fmt code-vet manifests ## Run unit test
 ifeq (, $(USE_EXISTING_CLUSTER))

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -150,6 +150,7 @@ const (
 	RegistryPending  RegistryPhase = "Pending"
 	RegistryUpdating RegistryPhase = "Updating"
 	RegistryFailed   RegistryPhase = "Failed"
+	RegistryWaiting  RegistryPhase = "Waiting for CatalogSource being ready"
 	RegistryInit     RegistryPhase = "Initialized"
 	RegistryNone     RegistryPhase = ""
 )

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -404,7 +404,7 @@ func (r *OperandRequest) GetRegistryKey(req Request) types.NamespacedName {
 	return types.NamespacedName{Namespace: regNs, Name: regName}
 }
 
-//InitConfigStatus OperandConfig status
+//InitRequestStatus OperandConfig status
 func (r *OperandRequest) InitRequestStatus() bool {
 	isInitialized := true
 	if r.Status.Phase == "" {

--- a/controllers/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo_controller.go
@@ -54,6 +54,11 @@ type OperandBindInfoReconciler struct {
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=*
 
+// Reconcile reads that state of the cluster for a OperandBindInfo object and makes changes based on the state read
+// and what is in the OperandBindInfo.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *OperandBindInfoReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 
@@ -500,6 +505,7 @@ func unique(stringSlice []string) []string {
 	return list
 }
 
+// SetupWithManager adds OperandBindInfo controller to the manager.
 func (r *OperandBindInfoReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1alpha1.OperandBindInfo{}).

--- a/controllers/operandbindinfo_controller_test.go
+++ b/controllers/operandbindinfo_controller_test.go
@@ -18,7 +18,6 @@ package controllers
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -33,7 +32,6 @@ import (
 // +kubebuilder:docs-gen:collapse=Imports
 
 var _ = Describe("OperandBindInfo controller", func() {
-	// Define utility constants for object names and testing timeouts/durations and intervals.
 	const (
 		name              = "ibm-operators-bindinfo"
 		namespace         = "ibm-operators"
@@ -98,7 +96,7 @@ var _ = Describe("OperandBindInfo controller", func() {
 	})
 
 	Context("Sharing the the secret and configmap with public scope", func() {
-		It("Should BindInfo is completed", func() {
+		It("Should Status of the OperandBindInfo be completed", func() {
 
 			By("Prepare init resources for OperandBindInfo controller")
 			Expect(k8sClient.Create(ctx, secret1)).Should(Succeed())
@@ -116,13 +114,15 @@ var _ = Describe("OperandBindInfo controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Checking status of the OperandBindInfo")
-			bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
-			Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 			Eventually(func() operatorv1alpha1.BindInfoPhase {
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 				return bindInfoInstance.Status.Phase
-			}).Should(Equal(operatorv1alpha1.BindInfoCompleted))
+			}, timeout, interval).Should(Equal(operatorv1alpha1.BindInfoCompleted))
 
 			Eventually(func() int {
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 				return len(bindInfoInstance.Status.RequestNamespaces)
 			}, timeout, interval).Should(Equal(1))
 
@@ -141,7 +141,7 @@ var _ = Describe("OperandBindInfo controller", func() {
 	})
 
 	Context("Sharing the secret and configmap with private scope", func() {
-		It("Should BindInfo be initialized", func() {
+		It("Should Status of the OperandBindInfo be initialized", func() {
 
 			By("Prepare init resources for OperandBindInfo controller")
 			Expect(k8sClient.Create(ctx, secret2)).Should(Succeed())
@@ -157,14 +157,15 @@ var _ = Describe("OperandBindInfo controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Checking status of the OperandBindInfo")
-			bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
-			Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 			Eventually(func() operatorv1alpha1.BindInfoPhase {
-				fmt.Println(bindInfoInstance.Status.Phase)
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 				return bindInfoInstance.Status.Phase
 			}).Should(Equal(operatorv1alpha1.BindInfoInit))
 
 			Eventually(func() int {
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 				return len(bindInfoInstance.Status.RequestNamespaces)
 			}, timeout, interval).Should(Equal(0))
 
@@ -174,7 +175,7 @@ var _ = Describe("OperandBindInfo controller", func() {
 	})
 
 	Context("Sharing the not existing secret and configmap", func() {
-		It("Should BindInfo be initialized", func() {
+		It("Should Status of the OperandBindInfo be initialized", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(ctx, secret3Key, &corev1.Secret{})
 				return err != nil && errors.IsNotFound(err)
@@ -185,14 +186,15 @@ var _ = Describe("OperandBindInfo controller", func() {
 			}, timeout, interval).Should(BeTrue())
 
 			By("Checking status of the OperandBindInfo")
-			bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
-			Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 			Eventually(func() operatorv1alpha1.BindInfoPhase {
-				fmt.Println(bindInfoInstance.Status.Phase)
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 				return bindInfoInstance.Status.Phase
 			}).Should(Equal(operatorv1alpha1.BindInfoInit))
 
 			Eventually(func() int {
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
 				return len(bindInfoInstance.Status.RequestNamespaces)
 			}, timeout, interval).Should(Equal(0))
 

--- a/controllers/operandrequest_controller.go
+++ b/controllers/operandrequest_controller.go
@@ -56,6 +56,11 @@ type clusterObjects struct {
 
 // +kubebuilder:rbac:groups=*,resources=*,verbs=*
 
+// Reconcile reads that state of the cluster for a OperandRequest object and makes changes based on the state read
+// and what is in the OperandRequest.Spec
+// Note:
+// The Controller will requeue the Request to be processed again if the returned error is non-nil or
+// Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *OperandRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	// Fetch the OperandRequest instance
 	requestInstance := &operatorv1alpha1.OperandRequest{}
@@ -200,6 +205,7 @@ func getConfigToRequestMapper(mgr manager.Manager) handler.ToRequestsFunc {
 	}
 }
 
+// SetupWithManager adds OperandRequest controller to the manager.
 func (r *OperandRequestReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorv1alpha1.OperandRequest{}).

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -52,8 +52,8 @@ var (
 	testEnv   *envtest.Environment
 	// scheme    = runtime.NewScheme()
 
-	timeout  = time.Second * 10
-	interval = time.Millisecond * 250
+	timeout  = time.Second * 60
+	interval = time.Second * 3
 )
 
 func TestAPIs(t *testing.T) {
@@ -134,7 +134,7 @@ var _ = BeforeSuite(func(done Done) {
 	// End your controllers test logic
 
 	close(done)
-}, 60)
+}, 600)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds basic unit tests for OperandConfig OperandRegistry and OperandRequest controller.
Because ODLM depends on OLM, thus the unit test has limits on checking all the functions, we still need e2e test to cover more testing cases.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
