### PR TITLE
Shrink permissions for ODLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,6 @@ check: lint-all ## Check all files lint error
 
 code-dev: ## Run the default dev commands which are the go tidy, fmt, vet then execute the $ make code-gen
 	@echo Running the common required commands for developments purposes
-	- make generate-all
 	- make code-tidy
 	- make code-fmt
 	- make code-vet
@@ -118,7 +117,7 @@ manager: generate code-fmt code-vet ## Build manager binary
 	go build -o bin/manager main.go
 
 run: generate code-fmt code-vet manifests ## Run against the configured Kubernetes cluster in ~/.kube/config
-	OPERATOR_NAMESPACE="" go run ./main.go -v=2
+	OPERATOR_NAMESPACE="ibm-common-services" INSTALL_SCOPE="namespaced" go run ./main.go -v=2
 
 install: manifests kustomize ## Install CRDs into a cluster
 	$(KUSTOMIZE) build config/crd | kubectl apply -f -
@@ -169,6 +168,7 @@ test: ## Run unit test on prow
 	|| curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	@test -d ${ENVTEST_ASSETS_DIR}/crds || make fetch-olm-crds
 	@source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./controllers/... -coverprofile cover.out
+	@rm -rf ${ENVTEST_ASSETS_DIR}
 
 
 unit-test: generate code-fmt code-vet manifests ## Run unit test
@@ -180,8 +180,8 @@ coverage: ## Run code coverage test
 	@test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh \
 	|| curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
 	@test -d ${ENVTEST_ASSETS_DIR}/crds || make fetch-olm-crds
-	@source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR);
-	@common/scripts/codecov.sh ${BUILD_LOCALLY} "controllers"
+	@source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); common/scripts/codecov.sh ${BUILD_LOCALLY} "controllers"
+	@rm -rf ${ENVTEST_ASSETS_DIR}
 
 scorecard: operator-sdk ## Run scorecard test
 	@echo ... Running the scorecard test

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -197,11 +197,20 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - '*'
+          - operator.ibm.com
           resources:
-          - '*'
+          - operandbindinfos
+          - operandconfigs
+          - operandregistries
+          - operandrequests
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: operand-deployment-lifecycle-manager
       deployments:
       - name: operand-deployment-lifecycle-manager
@@ -267,32 +276,11 @@ spec:
       permissions:
       - rules:
         - apiGroups:
-          - ""
+          - '*'
           resources:
-          - configmaps
+          - '*'
           verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps/status
-          verbs:
-          - get
-          - update
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
+          - '*'
         serviceAccountName: operand-deployment-lifecycle-manager
     strategy: deployment
   installModes:
@@ -318,4 +306,5 @@ spec:
   maturity: stable
   provider:
     name: IBM
+  replaces: operand-deployment-lifecycle-manager.v1.3.1
   version: 1.4.0

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,8 +1,8 @@
 resources:
 - role.yaml
 - role_binding.yaml
-- leader_election_role.yaml
-- leader_election_role_binding.yaml
+# - leader_election_role.yaml
+# - leader_election_role_binding.yaml
 # Comment the following 4 lines if you want to disable
 # the auth proxy (https://github.com/brancz/kube-rbac-proxy)
 # which protects your /metrics endpoint.

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,30 @@ metadata:
   creationTimestamp: null
   name: operand-deployment-lifecycle-manager
 rules:
+- verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+  apiGroups:
+    - operator.ibm.com
+  resources:
+    - operandbindinfos
+    - operandconfigs
+    - operandregistries
+    - operandrequests
+
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  creationTimestamp: null
+  name: operand-deployment-lifecycle-manager
+rules:
 - apiGroups:
   - '*'
   resources:

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -10,3 +10,17 @@ subjects:
 - kind: ServiceAccount
   name: operand-deployment-lifecycle-manager
   namespace: system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: operand-deployment-lifecycle-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: operand-deployment-lifecycle-manager
+subjects:
+- kind: ServiceAccount
+  name: operand-deployment-lifecycle-manager
+  namespace: system

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -26,4 +26,13 @@ const (
 
 	//OpreqLabel is the label used to label the subscription/CR managed by ODLM
 	OpreqLabel string = "operator.ibm.com/opreq-control"
+
+	//OpbiNsLabel is the label used to add OperandBindInfo namespace to the secrets/configmaps watched by ODLM
+	OpbiNsLabel string = "operator.ibm.com/watched-by-opbi-with-namespace"
+
+	//OpbiNameLabel is the label used to add OperandBindInfo name to the secrets/configmaps watched by ODLM
+	OpbiNameLabel string = "operator.ibm.com/watched-by-opbi-with-name"
+
+	//OpbiTypeLabel is the label used to label if secrets/configmaps are "original" or "copy"
+	OpbiTypeLabel string = "operator.ibm.com/managedBy-opbi"
 )

--- a/controllers/k8sutil/cache.go
+++ b/controllers/k8sutil/cache.go
@@ -1,0 +1,479 @@
+//
+// Copyright 2020 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package k8sutil
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/rest"
+	toolscache "k8s.io/client-go/tools/cache"
+	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// NewODLMCache implements a customized cache with a for ODLM
+func NewODLMCache(namespace string) cache.NewCacheFunc {
+	return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
+
+		// Get the frequency that informers are resynced
+		var resync time.Duration
+		if opts.Resync != nil {
+			resync = *opts.Resync
+		}
+
+		// Generate informermap to contain the gvks and their informers
+		informerMap, err := buildInformerMap(config, opts, resync)
+		if err != nil {
+			return nil, err
+		}
+
+		opts.Namespace = namespace
+		// Create a default cache for the other resources
+		fallback, err := cache.New(config, opts)
+		if err != nil {
+			klog.Error(err, "Failed to init fallback cache")
+			return nil, err
+		}
+
+		// Return the customized cache
+		return filteredCache{config: config, informerMap: informerMap, fallback: fallback, namespace: "", Scheme: opts.Scheme}, nil
+	}
+}
+
+//buildInformerMap generates informerMap of the specified resource
+func buildInformerMap(config *rest.Config, opts cache.Options, resync time.Duration) (map[schema.GroupVersionKind]toolscache.SharedIndexInformer, error) {
+	// Initialize informerMap
+	informerMap := make(map[schema.GroupVersionKind]toolscache.SharedIndexInformer)
+
+	gvkList := []schema.GroupVersionKind{
+		{Group: "operator.ibm.com", Kind: "OperandRequest", Version: "v1alpha1"},
+		{Group: "operator.ibm.com", Kind: "OperandRegistry", Version: "v1alpha1"},
+		{Group: "operator.ibm.com", Kind: "OperandConfig", Version: "v1alpha1"},
+		{Group: "operator.ibm.com", Kind: "OperandBindInfo", Version: "v1alpha1"},
+	}
+
+	for _, gvk := range gvkList {
+
+		// Create ListerWatcher with the label by NewFilteredListWatchFromClient
+		client, err := getClientForGVK(gvk, config, opts.Scheme)
+		if err != nil {
+			return nil, err
+		}
+
+		// Get the plural type of the kind as resource
+		plural := kindToResource(gvk.Kind)
+		listerWatcher := toolscache.NewFilteredListWatchFromClient(client, plural, opts.Namespace, func(options *metav1.ListOptions) {})
+
+		// Build typed runtime object for informer
+		objType := &unstructured.Unstructured{}
+		objType.GetObjectKind().SetGroupVersionKind(gvk)
+		typed, err := opts.Scheme.New(gvk)
+		if err != nil {
+			return nil, err
+		}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(objType.UnstructuredContent(), typed); err != nil {
+			return nil, err
+		}
+
+		// Create new inforemer with the listerwatcher
+		informer := toolscache.NewSharedIndexInformer(listerWatcher, typed, resync, toolscache.Indexers{toolscache.NamespaceIndex: toolscache.MetaNamespaceIndexFunc})
+		informerMap[gvk] = informer
+		// Build list type for the GVK
+		gvkList := schema.GroupVersionKind{Group: gvk.Group, Version: gvk.Version, Kind: gvk.Kind + "List"}
+		informerMap[gvkList] = informer
+	}
+
+	return informerMap, nil
+}
+
+// filteredCache is the customized cache by the specified label
+type filteredCache struct {
+	config      *rest.Config
+	informerMap map[schema.GroupVersionKind]toolscache.SharedIndexInformer
+	fallback    cache.Cache
+	namespace   string
+	Scheme      *runtime.Scheme
+}
+
+// Get implements Reader
+// If the resource is in the cache, Get function get fetch in from the informer
+// Otherwise, resource will be get by the k8s client
+func (c filteredCache) Get(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+
+	// Get the GVK of the runtime object
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return err
+	}
+
+	if informer, ok := c.informerMap[gvk]; ok {
+		// Looking for object from the cache
+		if err := c.getFromStore(informer, key, obj, gvk); err == nil {
+			// If not found the object from cache, then fetch it from k8s apiserver
+		} else if err := c.getFromClient(ctx, key, obj, gvk); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// Passthrough
+	return c.fallback.Get(ctx, key, obj)
+}
+
+// getFromStore gets the resource from the cache
+func (c filteredCache) getFromStore(informer toolscache.SharedIndexInformer, key client.ObjectKey, obj runtime.Object, gvk schema.GroupVersionKind) error {
+
+	// Different key for cluster scope resource and namespaced resource
+	var keyString string
+	if key.Namespace == "" {
+		keyString = key.Name
+	} else {
+		keyString = key.Namespace + "/" + key.Name
+	}
+
+	item, exists, err := informer.GetStore().GetByKey(keyString)
+	if err != nil {
+		klog.Info("Failed to get item from cache", "error", err)
+		return err
+	}
+	if !exists {
+		return apierrors.NewNotFound(schema.GroupResource{Group: gvk.Group, Resource: gvk.Kind}, key.String())
+	}
+	if _, isObj := item.(runtime.Object); !isObj {
+		// This should never happen
+		return fmt.Errorf("cache contained %T, which is not an Object", item)
+	}
+
+	// deep copy to avoid mutating cache
+	item = item.(runtime.Object).DeepCopyObject()
+
+	// Copy the value of the item in the cache to the returned value
+	objVal := reflect.ValueOf(obj)
+	itemVal := reflect.ValueOf(item)
+	if !objVal.Type().AssignableTo(objVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", itemVal.Type(), objVal.Type())
+	}
+	reflect.Indirect(objVal).Set(reflect.Indirect(itemVal))
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+
+	return nil
+}
+
+// getFromClient gets the resource by the k8s client
+func (c filteredCache) getFromClient(ctx context.Context, key client.ObjectKey, obj runtime.Object, gvk schema.GroupVersionKind) error {
+
+	// Get resource by the kubeClient
+	resource := kindToResource(gvk.Kind)
+
+	client, err := getClientForGVK(gvk, c.config, c.Scheme)
+	if err != nil {
+		return err
+	}
+	result, err := client.
+		Get().
+		Namespace(key.Namespace).
+		Name(key.Name).
+		Resource(resource).
+		VersionedParams(&metav1.GetOptions{}, metav1.ParameterCodec).
+		Do(ctx).
+		Get()
+
+	if apierrors.IsNotFound(err) {
+		return err
+	} else if err != nil {
+		klog.Info("Failed to retrieve resource list", "error", err)
+		return err
+	}
+
+	// Copy the value of the item in the cache to the returned value
+	objVal := reflect.ValueOf(obj)
+	itemVal := reflect.ValueOf(result)
+	if !objVal.Type().AssignableTo(objVal.Type()) {
+		return fmt.Errorf("cache had type %s, but %s was asked for", itemVal.Type(), objVal.Type())
+	}
+	reflect.Indirect(objVal).Set(reflect.Indirect(itemVal))
+	obj.GetObjectKind().SetGroupVersionKind(gvk)
+
+	return nil
+}
+
+// List lists items out of the indexer and writes them to list
+func (c filteredCache) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+	gvk, err := apiutil.GVKForObject(list, c.Scheme)
+	if err != nil {
+		return err
+	}
+	if informer, ok := c.informerMap[gvk]; ok {
+		// Construct filter
+		var objList []interface{}
+
+		listOpts := client.ListOptions{}
+		listOpts.ApplyOptions(opts)
+
+		// Check the labelSelector
+		var labelSel labels.Selector
+		if listOpts.LabelSelector != nil {
+			labelSel = listOpts.LabelSelector
+		}
+
+		if listOpts.FieldSelector != nil {
+			// combining multiple indices, GetIndexers, etc
+			field, val, requiresExact := requiresExactMatch(listOpts.FieldSelector)
+			if !requiresExact {
+				return fmt.Errorf("non-exact field matches are not supported by the cache")
+			}
+			// list all objects by the field selector.  If this is namespaced and we have one, ask for the
+			// namespaced index key.  Otherwise, ask for the non-namespaced variant by using the fake "all namespaces"
+			// namespace.
+			objList, err = informer.GetIndexer().ByIndex(FieldIndexName(field), KeyToNamespacedKey(listOpts.Namespace, val))
+		} else if listOpts.Namespace != "" {
+			objList, err = informer.GetIndexer().ByIndex(toolscache.NamespaceIndex, listOpts.Namespace)
+		} else {
+			objList = informer.GetIndexer().List()
+		}
+		if err != nil {
+			return err
+		}
+
+		// Check namespace and labelSelector
+		runtimeObjList := make([]runtime.Object, 0, len(objList))
+		for _, item := range objList {
+			obj, isObj := item.(runtime.Object)
+			if !isObj {
+				return fmt.Errorf("cache contained %T, which is not an Object", obj)
+			}
+			meta, err := apimeta.Accessor(obj)
+			if err != nil {
+				return err
+			}
+
+			var namespace string
+
+			if c.namespace != "" {
+				if listOpts.Namespace != "" && c.namespace != listOpts.Namespace {
+					return fmt.Errorf("unable to list from namespace : %v because of unknown namespace for the cache", listOpts.Namespace)
+				}
+				namespace = c.namespace
+			} else if listOpts.Namespace != "" {
+				namespace = listOpts.Namespace
+			}
+
+			if namespace != "" && namespace != meta.GetNamespace() {
+				continue
+			}
+
+			if labelSel != nil {
+				lbls := labels.Set(meta.GetLabels())
+				if !labelSel.Matches(lbls) {
+					continue
+				}
+			}
+
+			outObj := obj.DeepCopyObject()
+			outObj.GetObjectKind().SetGroupVersionKind(listToGVK(gvk))
+			runtimeObjList = append(runtimeObjList, outObj)
+		}
+		return apimeta.SetList(list, runtimeObjList)
+	}
+
+	// Passthrough
+	return c.fallback.List(ctx, list, opts...)
+}
+
+// GetInformer fetches or constructs an informer for the given object that corresponds to a single
+// API kind and resource.
+func (c filteredCache) GetInformer(ctx context.Context, obj runtime.Object) (cache.Informer, error) {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	if informer, ok := c.informerMap[gvk]; ok {
+		return informer, nil
+	}
+	// Passthrough
+	return c.fallback.GetInformer(ctx, obj)
+}
+
+// GetInformerForKind is similar to GetInformer, except that it takes a group-version-kind, instead
+// of the underlying object.
+func (c filteredCache) GetInformerForKind(ctx context.Context, gvk schema.GroupVersionKind) (cache.Informer, error) {
+	if informer, ok := c.informerMap[gvk]; ok {
+		return informer, nil
+	}
+	// Passthrough
+	return c.fallback.GetInformerForKind(ctx, gvk)
+}
+
+// Start runs all the informers known to this cache until the given channel is closed.
+// It blocks.
+func (c filteredCache) Start(stopCh <-chan struct{}) error {
+	klog.Info("Start ODLM cache")
+	for _, informer := range c.informerMap {
+		informer := informer
+		go informer.Run(stopCh)
+	}
+	return c.fallback.Start(stopCh)
+}
+
+// WaitForCacheSync waits for all the caches to sync.  Returns false if it could not sync a cache.
+func (c filteredCache) WaitForCacheSync(stop <-chan struct{}) bool {
+	// Wait for informer to sync
+	waiting := true
+	for waiting {
+		select {
+		case <-stop:
+			waiting = false
+		case <-time.After(time.Second):
+			for _, informer := range c.informerMap {
+				waiting = !informer.HasSynced() && waiting
+			}
+		}
+	}
+	// Wait for fallback cache to sync
+	return c.fallback.WaitForCacheSync(stop)
+}
+
+// IndexField adds an indexer to the underlying cache, using extraction function to get
+// value(s) from the given field. The filtered cache doesn't support the index yet.
+func (c filteredCache) IndexField(ctx context.Context, obj runtime.Object, field string, extractValue client.IndexerFunc) error {
+	gvk, err := apiutil.GVKForObject(obj, c.Scheme)
+	if err != nil {
+		return err
+	}
+
+	if informer, ok := c.informerMap[gvk]; ok {
+		return indexByField(informer, field, extractValue)
+	}
+
+	return c.fallback.IndexField(ctx, obj, field, extractValue)
+}
+
+func indexByField(indexer cache.Informer, field string, extractor client.IndexerFunc) error {
+	indexFunc := func(objRaw interface{}) ([]string, error) {
+		// TODO(directxman12): check if this is the correct type?
+		obj, isObj := objRaw.(runtime.Object)
+		if !isObj {
+			return nil, fmt.Errorf("object of type %T is not an Object", objRaw)
+		}
+		meta, err := apimeta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		ns := meta.GetNamespace()
+
+		rawVals := extractor(obj)
+		var vals []string
+		if ns == "" {
+			// if we're not doubling the keys for the namespaced case, just re-use what was returned to us
+			vals = rawVals
+		} else {
+			// if we need to add non-namespaced versions too, double the length
+			vals = make([]string, len(rawVals)*2)
+		}
+		for i, rawVal := range rawVals {
+			// save a namespaced variant, so that we can ask
+			// "what are all the object matching a given index *in a given namespace*"
+			vals[i] = KeyToNamespacedKey(ns, rawVal)
+			if ns != "" {
+				// if we have a namespace, also inject a special index key for listing
+				// regardless of the object namespace
+				vals[i+len(rawVals)] = KeyToNamespacedKey("", rawVal)
+			}
+		}
+
+		return vals, nil
+	}
+
+	return indexer.AddIndexers(toolscache.Indexers{FieldIndexName(field): indexFunc})
+}
+
+// kindToResource converts kind to resource
+func kindToResource(kind string) string {
+	kindToResourceMap := map[string]string{
+		"OperandRequest":  "operandrequests",
+		"OperandRegistry": "operandregistries",
+		"OperandConfig":   "operandconfigs",
+		"OperandBindInfo": "operandbindinfos",
+	}
+	return kindToResourceMap[kind]
+}
+
+// listToGVK converts GVK list to GVK
+func listToGVK(list schema.GroupVersionKind) schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: list.Group, Version: list.Version, Kind: list.Kind[:len(list.Kind)-4]}
+}
+
+// requiresExactMatch checks if the given field selector is of the form `k=v` or `k==v`.
+func requiresExactMatch(sel fields.Selector) (field, val string, required bool) {
+	reqs := sel.Requirements()
+	if len(reqs) != 1 {
+		return "", "", false
+	}
+	req := reqs[0]
+	if req.Operator != selection.Equals && req.Operator != selection.DoubleEquals {
+		return "", "", false
+	}
+	return req.Field, req.Value, true
+}
+
+// FieldIndexName constructs the name of the index over the given field,
+// for use with an indexer.
+func FieldIndexName(field string) string {
+	return "field:" + field
+}
+
+// noNamespaceNamespace is used as the "namespace" when we want to list across all namespaces
+const allNamespacesNamespace = "__all_namespaces"
+
+// KeyToNamespacedKey prefixes the given index key with a namespace
+// for use in field selector indexes.
+func KeyToNamespacedKey(ns string, baseKey string) string {
+	if ns != "" {
+		return ns + "/" + baseKey
+	}
+	return allNamespacesNamespace + "/" + baseKey
+}
+
+func getClientForGVK(gvk schema.GroupVersionKind, config *rest.Config, scheme *runtime.Scheme) (toolscache.Getter, error) {
+	gv := gvk.GroupVersion()
+	cfg := rest.CopyConfig(config)
+	cfg.GroupVersion = &gv
+	cfg.APIPath = "/apis"
+	if cfg.UserAgent == "" {
+		cfg.UserAgent = rest.DefaultKubernetesUserAgent()
+	}
+	if cfg.NegotiatedSerializer == nil {
+		cfg.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: serializer.NewCodecFactory(scheme)}
+	}
+	return rest.RESTClientFor(cfg)
+}

--- a/controllers/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo_controller.go
@@ -53,8 +53,6 @@ type OperandBindInfoReconciler struct {
 	Scheme   *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=*,resources=*,verbs=*
-
 // Reconcile reads that state of the cluster for a OperandBindInfo object and makes changes based on the state read
 // and what is in the OperandBindInfo.Spec
 // Note:
@@ -247,20 +245,7 @@ func (r *OperandBindInfoReconciler) copySecret(sourceName, targetName, sourceNs,
 	if err := r.Create(context.TODO(), secretCopy); err != nil {
 		if errors.IsAlreadyExists(err) {
 			// If already exist, update the Secret
-			existingSecret := &corev1.Secret{}
-			if err := r.Get(context.TODO(), types.NamespacedName{
-				Name:      targetName,
-				Namespace: targetNs,
-			}, existingSecret); err != nil {
-				klog.Errorf("failed to get the existing secret %s in the namespace %s: %s", sourceName, targetNs, err)
-				return false, err
-			}
-			if reflect.DeepEqual(existingSecret.Data, secretCopy.Data) && reflect.DeepEqual(existingSecret.StringData, secretCopy.StringData) {
-				klog.V(3).Infof("There is no change in Secret %s in the namespace %s. Skip the update", targetName, targetNs)
-				return false, nil
-			}
-			existingSecret.Data, existingSecret.StringData = secretCopy.Data, secretCopy.StringData
-			if err := r.Update(context.TODO(), existingSecret); err != nil {
+			if err := r.Update(context.TODO(), secretCopy); err != nil {
 				klog.Errorf("failed to update secret %s in the namespace %s: %s", targetName, targetNs, err)
 				return false, err
 			}
@@ -334,20 +319,7 @@ func (r *OperandBindInfoReconciler) copyConfigmap(sourceName, targetName, source
 	if err := r.Create(context.TODO(), cmCopy); err != nil {
 		if errors.IsAlreadyExists(err) {
 			// If already exist, update the ConfigMap
-			existingCm := &corev1.ConfigMap{}
-			if err := r.Get(context.TODO(), types.NamespacedName{
-				Name:      targetName,
-				Namespace: targetNs,
-			}, existingCm); err != nil {
-				klog.Errorf("failed to get the existing ConfigMap %s in the namespace %s: %s", sourceName, targetNs, err)
-				return false, err
-			}
-			if reflect.DeepEqual(existingCm.Data, cmCopy.Data) && reflect.DeepEqual(existingCm.BinaryData, cmCopy.BinaryData) {
-				klog.V(3).Infof("There is no change in ConfigMap %s in the namespace %s. Skip the update", targetName, targetNs)
-				return false, nil
-			}
-			existingCm.Data, existingCm.BinaryData = cmCopy.Data, cmCopy.BinaryData
-			if err := r.Update(context.TODO(), existingCm); err != nil {
+			if err := r.Update(context.TODO(), cmCopy); err != nil {
 				klog.Errorf("failed to update ConfigMap %s in the namespace %s: %s", sourceName, targetNs, err)
 				return false, err
 			}

--- a/controllers/operandconfig_controller.go
+++ b/controllers/operandconfig_controller.go
@@ -52,8 +52,6 @@ type OperandConfigReconciler struct {
 	Scheme   *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=*,resources=*,verbs=*
-
 // Reconcile reads that state of the cluster for a OperandConfig object and makes changes based on the state read
 // and what is in the OperandConfig.Spec
 // Note:

--- a/controllers/operandregistry_controller.go
+++ b/controllers/operandregistry_controller.go
@@ -46,8 +46,6 @@ type OperandRegistryReconciler struct {
 	Scheme   *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=*,resources=*,verbs=*
-
 // Reconcile reads that state of the cluster for a OperandRegistry object and makes changes based on the state read
 // and what is in the OperandRegistry.Spec
 // Note:

--- a/controllers/operandrequest_controller.go
+++ b/controllers/operandrequest_controller.go
@@ -55,8 +55,6 @@ type clusterObjects struct {
 	subscription  *olmv1alpha1.Subscription
 }
 
-// +kubebuilder:rbac:groups=*,resources=*,verbs=*
-
 // Reconcile reads that state of the cluster for a OperandRequest object and makes changes based on the state read
 // and what is in the OperandRequest.Spec
 // Note:

--- a/controllers/reconcile_operand.go
+++ b/controllers/reconcile_operand.go
@@ -608,7 +608,7 @@ func (r *OperandRequestReconciler) deleteCustomResource(unstruct unstructured.Un
 }
 
 func (r *OperandRequestReconciler) checkCustomResource(requestInstance *operatorv1alpha1.OperandRequest) error {
-	klog.V(2).Infof("checking the custom resource should be deleted from OperandRequest %s/%s", requestInstance.Namespace, requestInstance.Name)
+	klog.V(3).Infof("checking the custom resource should be deleted from OperandRequest %s/%s", requestInstance.Namespace, requestInstance.Name)
 
 	members := requestInstance.Status.Members
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -137,7 +137,7 @@ var _ = BeforeSuite(func(done Done) {
 	// End your controllers test logic
 
 	close(done)
-}, 600)
+}, 60)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -137,7 +137,7 @@ var _ = BeforeSuite(func(done Done) {
 	// End your controllers test logic
 
 	close(done)
-}, 60)
+}, 600)
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/controllers/util/get_env.go
+++ b/controllers/util/get_env.go
@@ -28,3 +28,12 @@ func GetOperatorNamespace() string {
 	}
 	return ns
 }
+
+// GetInstallScope returns the scope of the installation
+func GetInstallScope() string {
+	ns, found := os.LookupEnv("INSTALL_SCOPE")
+	if !found {
+		return "cluster"
+	}
+	return ns
+}

--- a/controllers/util/get_env_test.go
+++ b/controllers/util/get_env_test.go
@@ -34,5 +34,14 @@ var _ = Describe("Get environmental variables", func() {
 			ns := GetOperatorNamespace()
 			Expect(ns).Should(Equal(testNs))
 		})
+
+		It("Should get INSTALL_SCOPE", func() {
+			scope := "namespaced"
+			err := os.Setenv("INSTALL_SCOPE", scope)
+			Expect(err).NotTo(HaveOccurred())
+
+			ns := GetInstallScope()
+			Expect(ns).Should(Equal(scope))
+		})
 	})
 })

--- a/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.4.0/operand-deployment-lifecycle-manager.v1.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/operand-deployment-lifecycle-manager/1.4.0/operand-deployment-lifecycle-manager.v1.4.0.clusterserviceversion.yaml
@@ -197,11 +197,20 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
-          - '*'
+          - operator.ibm.com
           resources:
-          - '*'
+          - operandbindinfos
+          - operandconfigs
+          - operandregistries
+          - operandrequests
           verbs:
-          - '*'
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
         serviceAccountName: operand-deployment-lifecycle-manager
       deployments:
       - name: operand-deployment-lifecycle-manager
@@ -267,32 +276,11 @@ spec:
       permissions:
       - rules:
         - apiGroups:
-          - ""
+          - '*'
           resources:
-          - configmaps
+          - '*'
           verbs:
-          - get
-          - list
-          - watch
-          - create
-          - update
-          - patch
-          - delete
-        - apiGroups:
-          - ""
-          resources:
-          - configmaps/status
-          verbs:
-          - get
-          - update
-          - patch
-        - apiGroups:
-          - ""
-          resources:
-          - events
-          verbs:
-          - create
-          - patch
+          - '*'
         serviceAccountName: operand-deployment-lifecycle-manager
     strategy: deployment
   installModes:
@@ -318,4 +306,5 @@ spec:
   maturity: stable
   provider:
     name: IBM
+  replaces: operand-deployment-lifecycle-manager.v1.3.1
   version: 1.4.0

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/IBM/operand-deployment-lifecycle-manager
 go 1.13
 
 require (
+	github.com/IBM/controller-filtered-cache v0.1.2
 	github.com/coreos/etcd-operator v0.9.4
 	github.com/deckarep/golang-set v1.7.1
 	github.com/onsi/ginkgo v1.12.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM/operand-deployment-lifecycle-manager
 go 1.13
 
 require (
-	github.com/IBM/controller-filtered-cache v0.1.2
+	github.com/IBM/controller-filtered-cache v0.2.0
 	github.com/coreos/etcd-operator v0.9.4
 	github.com/deckarep/golang-set v1.7.1
 	github.com/onsi/ginkgo v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/IBM/controller-filtered-cache v0.1.2 h1:ImZhV3Z4Jp5X9m7YWTraZhfE+T0JWtoUr2cpFYKNEtQ=
-github.com/IBM/controller-filtered-cache v0.1.2/go.mod h1:LdIiGoXOiAVcKWzsn+tYAYMp8biM0VbMJ831fAoS0wQ=
+github.com/IBM/controller-filtered-cache v0.2.0 h1:8fsaX9DEg2u1QhdHV/AkS2Pdm1EBjXS/pjR/5Sb2oFw=
+github.com/IBM/controller-filtered-cache v0.2.0/go.mod h1:x6kTgtNFa6YL5mqVUh14RMoW89ycqP9/6ZjgzkBP808=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/IBM/controller-filtered-cache v0.1.2 h1:ImZhV3Z4Jp5X9m7YWTraZhfE+T0JWtoUr2cpFYKNEtQ=
+github.com/IBM/controller-filtered-cache v0.1.2/go.mod h1:LdIiGoXOiAVcKWzsn+tYAYMp8biM0VbMJ831fAoS0wQ=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
@@ -142,6 +144,8 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-openapi/validate v0.19.5/go.mod h1:8DJv2CVJQ6kGNpFW6eV9N3JviE1C85nY1c2z52x1Gk4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobuffalo/flect v0.1.5/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
+github.com/gobuffalo/flect v0.2.0 h1:EWCvMGGxOjsgwlWaP+f4+Hh6yrrte7JeFL2S6b+0hdM=
 github.com/gobuffalo/flect v0.2.0/go.mod h1:W3K3X9ksuZfir8f/LrfVtWmCDQFfayuylOJ7sz/Fj80=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=


### PR DESCRIPTION
**What this PR does / why we need it**:

1. Shrink permissions for ODLM to make it can be deployed in one namespace with few cluster permission.
2. If “INSTALL_SCOPE” is “namespaced”, then create the special cache for ODLM: It will list and watch ODLM CRs from the cluster but only list and watch resource for the namespace of the ODLM operator.
3. Else, it will use a filtered cache to list and watch resource from the cluster scope with a filter to reduce the memory usage.
 
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
