### PR TITLE
feat: use patch command to manage resources finalizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ test: ## Run unit test on prow
 	@echo "Running unit tests for the controllers."
 	@mkdir -p ${ENVTEST_ASSETS_DIR}
 	@test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh \
-	|| curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
+	|| curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/release-0.6/hack/setup-envtest.sh
 	@test -d ${ENVTEST_ASSETS_DIR}/crds || make fetch-test-crds
 	@source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); OPERATOR_NAMESPACE="ibm-operators" go test ./controllers/... -coverprofile cover.out
 	@rm -rf ${ENVTEST_ASSETS_DIR}

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -89,7 +89,7 @@ func (r *Reconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, reconcileErr er
 
 	// If the finalizer is added, EnsureFinalizer() will return true. If the finalizer is already there, EnsureFinalizer() will return false
 	if bindInfoInstance.EnsureFinalizer() {
-		err := r.Update(ctx, bindInfoInstance)
+		err := r.Patch(ctx, bindInfoInstance, client.MergeFrom(originalInstance))
 		if err != nil {
 			klog.Errorf("failed to update the OperandBindinfo %s: %v", req.NamespacedName.String(), err)
 			return ctrl.Result{}, err
@@ -394,9 +394,10 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 		}
 	}
 	// Update finalizer to allow delete CR
+	originalBind := bindInfoInstance.DeepCopy()
 	removed := bindInfoInstance.RemoveFinalizer()
 	if removed {
-		err := r.Update(ctx, bindInfoInstance)
+		err := r.Patch(ctx, bindInfoInstance, client.MergeFrom(originalBind))
 		if err != nil {
 			return err
 		}

--- a/controllers/operandrequest/operandrequest_controller_test.go
+++ b/controllers/operandrequest/operandrequest_controller_test.go
@@ -307,7 +307,9 @@ var _ = Describe("OperandRegistry controller", func() {
 			requestInstance1 := &operatorv1alpha1.OperandRequest{}
 			Expect(k8sClient.Get(ctx, requestKey1, requestInstance1)).Should(Succeed())
 			requestInstance1.Spec.Requests[0].Operands = requestInstance1.Spec.Requests[0].Operands[1:]
-			Expect(k8sClient.Update(ctx, requestInstance1)).Should(Succeed())
+			Eventually(func() error {
+				return k8sClient.Update(ctx, requestInstance1)
+			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 			Eventually(func() error {
 				etcdCluster := &v1beta2.EtcdCluster{}
 				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: "example", Namespace: operatorNamespaceName}, etcdCluster)
@@ -318,7 +320,9 @@ var _ = Describe("OperandRegistry controller", func() {
 			requestInstance2 := &operatorv1alpha1.OperandRequest{}
 			Expect(k8sClient.Get(ctx, requestKey2, requestInstance2)).Should(Succeed())
 			requestInstance2.Spec.Requests[0].Operands = requestInstance2.Spec.Requests[0].Operands[1:]
-			Expect(k8sClient.Update(ctx, requestInstance2)).Should(Succeed())
+			Eventually(func() error {
+				return k8sClient.Update(ctx, requestInstance2)
+			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 			Eventually(func() bool {
 				etcdCluster := &v1beta2.EtcdCluster{}
 				err := k8sClient.Get(context.TODO(), types.NamespacedName{Name: "example", Namespace: operatorNamespaceName}, etcdCluster)


### PR DESCRIPTION
using patch command to add and remove finalizers from OperandRequest and OperandBindInfo to avoid the issue "the object has been modified; please apply your changes to the latest version and try again"

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
