### PR TITLE
Reconcile two NSS CRs managedby ODLM

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -43,6 +43,9 @@ const (
 	//NamespaceScopeCrName is the name use to get NamespaceScopeCrName instance
 	NamespaceScopeCrName string = "nss-managedby-odlm"
 
+	//OdlmScopeNssCrName is the name use to get OdlmScopeNssCrName instance
+	OdlmScopeNssCrName string = "odlm-scope-managedby-odlm"
+
 	//FindOperandRegistry is the key for checking if the OperandRegistry is found
 	FindOperandRegistry string = "operator.ibm.com/operandregistry-is-not-found"
 

--- a/controllers/testutil/test_util.go
+++ b/controllers/testutil/test_util.go
@@ -261,6 +261,17 @@ func NamespaceScopeObj(namespace string) *nssv1.NamespaceScope {
 		},
 	}
 }
+func OdlmNssObj(namespace string) *nssv1.NamespaceScope {
+	return &nssv1.NamespaceScope{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constant.OdlmScopeNssCrName,
+			Namespace: namespace,
+		},
+		Spec: nssv1.NamespaceScopeSpec{
+			NamespaceMembers: []string{},
+		},
+	}
+}
 func NamespaceObj(name string) *corev1.Namespace {
 	return &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.17.0
 	github.com/pkg/errors v0.9.1
 	k8s.io/api v0.18.9
-	k8s.io/apiextensions-apiserver v0.18.9
 	k8s.io/apimachinery v0.18.9
 	k8s.io/client-go v0.18.9
 	k8s.io/klog v1.0.0


### PR DESCRIPTION
ODLM will add the namespace which are captured from the `Namespace` where Operator will be installed in `OperandRegistry` and `Namespace` of `OperandRequest` into both `nss-managedby-odlm` and `odlm-scope-managedby-odlm` NSS CRs.

On the other word, those two NSS CRs has the same `namespaceMember`

The first `nss-managedby-odlm` is used to control namespace-scope for individual CS operators.
The latter `odlm-scope-managedby-odlm` is used to control namespace-scope for ODLM.

Also those two NSS CRs will only take effect in on-prem Single CS instance case.

If the `odlmScopeEnable` is `true`, indicating the SaaS or om-prem multi instances case, `namespacescope_controller` will be disabled and above two CRs will not be generated. See details here
https://github.com/IBM/ibm-common-service-operator/pull/490