### PR TITLE
remove namespace from nss when there is no operandrequest in that ns

### DIFF
--- a/controllers/operandrequest_controller.go
+++ b/controllers/operandrequest_controller.go
@@ -107,6 +107,12 @@ func (r *OperandRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 			return ctrl.Result{}, err
 		}
 
+		// Check and remove namespaceMember from NamespaceScope CR
+		if err := r.RemoveNamespaceMemberFromNamespaceScope(req.NamespacedName); err != nil {
+			klog.Errorf("failed to remove NamespaceMember %s from NamespaceScope: %v", req.Namespace, err)
+			return ctrl.Result{}, err
+		}
+
 		// Update finalizer to allow delete CR
 		removed := requestInstance.RemoveFinalizer()
 		if removed {
@@ -120,7 +126,7 @@ func (r *OperandRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	}
 
 	// Update NamespaceScope CR if it exist
-	if err := r.UpdateNamespaceScope(req.NamespacedName); err != nil {
+	if err := r.AddNamespaceMemberIntoNamespaceScope(req.NamespacedName); err != nil {
 		klog.Errorf("failed to add NamespaceMember %s to NamespaceScope: %v", req.Namespace, err)
 		return ctrl.Result{}, err
 	}
@@ -148,7 +154,15 @@ func (r *OperandRequestReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 	return ctrl.Result{RequeueAfter: 30 * time.Minute}, nil
 }
 
-func (r *OperandRequestReconciler) UpdateNamespaceScope(namespacedName types.NamespacedName) error {
+func (r *OperandRequestReconciler) AddNamespaceMemberIntoNamespaceScope(namespacedName types.NamespacedName) error {
+	return r.UpdateNamespaceScope(namespacedName, false)
+}
+
+func (r *OperandRequestReconciler) RemoveNamespaceMemberFromNamespaceScope(namespacedName types.NamespacedName) error {
+	return r.UpdateNamespaceScope(namespacedName, true)
+}
+
+func (r *OperandRequestReconciler) UpdateNamespaceScope(namespacedName types.NamespacedName, delete bool) error {
 	dc := discovery.NewDiscoveryClientForConfigOrDie(r.Config)
 	if exist, err := util.ResourceExists(dc, "operator.ibm.com/v1", "NamespaceScope"); err != nil {
 		klog.Errorf("check resource NamespaceScope exist failed: %v", err)
@@ -182,14 +196,10 @@ func (r *OperandRequestReconciler) UpdateNamespaceScope(namespacedName types.Nam
 		nsSet.Add(operatorNs)
 	}
 
-	for _, existNs := range nsScope.Spec.NamespaceMembers {
-		if existNs == "" {
+	for _, opreq := range opreqList.Items {
+		if delete && opreq.Namespace == namespacedName.Namespace && opreq.Name == namespacedName.Name {
 			continue
 		}
-		nsSet.Add(existNs)
-	}
-
-	for _, opreq := range opreqList.Items {
 		nsSet.Add(opreq.Namespace)
 	}
 


### PR DESCRIPTION

**What this PR does / why we need it**:

remove namespace from nss when there is no operandrequest in that namespace

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
