### PR TITLE
switch 1.5 to v3 channel

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -348,5 +348,4 @@ spec:
   maturity: stable
   provider:
     name: IBM
-  replaces: operand-deployment-lifecycle-manager.v1.4.1
   version: 1.5.0

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -123,5 +123,4 @@ spec:
   maturity: stable
   provider:
     name: IBM
-  replaces: operand-deployment-lifecycle-manager.v1.4.1
   version: 0.0.0


### PR DESCRIPTION
1. Remove the `replace` section as it is the origin of v3 channel.

2. Keep `olm.skipRange: `'>=1.2.0 <1.5.0'` as it supports upgrading from the version smaller than `1.5.0`