### PR TITLE
handle that not found operator in operandregistry

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -141,12 +141,13 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reconcileErr er
 		return ctrl.Result{}, nil
 	}
 	// Get the operand namespace
-	operandNamespace := registryInstance.GetOperator(bindInfoInstance.Spec.Operand).Namespace
-	if operandNamespace == "" {
+	operandOperator := registryInstance.GetOperator(bindInfoInstance.Spec.Operand)
+	if operandOperator == nil {
 		klog.Errorf("failed to find operator %s in the OperandRegistry %s", bindInfoInstance.Spec.Operand, registryInstance.Name)
 		r.Recorder.Eventf(bindInfoInstance, corev1.EventTypeWarning, "NotFound", "NotFound operator %s in the OperandRegistry %s", bindInfoInstance.Spec.Operand, registryInstance.Name)
 		return ctrl.Result{}, nil
 	}
+	operandNamespace := operandOperator.Namespace
 
 	// If Secret or ConfigMap not found, reconcile will requeue after 1 min
 	var requeue bool


### PR DESCRIPTION
should check whether the operator is found before we get its namespace.

When pick the change in `release-1.4` after this one is merged.