### PR TITLE
Revert "fix: When operandrequest is empty then set OperandRequest to running …"

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -477,7 +477,7 @@ func (r *OperandRequest) UpdateClusterPhase() {
 		clusterPhase = ClusterPhaseInstalling
 	} else if clusterStatusStat.creatingNum > 0 {
 		clusterPhase = ClusterPhaseCreating
-	} else if clusterStatusStat.runningNum > 0 || len(r.Status.Members) == 0 {
+	} else if clusterStatusStat.runningNum > 0 {
 		clusterPhase = ClusterPhaseRunning
 	} else {
 		clusterPhase = ClusterPhaseNone


### PR DESCRIPTION
Reverts IBM/operand-deployment-lifecycle-manager#796