### PR TITLE
apply k8s PreserveUnknownFields into API

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -72,6 +72,7 @@ type Operand struct {
 	InstanceName string `json:"instanceName,omitempty"`
 	// Spec is used when users want to deploy multiple custom resources.
 	// It is the configuration map of custom resource.
+	// +kubebuilder:pruning:PreserveUnknownFields
 	// +nullable
 	// +optional
 	Spec *runtime.RawExtension `json:"spec,omitempty"`

--- a/bundle/manifests/operator.ibm.com_operandrequests.yaml
+++ b/bundle/manifests/operator.ibm.com_operandrequests.yaml
@@ -110,6 +110,7 @@ spec:
                               resource.
                             nullable: true
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
                         - name
                         type: object

--- a/config/crd/bases/operator.ibm.com_operandrequests.yaml
+++ b/config/crd/bases/operator.ibm.com_operandrequests.yaml
@@ -87,6 +87,7 @@ spec:
                             description: Spec is used when users want to deploy multiple custom resources. It is the configuration map of custom resource.
                             nullable: true
                             type: object
+                            x-kubernetes-preserve-unknown-fields: true
                         required:
                         - name
                         type: object


### PR DESCRIPTION
Preserve the unknown filed in `spec` section of CRs when it is created by `OperandRequest`