### PR TITLE
update status of deprecated service to not found

### DIFF
--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -127,6 +127,7 @@ const (
 	ServiceFailed   ServicePhase = "Failed"
 	ServiceInit     ServicePhase = "Initialized"
 	ServiceCreating ServicePhase = "Creating"
+	ServiceNotFound ServicePhase = "Not Found"
 	ServiceNone     ServicePhase = ""
 )
 

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -109,6 +109,7 @@ const (
 	OperatorUpdating   OperatorPhase = "Updating"
 	OperatorFailed     OperatorPhase = "Failed"
 	OperatorInit       OperatorPhase = "Initialized"
+	OperatorNotFound   OperatorPhase = "Not Found"
 	OperatorNone       OperatorPhase = ""
 
 	ClusterPhaseNone       ClusterPhase = "Pending"

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -69,6 +69,7 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 			opdRegistry := registryInstance.GetOperator(operand.Name)
 			if opdRegistry == nil {
 				klog.Warningf("Cannot find %s in the OperandRegistry instance %s in the namespace %s ", operand.Name, req.Registry, req.RegistryNamespace)
+				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorNotFound, operatorv1alpha1.ServiceNotFound, &r.Mutex)
 				continue
 			}
 


### PR DESCRIPTION
Taking `ibm-metering-operator` as an example, it is removed from `OperandRegistry` after upgrading to cd version. But it still stays in `OperandRequest`.

If the service is not found in `OperandRegistry`, we will update the status of `ibm-metering-operator` to `Not Found` in `OperandRequest`.
The overall status of `OperandRequest` remains as `Running` and will no longer be affected by the status of those deprecated services.

Example
```
  members:
    - name: ibm-cert-manager-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
    - name: ibm-mongodb-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
    - name: ibm-licensing-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
    - name: ibm-metering-operator
      phase:
        operandPhase: Not Found
        operatorPhase: Not Found
```