### PR TITLE
add API for creating CR by OperandConfig

### DIFF
--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -39,6 +39,34 @@ type ConfigService struct {
 	Spec map[string]runtime.RawExtension `json:"spec"`
 	// State is a flag to enable or disable service.
 	State string `json:"state,omitempty"`
+	// Resources is used to specify the k8s resources that are needed for the service.
+	// +optional
+	Resources []ConfigResource `json:"resources,omitempty"`
+}
+
+// ConfigResource defines the resource needed for the service
+type ConfigResource struct {
+	// Name is the resource name.
+	Name string `json:"name"`
+	// Kind identifies the kind of the custom resource.
+	Kind string `json:"kind"`
+	// APIVersion defines the versioned schema of this representation of an object.
+	APIVersion string `json:"apiVersion"`
+	// Namespace is the namespace of the resource.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+	// Labels are the labels used in the resource.
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+	// Annotations are the annotations used in the resource.
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+	// Force is used to determine whether the existing resource should be overwritten.
+	// +optional
+	Force bool `json:"force,omitempty"`
+	// Data is the configuration map of custom resource.
+	// +optional
+	Data map[string]runtime.RawExtension `json:"data,omitempty"`
 }
 
 // OperandConfigStatus defines the observed state of OperandConfig.

--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -39,7 +39,7 @@ type ConfigService struct {
 	Spec map[string]runtime.RawExtension `json:"spec"`
 	// State is a flag to enable or disable service.
 	State string `json:"state,omitempty"`
-	// Resources is used to specify the k8s resources that are needed for the service.
+	// Resources is used to specify the kubernetes resources that are needed for the service.
 	// +optional
 	Resources []ConfigResource `json:"resources,omitempty"`
 }
@@ -48,7 +48,7 @@ type ConfigService struct {
 type ConfigResource struct {
 	// Name is the resource name.
 	Name string `json:"name"`
-	// Kind identifies the kind of the custom resource.
+	// Kind identifies the kind of the kubernetes resource.
 	Kind string `json:"kind"`
 	// APIVersion defines the versioned schema of this representation of an object.
 	APIVersion string `json:"apiVersion"`
@@ -61,10 +61,10 @@ type ConfigResource struct {
 	// Annotations are the annotations used in the resource.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// Force is used to determine whether the existing resource should be overwritten.
+	// Force is used to determine whether the existing kubernetes resource should be overwritten.
 	// +optional
 	Force bool `json:"force,omitempty"`
-	// Data is the configuration map of custom resource.
+	// Data is the configuration map of kubernetes resource.
 	// +optional
 	Data map[string]runtime.RawExtension `json:"data,omitempty"`
 }

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -59,6 +59,53 @@ spec:
                     name:
                       description: Name is the subscription name.
                       type: string
+                    resources:
+                      description: Resources is used to specify the k8s resources
+                        that are needed for the service.
+                      items:
+                        description: ConfigResource defines the resource needed for
+                          the service
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations are the annotations used in the
+                              resource.
+                            type: object
+                          apiVersion:
+                            description: APIVersion defines the versioned schema of
+                              this representation of an object.
+                            type: string
+                          data:
+                            additionalProperties:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description: Data is the configuration map of custom resource.
+                            type: object
+                          force:
+                            description: Force is used to determine whether the existing
+                              resource should be overwritten.
+                            type: boolean
+                          kind:
+                            description: Kind identifies the kind of the custom resource.
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels are the labels used in the resource.
+                            type: object
+                          name:
+                            description: Name is the resource name.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the resource.
+                            type: string
+                        required:
+                        - apiVersion
+                        - kind
+                        - name
+                        type: object
+                      type: array
                     spec:
                       additionalProperties:
                         type: object

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -60,7 +60,7 @@ spec:
                       description: Name is the subscription name.
                       type: string
                     resources:
-                      description: Resources is used to specify the k8s resources
+                      description: Resources is used to specify the kubernetes resources
                         that are needed for the service.
                       items:
                         description: ConfigResource defines the resource needed for
@@ -80,14 +80,16 @@ spec:
                             additionalProperties:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
-                            description: Data is the configuration map of custom resource.
+                            description: Data is the configuration map of kubernetes
+                              resource.
                             type: object
                           force:
                             description: Force is used to determine whether the existing
-                              resource should be overwritten.
+                              kubernetes resource should be overwritten.
                             type: boolean
                           kind:
-                            description: Kind identifies the kind of the custom resource.
+                            description: Kind identifies the kind of the kubernetes
+                              resource.
                             type: string
                           labels:
                             additionalProperties:

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -58,7 +58,7 @@ spec:
                       description: Name is the subscription name.
                       type: string
                     resources:
-                      description: Resources is used to specify the k8s resources
+                      description: Resources is used to specify the kubernetes resources
                         that are needed for the service.
                       items:
                         description: ConfigResource defines the resource needed for
@@ -78,14 +78,16 @@ spec:
                             additionalProperties:
                               type: object
                               x-kubernetes-preserve-unknown-fields: true
-                            description: Data is the configuration map of custom resource.
+                            description: Data is the configuration map of kubernetes
+                              resource.
                             type: object
                           force:
                             description: Force is used to determine whether the existing
-                              resource should be overwritten.
+                              kubernetes resource should be overwritten.
                             type: boolean
                           kind:
-                            description: Kind identifies the kind of the custom resource.
+                            description: Kind identifies the kind of the kubernetes
+                              resource.
                             type: string
                           labels:
                             additionalProperties:

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -57,6 +57,53 @@ spec:
                     name:
                       description: Name is the subscription name.
                       type: string
+                    resources:
+                      description: Resources is used to specify the k8s resources
+                        that are needed for the service.
+                      items:
+                        description: ConfigResource defines the resource needed for
+                          the service
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: Annotations are the annotations used in the
+                              resource.
+                            type: object
+                          apiVersion:
+                            description: APIVersion defines the versioned schema of
+                              this representation of an object.
+                            type: string
+                          data:
+                            additionalProperties:
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            description: Data is the configuration map of custom resource.
+                            type: object
+                          force:
+                            description: Force is used to determine whether the existing
+                              resource should be overwritten.
+                            type: boolean
+                          kind:
+                            description: Kind identifies the kind of the custom resource.
+                            type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: Labels are the labels used in the resource.
+                            type: object
+                          name:
+                            description: Name is the resource name.
+                            type: string
+                          namespace:
+                            description: Namespace is the namespace of the resource.
+                            type: string
+                        required:
+                        - apiVersion
+                        - kind
+                        - name
+                        type: object
+                      type: array
                     spec:
                       additionalProperties:
                         type: object


### PR DESCRIPTION
The previous design used `spec` section for the configuration of that specific resource.

But I am thinking that if we could make the resource creation more generic by using the `data` section instead of `spec`

Here is the example for `Job` resource:

Previously
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandConfig
metadata:
  name: operandconfig
  namespace: default
spec:
  services:
  - name: example-operator
     spec:
      example-operand:
        some-spec-field: myvalue
     resources:
     -   kind: Job
         name:  registry-key-generater
         apiVersion: batch/v1
         spec: ------------------- spec indicates the spec section in job, but other section could not be created
           template:
             metadata:
               ..         
```
Now
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandConfig
metadata:
  name: operandconfig
  namespace: default
spec:
  services:
  - name: example-operator
     spec:
      example-operand:
        some-spec-field: myvalue
     resources:
     -   kind: Job
         name:  registry-key-generater
         apiVersion: batch/v1
         data:    ------------------- data section indicates the configuration in the resource other than metadata, kind and apiVersion
           spec:  ------------------- spec indicates the spec section in job
             template:
               metadata:
               ..         
```

And for other resource like `Role`
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandConfig
metadata:
  name: operandconfig
  namespace: default
spec:
  services:
  - name: example-operator
     spec:
      example-operand:
        some-spec-field: myvalue
     resources:
     -   apiVersion: rbac.authorization.k8s.io/v1
         kind: Role
         namespace: default
         name: registry-key-generator
         data: 
           rules: ---------------------- Role resource does not have spec section, but it contains rules section
              - apiGroups: [""]
                resources: ["pods"]
                verbs: ["get", "watch", "list"]
            ......
```