### PR TITLE
fix: add more restricted rule for operator upgrade

### DIFF
--- a/controllers/operatorchecker/operatorchecker_controller.go
+++ b/controllers/operatorchecker/operatorchecker_controller.go
@@ -73,7 +73,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		}
 	}
 
-	if subscriptionInstance.Status.CurrentCSV != "" && subscriptionInstance.Status.State == "UpgradePending" {
+	if subscriptionInstance.Status.CurrentCSV != "" && subscriptionInstance.Status.InstalledCSV != "" && subscriptionInstance.Status.InstalledCSV != subscriptionInstance.Status.CurrentCSV && subscriptionInstance.Status.State == "UpgradePending" {
 		// cover upgrade case
 		csvList, err := r.getCSVBySubscription(ctx, subscriptionInstance)
 		if err != nil {
@@ -92,7 +92,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			if err != nil {
 				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
-			if subscriptionInstance.Status.CurrentCSV != "" && subscriptionInstance.Status.State == "UpgradePending" {
+			if subscriptionInstance.Status.CurrentCSV != "" && subscriptionInstance.Status.InstalledCSV != "" && subscriptionInstance.Status.InstalledCSV != subscriptionInstance.Status.CurrentCSV && subscriptionInstance.Status.State == "UpgradePending" {
 				if err = r.deleteCSV(ctx, csv.Name, csv.Namespace); err != nil {
 					return ctrl.Result{}, client.IgnoreNotFound(err)
 				}


### PR DESCRIPTION
Make operator upgrade more robust and won't impact fresh install operator

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
