### PR TITLE
fetch ODLM_SCOPE and cache ODLM CRs

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -265,7 +265,7 @@ spec:
                 app.kubernetes.io/instance: operand-deployment-lifecycle-manager
                 app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
                 app.kubernetes.io/name: operand-deployment-lifecycle-manager
-                intent: projected
+                intent: projected-odlm
                 name: operand-deployment-lifecycle-manager
             spec:
               affinity:

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -293,7 +293,7 @@ spec:
                 - name: WATCH_NAMESPACE
                   valueFrom:
                     configMapKeyRef:
-                      name: namespace-scope
+                      name: odlm-scope
                       key: namespaces
                 image: quay.io/opencloudio/odlm:latest
                 name: manager

--- a/config/e2e/manager/manager.yaml
+++ b/config/e2e/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: operand-deployment-lifecycle-manager
         app.kubernetes.io/managed-by: "operand-deployment-lifecycle-manager"
         app.kubernetes.io/name: "operand-deployment-lifecycle-manager"
-        intent: projected
+        intent: projected-odlm
       annotations:
         productName: "IBM Cloud Platform Common Services"
         productID: "068a62892a1e4db39641342e592daa25"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -24,7 +24,7 @@ spec:
         app.kubernetes.io/instance: operand-deployment-lifecycle-manager
         app.kubernetes.io/managed-by: "operand-deployment-lifecycle-manager"
         app.kubernetes.io/name: "operand-deployment-lifecycle-manager"
-        intent: projected
+        intent: projected-odlm
       annotations:
         productName: "IBM Cloud Platform Common Services"
         productID: "068a62892a1e4db39641342e592daa25"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -56,7 +56,7 @@ spec:
         - name: WATCH_NAMESPACE
           valueFrom:
             configMapKeyRef:
-              name: namespace-scope
+              name: odlm-scope
               key: namespaces
         image: quay.io/opencloudio/odlm:latest
         name: manager

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -50,12 +50,12 @@ func GetInstallScope() string {
 	return ns
 }
 
-func GetOdlmScope() string {
+func GetOdlmScope() bool {
 	isEnable, found := os.LookupEnv("ODLM_SCOPE")
-	if !found {
-		return "false"
+	if !found || isEnable != "true" {
+		return false
 	}
-	return isEnable
+	return true
 }
 
 // ResourceExists returns true if the given resource kind exists

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -50,6 +50,14 @@ func GetInstallScope() string {
 	return ns
 }
 
+func GetOdlmScope() string {
+	isEnable, found := os.LookupEnv("ODLM_SCOPE")
+	if !found {
+		return "false"
+	}
+	return isEnable
+}
+
 // ResourceExists returns true if the given resource kind exists
 // in the given api groupversion
 func ResourceExists(dc discovery.DiscoveryInterface, apiGroupVersion, kind string) (bool, error) {

--- a/main.go
+++ b/main.go
@@ -93,8 +93,7 @@ func main() {
 	watchNamespace := util.GetWatchNamespace()
 	odlmScopeEnable := util.GetOdlmScope()
 	if scope == "namespaced" {
-		// single ODLM instance
-		if odlmScopeEnable == "false" {
+		if odlmScopeEnable {
 			options.NewCache = k8sutil.NewODLMCache(strings.Split(watchNamespace, ","), gvkLabelMap)
 		} else {
 			// SaaS or on-prem multi instances case

--- a/main.go
+++ b/main.go
@@ -91,9 +91,17 @@ func main() {
 
 	scope := util.GetInstallScope()
 	watchNamespace := util.GetWatchNamespace()
+	odlmScopeEnable := util.GetOdlmScope()
 	if scope == "namespaced" {
-		options.NewCache = k8sutil.NewODLMCache(strings.Split(watchNamespace, ","), gvkLabelMap)
+		// single ODLM instance
+		if odlmScopeEnable == "false" {
+			options.NewCache = k8sutil.NewODLMCache(strings.Split(watchNamespace, ","), gvkLabelMap)
+		} else {
+			// SaaS or on-prem multi instances case
+			options.NewCache = cache.MultiNamespacedFilteredCacheBuilder(gvkLabelMap, strings.Split(watchNamespace, ","))
+		}
 	} else {
+		// cluster-scope ODLM
 		options.NewCache = cache.NewFilteredCacheBuilder(gvkLabelMap)
 	}
 


### PR DESCRIPTION
We will create an another ConfigMap called `odlm-scope` to manage the scope for ODLM.

It includes `ControlNs` comparing with the previous `namespace-scope` ConfigMap. We will remove `ControlNs` from `common-service` NSS CR.

```
apiVersion: v1
data:
  namespaces: placeholder
kind: ConfigMap
metadata:
  name: odlm-scope
  namespace: placeholder
```

Namespace-scope operator will have an additional CR called `nss-odlm-scope` to update the above ConfigMap, to make sure that scope of ODLM is in the valid namespaces.

```
apiVersion: operator.ibm.com/v1
kind: NamespaceScope
metadata:
  name: nss-odlm-scope
  namespace: placeholder
spec:
  namespaceMembers:
  - placeholder
  configmapName: odlm-scope
  restartLabels:
    intent: projected-odlm
```

Therefore `WATCH_NAMESPACE` in the csv in ODLM will change to watch the namespaces in ConfigMap `odlm-scope`.

Also we only cache the ODLM CRs in the scope, so ODLM will not watch the request out of scope.