### PR TITLE
feat: Support `protected` prefix in bindinfo.

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller_test.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller_test.go
@@ -55,11 +55,13 @@ var _ = Describe("OperandBindInfo controller", func() {
 		secret1               *corev1.Secret
 		secret2               *corev1.Secret
 		secret3               *corev1.Secret
+		secret4               *corev1.Secret
 		configmap1            *corev1.ConfigMap
 		configmap2            *corev1.ConfigMap
 		configmap3            *corev1.ConfigMap
-		secret3Key            types.NamespacedName
-		cm3Key                types.NamespacedName
+		configmap4            *corev1.ConfigMap
+		secret4Key            types.NamespacedName
+		cm4Key                types.NamespacedName
 	)
 
 	BeforeEach(func() {
@@ -75,12 +77,14 @@ var _ = Describe("OperandBindInfo controller", func() {
 
 		secret1 = testutil.SecretObj("secret1", namespaceName)
 		secret2 = testutil.SecretObj("secret2", namespaceName)
-		secret3 = testutil.SecretObj("secret3", requestNamespaceName)
+		secret3 = testutil.SecretObj("secret3", namespaceName)
+		secret4 = testutil.SecretObj("secret4", requestNamespaceName)
 		configmap1 = testutil.ConfigmapObj("cm1", namespaceName)
 		configmap2 = testutil.ConfigmapObj("cm2", namespaceName)
-		configmap3 = testutil.ConfigmapObj("cm3", requestNamespaceName)
-		secret3Key = types.NamespacedName{Name: "secret3", Namespace: requestNamespaceName}
-		cm3Key = types.NamespacedName{Name: "cm3", Namespace: requestNamespaceName}
+		configmap3 = testutil.ConfigmapObj("cm3", namespaceName)
+		configmap4 = testutil.ConfigmapObj("cm4", requestNamespaceName)
+		secret4Key = types.NamespacedName{Name: "secret4", Namespace: requestNamespaceName}
+		cm4Key = types.NamespacedName{Name: "cm4", Namespace: requestNamespaceName}
 
 		Expect(k8sClient.Create(ctx, testutil.NamespaceObj(namespaceName))).Should(Succeed())
 		Expect(k8sClient.Create(ctx, testutil.NamespaceObj(registryNamespaceName))).Should(Succeed())
@@ -108,22 +112,48 @@ var _ = Describe("OperandBindInfo controller", func() {
 			By("Prepare init resources for OperandBindInfo controller")
 			Expect(k8sClient.Create(ctx, secret1)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, secret2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, secret3)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, configmap1)).Should(Succeed())
 			Expect(k8sClient.Create(ctx, configmap2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, configmap3)).Should(Succeed())
 
 			By("Check if the public secret and configmap are shared")
 			Eventually(func() []byte {
-				secret3 := &corev1.Secret{}
-				err := k8sClient.Get(ctx, secret3Key, secret3)
+				secret4 := &corev1.Secret{}
+				err := k8sClient.Get(ctx, secret4Key, secret4)
 				if err != nil {
 					return []byte("")
 				}
-				return secret3.Data["test"]
+				return secret4.Data["test"]
 			}, timeout, interval).Should(Equal([]byte("secret1")))
 			Eventually(func() bool {
-				cm3 := &corev1.ConfigMap{}
-				err := k8sClient.Get(ctx, cm3Key, cm3)
-				return err == nil && cm3.Data["test"] == "cm1"
+				cm4 := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, cm4Key, cm4)
+				return err == nil && cm4.Data["test"] == "cm1"
+			}, timeout, interval).Should(BeTrue())
+
+			By("Check if the private secret and configmap are shared")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-secret2", Namespace: requestNamespaceName}, &corev1.Secret{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-cm2", Namespace: requestNamespaceName}, &corev1.ConfigMap{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Check if the protected secret and configmap are shared")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-secret3", Namespace: requestNamespaceName}, &corev1.Secret{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-cm3", Namespace: requestNamespaceName}, &corev1.ConfigMap{})
+				return errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
 			By("Check status of the OperandBindInfo")
@@ -144,11 +174,99 @@ var _ = Describe("OperandBindInfo controller", func() {
 
 			By("Check if the public secret and configmap are deleted")
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, secret3Key, &corev1.Secret{})
+				err := k8sClient.Get(ctx, secret4Key, &corev1.Secret{})
 				return err != nil && errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, cm3Key, &corev1.ConfigMap{})
+				err := k8sClient.Get(ctx, cm4Key, &corev1.ConfigMap{})
+				return err != nil && errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+		})
+	})
+
+	Context("Sharing the the secret and configmap with protected scope", func() {
+		It("Should Status of the OperandBindInfo be completed", func() {
+
+			request = testutil.OperandRequestObjWithProtected(registryName, registryNamespaceName, requestName, requestNamespaceName)
+
+			By("By updating a OperandRequest to trigger BindInfo controller")
+			Expect(k8sClient.Delete(ctx, request)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, request)).Should(Succeed())
+
+			By("Prepare init resources for OperandBindInfo controller")
+			Expect(k8sClient.Create(ctx, secret1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, secret2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, secret3)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, configmap1)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, configmap2)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, configmap3)).Should(Succeed())
+
+			By("Check if the public secret and configmap are shared")
+			Eventually(func() []byte {
+				secret4 := &corev1.Secret{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-secret1", Namespace: requestNamespaceName}, secret4)
+				if err != nil {
+					return []byte("")
+				}
+				return secret4.Data["test"]
+			}, timeout, interval).Should(Equal([]byte("secret1")))
+			Eventually(func() bool {
+				cm4 := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-cm1", Namespace: requestNamespaceName}, cm4)
+				return err == nil && cm4.Data["test"] == "cm1"
+			}, timeout, interval).Should(BeTrue())
+
+			By("Check if the private secret and configmap are shared")
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-secret2", Namespace: requestNamespaceName}, &corev1.Secret{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: name + "-cm2", Namespace: requestNamespaceName}, &corev1.ConfigMap{})
+				return errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+
+			By("Check if the protected secret and configmap are shared")
+
+			Eventually(func() []byte {
+				secret5 := &corev1.Secret{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "secret5", Namespace: requestNamespaceName}, secret5)
+				if err != nil {
+					return []byte("")
+				}
+				return secret5.Data["test"]
+			}, timeout, interval).Should(Equal([]byte("secret3")))
+			Eventually(func() bool {
+				cm5 := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "cm5", Namespace: requestNamespaceName}, cm5)
+				return err == nil && cm5.Data["test"] == "cm3"
+			}, timeout, interval).Should(BeTrue())
+
+			By("Check status of the OperandBindInfo")
+			Eventually(func() operatorv1alpha1.BindInfoPhase {
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
+				return bindInfoInstance.Status.Phase
+			}, timeout, interval).Should(Equal(operatorv1alpha1.BindInfoCompleted))
+
+			Eventually(func() int {
+				bindInfoInstance := &operatorv1alpha1.OperandBindInfo{}
+				Expect(k8sClient.Get(ctx, bindInfoKey, bindInfoInstance)).Should(Succeed())
+				return len(bindInfoInstance.Status.RequestNamespaces)
+			}, timeout, interval).Should(Equal(1))
+
+			By("Deleting the OperandBindInfo")
+			Expect(k8sClient.Delete(ctx, bindInfo)).Should(Succeed())
+
+			By("Check if the protected secret and configmap are deleted")
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "secret5", Namespace: requestNamespaceName}, &corev1.Secret{})
+				return err != nil && errors.IsNotFound(err)
+			}, timeout, interval).Should(BeTrue())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{Name: "cm5", Namespace: requestNamespaceName}, &corev1.ConfigMap{})
 				return err != nil && errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
@@ -162,11 +280,11 @@ var _ = Describe("OperandBindInfo controller", func() {
 			Expect(k8sClient.Create(ctx, configmap2)).Should(Succeed())
 
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, secret3Key, &corev1.Secret{})
+				err := k8sClient.Get(ctx, secret4Key, &corev1.Secret{})
 				return err != nil && errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, cm3Key, &corev1.ConfigMap{})
+				err := k8sClient.Get(ctx, cm4Key, &corev1.ConfigMap{})
 				return err != nil && errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
@@ -191,11 +309,11 @@ var _ = Describe("OperandBindInfo controller", func() {
 	Context("Sharing the not existing secret and configmap", func() {
 		It("Should Status of the OperandBindInfo be initialized", func() {
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, secret3Key, &corev1.Secret{})
+				err := k8sClient.Get(ctx, secret4Key, &corev1.Secret{})
 				return err != nil && errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, cm3Key, &corev1.ConfigMap{})
+				err := k8sClient.Get(ctx, cm4Key, &corev1.ConfigMap{})
 				return err != nil && errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 
@@ -221,21 +339,21 @@ var _ = Describe("OperandBindInfo controller", func() {
 		It("Should Status of the OperandBindInfo be completed", func() {
 
 			By("Prepare init resources for OperandBindInfo controller")
-			Expect(k8sClient.Create(ctx, secret3)).Should(Succeed())
-			Expect(k8sClient.Create(ctx, configmap3)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, secret4)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, configmap4)).Should(Succeed())
 
 			Eventually(func() []byte {
-				secret3 := &corev1.Secret{}
-				err := k8sClient.Get(ctx, secret3Key, secret3)
+				secret4 := &corev1.Secret{}
+				err := k8sClient.Get(ctx, secret4Key, secret4)
 				if err != nil {
 					return []byte("")
 				}
-				return secret3.Data["test"]
-			}, timeout, interval).Should(Equal([]byte("secret3")))
+				return secret4.Data["test"]
+			}, timeout, interval).Should(Equal([]byte("secret4")))
 			Eventually(func() bool {
-				cm3 := &corev1.ConfigMap{}
-				err := k8sClient.Get(ctx, cm3Key, cm3)
-				return err == nil && cm3.Data["test"] == "cm3"
+				cm4 := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, cm4Key, cm4)
+				return err == nil && cm4.Data["test"] == "cm4"
 			}, timeout, interval).Should(BeTrue())
 
 			Expect(k8sClient.Create(ctx, secret1)).Should(Succeed())
@@ -243,17 +361,17 @@ var _ = Describe("OperandBindInfo controller", func() {
 
 			By("Check if the public secret and configmap are shared")
 			Eventually(func() []byte {
-				secret3 := &corev1.Secret{}
-				err := k8sClient.Get(ctx, secret3Key, secret3)
+				secret4 := &corev1.Secret{}
+				err := k8sClient.Get(ctx, secret4Key, secret4)
 				if err != nil {
 					return []byte("")
 				}
-				return secret3.Data["test"]
+				return secret4.Data["test"]
 			}, timeout, interval).Should(Equal([]byte("secret1")))
 			Eventually(func() bool {
-				cm3 := &corev1.ConfigMap{}
-				err := k8sClient.Get(ctx, cm3Key, cm3)
-				return err == nil && cm3.Data["test"] == "cm1"
+				cm4 := &corev1.ConfigMap{}
+				err := k8sClient.Get(ctx, cm4Key, cm4)
+				return err == nil && cm4.Data["test"] == "cm1"
 			}, timeout, interval).Should(BeTrue())
 
 			By("Check status of the OperandBindInfo")

--- a/controllers/testutil/test_util.go
+++ b/controllers/testutil/test_util.go
@@ -123,8 +123,43 @@ func OperandRequestObj(registryName, registryNamespace, requestName, requestName
 							Name: "jenkins",
 							Bindings: map[string]apiv1alpha1.SecretConfigmap{
 								"public": {
-									Secret:    "secret3",
-									Configmap: "cm3",
+									Secret:    "secret4",
+									Configmap: "cm4",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// OperandRequestObjWithProtected returns OperandRequest obj
+func OperandRequestObjWithProtected(registryName, registryNamespace, requestName, requestNamespace string) *apiv1alpha1.OperandRequest {
+	return &apiv1alpha1.OperandRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      requestName,
+			Namespace: requestNamespace,
+			Labels: map[string]string{
+				registryNamespace + "." + registryName + "/registry": "true",
+			},
+		},
+		Spec: apiv1alpha1.OperandRequestSpec{
+			Requests: []apiv1alpha1.Request{
+				{
+					Registry:          registryName,
+					RegistryNamespace: registryNamespace,
+					Operands: []apiv1alpha1.Operand{
+						{
+							Name: "etcd",
+						},
+						{
+							Name: "jenkins",
+							Bindings: map[string]apiv1alpha1.SecretConfigmap{
+								"protected": {
+									Secret:    "secret5",
+									Configmap: "cm5",
 								},
 							},
 						},
@@ -154,6 +189,10 @@ func OperandBindInfoObj(name, namespace, registryName, registryNamespace string)
 				"private": {
 					Secret:    "secret2",
 					Configmap: "cm2",
+				},
+				"protected": {
+					Secret:    "secret3",
+					Configmap: "cm3",
 				},
 			},
 		},

--- a/docs/design/operand-deployment-lifecycle-manager.md
+++ b/docs/design/operand-deployment-lifecycle-manager.md
@@ -218,7 +218,7 @@ Fields in this CR are described below.
 3. The `operand` should be the the individual operator name.
 4. The `registry` section must match the name in the OperandRegistry CR in the current namespace.
 5. `description` is used to add a detailed description of a service.
-6. The `bindings` section is used to specify information about the access/configuration data that is to be shared. If the key of the bindings map is prefixed with public, it means the secret and/or configmap can be shared with the requester in the other namespace. If the key of the bindings map is prefixed with private, it means the secret and/or configmap can only be shared within its own namespace.
+6. The `bindings` section is used to specify information about the access/configuration data that is to be shared. If the key of the bindings map is prefixed with public, it means the secret and/or configmap can be shared with the requester in the other namespace. If the key of the bindings map is prefixed with private, it means the secret and/or configmap can only be shared within its own namespace. If the key of the bindings map is prefixed with protected, it means the secret and/or configmap can only be shared if it is explicitly declared in the OperandRequest.
 7. The `secret` field names an existing secret, if any, that has been created and holds information that is to be shared with the requester.
 8. The `configmap` field identifies a configmap object, if any, that should be shared with the requester
 


### PR DESCRIPTION
If the key of the bindings map is prefixed with protected, it means the secret and/or configmap can only be shared if it is explicitly declared in the OperandRequest.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
