### PR TITLE
disable leader election to avoid pod restarting

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -236,7 +236,6 @@ spec:
                         - s390x
               containers:
               - args:
-                - --enable-leader-election
                 - -v=2
                 command:
                 - /manager

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -22,4 +22,3 @@ spec:
       - name: manager
         args:
         - "--metrics-addr=127.0.0.1:8080"
-        - "--enable-leader-election"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -44,7 +44,6 @@ spec:
       - command:
         - /manager
         args:
-        - --enable-leader-election
         - -v=2
         image: quay.io/opencloudio/odlm:latest
         name: manager

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.4.0/operand-deployment-lifecycle-manager.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.4.0/operand-deployment-lifecycle-manager.v1.4.0.clusterserviceversion.yaml
@@ -236,7 +236,6 @@ spec:
                         - s390x
               containers:
               - args:
-                - --enable-leader-election
                 - -v=2
                 command:
                 - /manager


### PR DESCRIPTION
Remove flag of `enable-leader-election` from command args in order to disable this function.

@chenzhiwei @DanielXLee @horis233 Please correct me if it is wrong.
