### PR TITLE
add version compare for subscription channel

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -458,6 +458,8 @@ func (r *OperandRequest) UpdateClusterPhase() {
 			clusterStatusStat.runningNum++
 		case OperatorInstalling:
 			clusterStatusStat.installingNum++
+		case OperatorUpdating:
+			clusterStatusStat.installingNum++
 		default:
 		}
 

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -168,12 +168,15 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 			} else {
 				if ip.Status.Phase == olmv1alpha1.InstallPlanPhaseFailed {
 					klog.Errorf("installplan %s/%s is failed", ipNamespace, ipName)
+					requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "", &r.Mutex)
 					continue
 				} else if ip.Status.Phase == olmv1alpha1.InstallPlanPhaseRequiresApproval {
 					klog.V(2).Infof("Installplan %s/%s is waiting for approval", ipNamespace, ipName)
+					requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorInstalling, "", &r.Mutex)
 					continue
 				} else if ip.Status.Phase != olmv1alpha1.InstallPlanPhaseComplete {
 					klog.Warningf("Installplan %s/%s is not ready", ipNamespace, ipName)
+					requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorInstalling, "", &r.Mutex)
 					continue
 				}
 			}

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -177,7 +177,7 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
 		sub.Spec.Package = opt.PackageName
 		// For singleton services, compare the channel version to install the latest one
-		if checkSingletonServices(opt.Name) {
+		if CheckSingletonServices(opt.Name) {
 			v1IsLarger, convertErr := util.CompareChannelVersion(opt.Channel, originalSub.Spec.Channel)
 			if convertErr != nil {
 				return convertErr
@@ -565,7 +565,7 @@ func compareSub(sub *olmv1alpha1.Subscription, originalSub *olmv1alpha1.Subscrip
 	return !equality.Semantic.DeepEqual(sub.Spec, originalSub.Spec) || !equality.Semantic.DeepEqual(sub.Annotations, originalSub.Annotations)
 }
 
-func checkSingletonServices(operator string) bool {
+func CheckSingletonServices(operator string) bool {
 	singletonServices := []string{"ibm-cert-manager-operator", "ibm-licensing-operator"}
 	return util.Contains(singletonServices, operator)
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -19,6 +19,8 @@ package util
 import (
 	"os"
 	"sort"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -131,6 +133,48 @@ func ResourceNamespaced(dc discovery.DiscoveryInterface, apiGroupVersion, kind s
 					return r.Namespaced, nil
 				}
 			}
+		}
+	}
+	return false, nil
+}
+
+func CompareVersion(v1, v2 string) (v1IsLarger bool, err error) {
+	_, v1Cut, isExist := strings.Cut(v1, "v")
+	if !isExist {
+		v1Cut = "0.0"
+	}
+	v1Slice := strings.Split(v1Cut, ".")
+	if len(v1Slice) == 1 {
+		v1Cut = v1Cut + ".0"
+	}
+
+	_, v2Cut, isExist := strings.Cut(v2, "v")
+	if !isExist {
+		v1Cut = "0.0"
+	}
+	v2Slice := strings.Split(v2Cut, ".")
+	if len(v2Slice) == 1 {
+		v2Cut = v2Cut + ".0"
+	}
+
+	v1Slice = strings.Split(v1Cut, ".")
+	v2Slice = strings.Split(v2Cut, ".")
+	for index := range v1Slice {
+		v1SplitInt, e1 := strconv.Atoi(v1Slice[index])
+		if e1 != nil {
+			return false, e1
+		}
+		v2SplitInt, e2 := strconv.Atoi(v2Slice[index])
+		if e2 != nil {
+			return false, e2
+		}
+
+		if v1SplitInt > v2SplitInt {
+			return true, nil
+		} else if v1SplitInt == v2SplitInt {
+			continue
+		} else {
+			return false, nil
 		}
 	}
 	return false, nil

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -138,7 +138,7 @@ func ResourceNamespaced(dc discovery.DiscoveryInterface, apiGroupVersion, kind s
 	return false, nil
 }
 
-func CompareVersion(v1, v2 string) (v1IsLarger bool, err error) {
+func CompareChannelVersion(v1, v2 string) (v1IsLarger bool, err error) {
 	_, v1Cut, isExist := strings.Cut(v1, "v")
 	if !isExist {
 		v1Cut = "0.0"
@@ -178,4 +178,13 @@ func CompareVersion(v1, v2 string) (v1IsLarger bool, err error) {
 		}
 	}
 	return false, nil
+}
+
+func Contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>

When we deploy the same services from different OperandRegistries, the newer version(newer channel) of services will have higher priority and will be applied to the subscription.
