### PR TITLE
reserve the status for operators which are still in deletion stage

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	gset "github.com/deckarep/golang-set"
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/pkg/errors"
@@ -207,6 +208,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context, cr *operatorv1alpha1.Oper
 
 func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
 	klog.V(1).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
+	failedDeletedOperands := gset.NewSet()
 	existingSub := &olmv1alpha1.SubscriptionList{}
 
 	opts := []client.ListOption{
@@ -220,7 +222,7 @@ func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operat
 		return nil
 	}
 	// Delete all the subscriptions that created by current request
-	if err := r.absentOperatorsAndOperands(ctx, requestInstance); err != nil {
+	if err := r.absentOperatorsAndOperands(ctx, requestInstance, &failedDeletedOperands); err != nil {
 		return err
 	}
 	return nil

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -100,21 +100,6 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 				klog.Warningf("Subscription %s in the namespace %s isn't created by ODLM", sub.Name, sub.Namespace)
 			}
 
-			// check config annotation in subscription, identify the first ODLM has the priority to reconcile
-			var firstMatch string
-			reg, _ := regexp.Compile(`^(.*)\.(.*)\/config`)
-			for anno := range sub.Annotations {
-				if reg.MatchString(anno) {
-					firstMatch = anno
-					break
-				}
-			}
-
-			if firstMatch != "" && firstMatch != regNs+"."+regName+"/config" {
-				klog.V(2).Infof("Subscription %s in the namespace %s is currently managed by %s", sub.Name, sub.Namespace, firstMatch)
-				continue
-			}
-
 			// It the installplan is not created yet, ODLM will try later
 			if sub.Status.Install == nil || sub.Status.InstallPlanRef.Name == "" {
 				klog.Warningf("The Installplan for Subscription %s is not ready. Will check it again", sub.Name)
@@ -157,6 +142,22 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 
 			klog.V(3).Info("Generating customresource base on ClusterServiceVersion: ", csv.GetName())
 			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, "", &r.Mutex)
+
+			// check config annotation in subscription, identify the first ODLM has the priority to reconcile
+			var firstMatch string
+			reg, _ := regexp.Compile(`^(.*)\.(.*)\/config`)
+			for anno := range sub.Annotations {
+				if reg.MatchString(anno) {
+					firstMatch = anno
+					break
+				}
+			}
+
+			if firstMatch != "" && firstMatch != regNs+"."+regName+"/config" {
+				klog.V(2).Infof("Subscription %s in the namespace %s is currently managed by %s, Skip creating CR for it", sub.Name, sub.Namespace, firstMatch)
+				requestInstance.SetMemberStatus(operand.Name, "", operatorv1alpha1.ServiceRunning, &r.Mutex)
+				continue
+			}
 
 			// Merge and Generate CR
 			if operand.Kind == "" {

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -46,18 +46,11 @@ import (
 
 func (r *Reconciler) reconcileOperator(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
 	klog.V(1).Infof("Reconciling Operators for OperandRequest: %s/%s", requestInstance.GetNamespace(), requestInstance.GetName())
-	var returnErr error
 	// It is important to NOT pass the set directly into defer functions.
 	// The arguments to the deferred function are evaluated when the defer executes
 	failedDeletedOperands := gset.NewSet()
 	// Update request status
 	defer func() {
-		if failedDeletedOperands.Cardinality() != 0 {
-			klog.Infof("Failed to delete operands, %s", strings.Trim(fmt.Sprint(failedDeletedOperands.ToSlice()), "[]"))
-			returnErr = fmt.Errorf("time out to clean operators %s ", strings.Trim(fmt.Sprint(failedDeletedOperands.ToSlice()), "[]"))
-		} else {
-			returnErr = nil
-		}
 		requestInstance.FreshMemberStatus(&failedDeletedOperands)
 		requestInstance.UpdateClusterPhase()
 	}()
@@ -149,7 +142,7 @@ func (r *Reconciler) reconcileOperator(ctx context.Context, requestInstance *ope
 	}
 	klog.V(1).Infof("Finished reconciling Operators for OperandRequest: %s/%s", requestInstance.GetNamespace(), requestInstance.GetName())
 
-	return returnErr
+	return nil
 }
 
 func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest, registryInstance *operatorv1alpha1.OperandRegistry, operand operatorv1alpha1.Operand, registryKey types.NamespacedName, mu sync.Locker) error {


### PR DESCRIPTION
### Background

ODLM get the operators which will be deleted by [comparing the differences](https://github.com/IBM/operand-deployment-lifecycle-manager/blob/2e39cfbddb9b3a3b7092e12fac37947ce2777026/controllers/operandrequest/reconcile_operator.go#L430) between operators in `OperandRequest` status with operators in `OperandRequest` spec.

### Root cause
At the end of each reconciliation, ODLM will [refresh the `OperandRequest` status](https://github.com/IBM/operand-deployment-lifecycle-manager/blob/2e39cfbddb9b3a3b7092e12fac37947ce2777026/controllers/operandrequest/reconcile_operator.go#L52) based on existing operators in `OperandRequest` status.
When we remove an operator from `OperandRequest` spec, it will be removed from `OperandRequest` status as well.

However, if the deletion of those operators hits an error, those operators will be left in the cluster.
But ODLM will still refresh the status of `OperandRequest` based on spec in current and following reconciliation. And as a consequence, the status of those operators left in the cluster is gone.

ODLM will never find the information about those orphan operators in the comparison of status and spec, and continue the deletion process.

### Solution
When ODLM is refreshing the status of OperandRequest. It will go through all operators in existing status.
The status of operators will be reserved if they are either in the `OperandRequest` spec or exist in cluster(Subscription exists).

### How to test
#### Reproduce the issue
1. Create a OperandRequest containing operator `ibm-cert-manager-operator` and `cloud-native-postgresql`
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: example-service
  namespace: cp4d
spec:
  requests:
    - operands:
        - name: cloud-native-postgresql
        - name: ibm-cert-manager-operator
      registry: common-service
```

2. Check the status of `OperandRequest`, both `ibm-cert-manager-operator` and `cloud-native-postgresql` exists.
```
  members:
    - name: cloud-native-postgresql
      phase:
        operandPhase: Running
        operatorPhase: Running
    - name: ibm-cert-manager-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
  phase: Running
```

3. Add a finalizer in cert-manager CR
```
apiVersion: operator.ibm.com/v1alpha1
kind: CertManager
metadata:
  finalizers:
    - not-uninstall
```
4. Remove `ibm-cert-manager-oeprator` from `OperandRequest`, keep `cloud-native-posygresql` unchanged
5. Wait to see the error msg from ODLM pod logs, it happens because the ODLM is not able to delete cert-manager CR due to the finalizer we added into before.
```
E1128 00:11:46.223735 1 operandrequest_controller.go:92] failed to clean up the subscriptions for OperandRequest cp4d/example-service: the following errors occurred:
- the following errors occurred:
- failed to delete custom resource -- Kind: CertManager, NamespacedName: cs-control/default: timed out waiting for the condition
```
6. OperandRequest do not has the status for `ibm-cert-manager-operator` anymore, but `ibm-cert-manager-operator` exists in the cluster.
```
  members:
    - name: cloud-native-postgresql
      phase:
        operandPhase: Running
        operatorPhase: Running
  phase: Running
```
7. We manually remove finalizer in Cert-Manager CR, Cert-Manager CR is gone automatically. But `ibm-cert-manager-operator`  remains in the cluster, ODLM does not delete it anymore.

### Correct behaviour after patching the ODLM image
#### Patch ODLM image in CSV: `quay.io/daniel_fan/odlm:3664b25d-dirty`
1. Add `ibm-cert-manager-operator` back into the OperandRequest spec
```
spec:
  requests:
    - operands:
        - name: cloud-native-postgresql
        - name: ibm-cert-manager-operator
```
2. Add finalizer into Cert-Manager CR as what we previously did
3. Remove `ibm-cert-manager-oeprator` from `OperandRequest`, keep `cloud-native-posygresql` unchanged
4. Wait to see the error msg from ODLM pod logs, it happens because the ODLM is not able to delete cert-manager CR due to the finalizer we added into before.
```
E1128 00:11:46.223735 1 operandrequest_controller.go:92] failed to clean up the subscriptions for OperandRequest cp4d/example-service: the following errors occurred:
- the following errors occurred:
- failed to delete custom resource -- Kind: CertManager, NamespacedName: cs-control/default: timed out waiting for the condition
```
5. OperandRequest still HAS the status for `ibm-cert-manager-operator`.
```
  members:
    - name: cloud-native-postgresql
      phase:
        operandPhase: Running
        operatorPhase: Running
    - name: ibm-cert-manager-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
  phase: Running
```
6. We manually remove finalizer in Cert-Manager CR, Cert-Manager CR is gone. ODLM will continue to uninstall `ibm-cert-manager-operator`. And finally `ibm-cert-manager-operator` will be uninstalled.

Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>
