### PR TITLE
update warning message when service can't be found in OperandConfig

### DIFF
--- a/controllers/operandrequest_controller.go
+++ b/controllers/operandrequest_controller.go
@@ -341,7 +341,7 @@ func (r *OperandRequestReconciler) updateOperandRequestStatus(newRequestInstance
 		}
 		existingRequestInstance.Status = *newStatus
 		if err := r.Status().Update(context.TODO(), existingRequestInstance); err != nil {
-			return false, err
+			return false, nil
 		}
 		return true, nil
 	})

--- a/controllers/reconcile_operand.go
+++ b/controllers/reconcile_operand.go
@@ -81,7 +81,7 @@ func (r *OperandRequestReconciler) reconcileOperand(requestKey types.NamespacedN
 				// Check the requested Service Config if exist in specific OperandConfig
 				opdConfig = configInstance.GetService(operand.Name)
 				if opdConfig == nil {
-					klog.Warningf("Cannot find %s in the OperandConfig instance %s in the namespace %s ", operand.Name, req.Registry, req.RegistryNamespace)
+					klog.V(2).Infof("There is no service: %s from the OperandConfig instance: %s/%s, Skip creating CR for it", operand.Name, req.RegistryNamespace, req.Registry)
 					continue
 				}
 			}

--- a/controllers/reconcile_operand.go
+++ b/controllers/reconcile_operand.go
@@ -75,17 +75,6 @@ func (r *OperandRequestReconciler) reconcileOperand(requestKey types.NamespacedN
 		}
 		for _, operand := range req.Operands {
 
-			var opdConfig *operatorv1alpha1.ConfigService
-
-			if operand.Kind == "" {
-				// Check the requested Service Config if exist in specific OperandConfig
-				opdConfig = configInstance.GetService(operand.Name)
-				if opdConfig == nil {
-					klog.V(2).Infof("There is no service: %s from the OperandConfig instance: %s/%s, Skip creating CR for it", operand.Name, req.RegistryNamespace, req.Registry)
-					continue
-				}
-			}
-
 			opdRegistry := registryInstance.GetOperator(operand.Name)
 			if opdRegistry == nil {
 				klog.Warningf("Cannot find %s in the OperandRegistry instance %s in the namespace %s ", operand.Name, req.Registry, req.RegistryNamespace)
@@ -144,6 +133,12 @@ func (r *OperandRequestReconciler) reconcileOperand(requestKey types.NamespacedN
 
 			// Merge and Generate CR
 			if operand.Kind == "" {
+				// Check the requested Service Config if exist in specific OperandConfig
+				opdConfig := configInstance.GetService(operand.Name)
+				if opdConfig == nil {
+					klog.V(2).Infof("There is no service: %s from the OperandConfig instance: %s/%s, Skip creating CR for it", operand.Name, req.RegistryNamespace, req.Registry)
+					continue
+				}
 				err = r.reconcileCRwithConfig(opdConfig, opdRegistry.Namespace, csv)
 			} else {
 				err = r.reconcileCRwithRequest(requestInstance, operand, requestKey, csv)


### PR DESCRIPTION
**What this PR does / why we need it**:
update warning message when service can't be found in OperandConfig
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #546 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
