### PR TITLE
fix: Make operandrequest can be removed together with the namespace d…

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -210,6 +210,12 @@ spec:
         - apiGroups:
           - operator.ibm.com
           resources:
+          - operandrequests
+          verbs:
+          - patch
+        - apiGroups:
+          - operator.ibm.com
+          resources:
           - certmanagers
           - ibmlicensings
           - meteringreportservers

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -17,6 +17,12 @@ rules:
     - operandbindinfos
     - operandconfigs
     - operandregistries
+- verbs:
+    - patch
+  apiGroups:
+    - operator.ibm.com
+  resources:
+    - operandrequests
 - apiGroups:
   - operator.ibm.com
   resources:


### PR DESCRIPTION
…eletion

Grant ODLM extra permission to patch the remaining OperandRequest to remove the finalizer from it.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #649

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
