### PR TITLE
Add displayname for OperandConfig

### DIFF
--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -65,6 +65,7 @@ type CrStatus struct {
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=.metadata.creationTimestamp
 // +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=.status.phase,description="Current Phase"
 // +kubebuilder:printcolumn:name="Created At",type=string,JSONPath=.metadata.creationTimestamp
+// +operator-sdk:gen-csv:customresourcedefinitions.displayName="OperandConfig"
 type OperandConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,6 +129,7 @@ spec:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
     - description: OperandConfig is the Schema for the operandconfigs API
+      displayName: OperandConfig
       kind: OperandConfig
       name: operandconfigs.operator.ibm.com
       specDescriptors:

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -62,6 +62,7 @@ spec:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
     - description: OperandConfig is the Schema for the operandconfigs API
+      displayName: OperandConfig
       kind: OperandConfig
       name: operandconfigs.operator.ibm.com
       specDescriptors:

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.3.0/operand-deployment-lifecycle-manager.v1.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.3.0/operand-deployment-lifecycle-manager.v1.3.0.clusterserviceversion.yaml
@@ -129,6 +129,7 @@ spec:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
     - description: OperandConfig is the Schema for the operandconfigs API
+      displayName: OperandConfig
       kind: OperandConfig
       name: operandconfigs.operator.ibm.com
       specDescriptors:


### PR DESCRIPTION
**What this PR does / why we need it**:


Add display name for the OperandConfig. Otherwise, there is no OperandConfig showing on the operator page.
<img width="1117" alt="Screen Shot 2020-08-18 at 2 34 54 PM" src="https://user-images.githubusercontent.com/33276414/90551888-00844580-e160-11ea-9e06-1dd868dbd614.png">


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
