### PR TITLE
update ocp to Redhat supports versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ Operand Deployment Lifecycle Manager has four CRDs:
 
 ## Supported platforms
 
-You can install the Operand Deployment Lifecycle Manager on Linux® x86_64 with Red Hat® OpenShift® Container Platform version 4.5+.
+You can install the Operand Deployment Lifecycle Manager on Linux® x86_64 with Red Hat® OpenShift® Container Platform version 4.3+.
 
 ## Prerequisites
 
-- [operator-sdk][operator_sdk] version v0.19.2.
-- [go][go_tool] version 1.13.4+
+- [operator-sdk][operator_sdk] version v1.3.0.
+- [go][go_tool] version 1.15.7+
 - [oc][oc_tool] version v3.11+ or [kubectl][kubectl_tool] v1.11.3+
-- Access to an Openshift v4.5.0+ cluster
+- Access to an Openshift v4.3+ cluster
 
 ## Documentation
 

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -2,7 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
-- [Install the operand deployment lifecycle manager On OCP 4.5+](#install-the-operand-deployment-lifecycle-manager-on-ocp-45)
+- [Install the operand deployment lifecycle manager On OCP 4.3+](#install-the-operand-deployment-lifecycle-manager-on-ocp-43)
   - [1. Create CatalogSource](#1-create-catalogsource)
   - [2. Create Operator NS, Group, Subscription](#2-create-operator-ns-group-subscription)
   - [3. Check Operator CSV](#3-check-operator-csv)
@@ -16,7 +16,7 @@
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
-# Install the operand deployment lifecycle manager On OCP 4.5+
+# Install the operand deployment lifecycle manager On OCP 4.3+
 
 ## 1. Create CatalogSource
 


### PR DESCRIPTION
**What this PR does / why we need it**:
OCP 4.2 or 4.3 are no longer supported by RadHat, updated ocp version to supported versions