### PR TITLE
check permission before creating k8s resource

### DIFF
--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -109,3 +109,21 @@ func WaitTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
 		return true // timed out
 	}
 }
+
+// ResourceNamespaced returns true if the given resource is namespaced
+func ResourceNamespaced(dc discovery.DiscoveryInterface, apiGroupVersion, kind string) (bool, error) {
+	_, apiLists, err := dc.ServerGroupsAndResources()
+	if err != nil {
+		return false, err
+	}
+	for _, apiList := range apiLists {
+		if apiList.GroupVersion == apiGroupVersion {
+			for _, r := range apiList.APIResources {
+				if r.Kind == kind {
+					return r.Namespaced, nil
+				}
+			}
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
When we try to create a configmap in `kube-public`, it is failed due to the lack of permission for ODLM
```
I0110 23:10:59.113598       1 reconcile_operand.go:241] ODLM doesn't have enough permission to reconcile k8s resource -- Kind: ConfigMap, NamespacedName: kube-public/game-demo
```

We will check operator permissions for both namespaced-scope and cluster-scope resources.