### PR TITLE
fix requestNamespaces for iam/management-ingress bindinfo

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -488,9 +488,7 @@ func (r *Reconciler) updateBindInfoPhase(bindInfoInstance *operatorv1alpha1.Oper
 	if bindInfoInstance.Status.Phase == phase && reflect.DeepEqual(requestNsList, bindInfoInstance.Status.RequestNamespaces) {
 		return
 	}
-	if len(requestNsList) != 0 {
-		bindInfoInstance.Status.RequestNamespaces = requestNsList
-	}
+	bindInfoInstance.Status.RequestNamespaces = requestNsList
 	bindInfoInstance.Status.Phase = phase
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

currently, delete zen instance, zen-tenant will not be removed from iam/management-ingress bindinfo's `requestNamespace`
