### PR TITLE
operandconfig status update

### DIFF
--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -107,6 +107,11 @@ func (r *Reconciler) updateConfigOperatorsStatus(instance *operatorv1alpha1.Oper
 			continue
 		}
 
+		// Check if the operator is request in the OperandRegistry
+		if !checkRegistryStatus(op.Name, registryInstance) {
+			continue
+		}
+
 		// Looking for the CSV
 		namespace := fetch.GetOperatorNamespace(op.InstallMode, op.Namespace)
 		sub, err := fetch.FetchSubscription(r.Client, op.Name, namespace, op.PackageName)
@@ -216,6 +221,16 @@ func (r *Reconciler) updateConfigOperatorsStatus(instance *operatorv1alpha1.Oper
 	}
 
 	return nil
+}
+
+func checkRegistryStatus(opName string, registryInstance *operatorv1alpha1.OperandRegistry) bool {
+	status := registryInstance.Status.OperatorsStatus
+	for opRegistryName := range status {
+		if opName == opRegistryName {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Reconciler) getRequestToConfigMapper() handler.ToRequestsFunc {


### PR DESCRIPTION
**What this PR does / why we need it**:

When updating the status of the OperandConfig, ODLM will check the status of OperandRegistry to check if the operator has been deployed.

Only if the operator is deployed, ODLM will update the status of OperandConfig for the CRs from that operator. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
