### PR TITLE
fix: Add a timeout for deleting an operandrequest

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -54,4 +54,19 @@ const (
 
 	//DefaultSyncPeriod is the frequency at which watched resources are reconciled
 	DefaultSyncPeriod = 3 * time.Hour
+
+	//DefaultCRFetchTimeout is the default timeout for getting a custom resource
+	DefaultCRFetchTimeout = 250 * time.Millisecond
+
+	//DefaultCRFetchPeriod is the default retry Period for getting a custom resource
+	DefaultCRFetchPeriod = 5 * time.Second
+
+	//DefaultCRDeleteTimeout is the default timeout for deleting a custom resource
+	DefaultCRDeleteTimeout = 5 * time.Minute
+
+	//DefaultCRDeletePeriod is the default retry Period for deleting a custom resource
+	DefaultCRDeletePeriod = 20 * time.Second
+
+	//DefaultSubDeleteTimeout is the default timeout for deleting a subscription
+	DefaultSubDeleteTimeout = 10 * time.Minute
 )

--- a/controllers/testutil/test_util.go
+++ b/controllers/testutil/test_util.go
@@ -170,6 +170,15 @@ func OperandRequestObjWithCR(registryName, registryNamespace, requestName, reque
 								Raw: []byte(`{"size": 3,"version": "3.2.15"}`),
 							},
 						},
+						{
+							Name:         "jenkins",
+							Kind:         "Jenkins",
+							APIVersion:   "jenkins.io/v1alpha2",
+							InstanceName: "example",
+							Spec: &runtime.RawExtension{
+								Raw: []byte(`{"service": {"port": 8081}}`),
+							},
+						},
 					},
 				},
 			},

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -19,6 +19,8 @@ package util
 import (
 	"os"
 	"sort"
+	"sync"
+	"time"
 
 	"k8s.io/client-go/discovery"
 )
@@ -90,4 +92,20 @@ func StringSliceContentEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+// WaitTimeout waits for the waitgroup for the specified max timeout.
+// Returns true if waiting timed out.
+func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	c := make(chan struct{})
+	go func() {
+		defer close(c)
+		wg.Wait()
+	}()
+	select {
+	case <-c:
+		return false // completed normally
+	case <-time.After(timeout):
+		return true // timed out
+	}
 }


### PR DESCRIPTION
Issue: When one subscription can't be deleted, if will block the operandrequest forever.

Solution: Set a timeout 10 mins to the subscription deletion.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #651 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
