### PR TITLE
remove crds from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.dylib
 bin
 testbin
-crds
 
 # Test binary, build with `go test -c`
 *.test


### PR DESCRIPTION
Remove `crds` from `.gitignore` file to avoid travis test failed in case bundle.
