### PR TITLE
add tombstone parameter in OperandRegistry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,12 @@ else
 ARTIFACTORYA_REGISTRY ?= "docker-na-public.artifactory.swg-devops.com/hyc-cloud-private-scratch-docker-local/ibmcom"
 endif
 
+ifdef DEV_REGISTRY
+DEV_REGISTRY := $(DEV_REGISTRY)
+else
+DEV_REGISTRY := ${QUAY_REGISTRY}
+endif
+
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= odlm
 # Current Operator bundle image name

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -71,6 +71,12 @@ type Operator struct {
 	// SubscriptionConfig is used to override operator configuration.
 	// +optional
 	SubscriptionConfig *olmv1alpha1.SubscriptionConfig `json:"subscriptionConfig,omitempty"`
+	// SupportStatus is used to indicate the support status for services.
+	// Valid values are:
+	// - "continuous" (default): operator is supported to be fresh deployed via OperandRequest from scratch
+	// - "maintained" operator is not supported to be fresh deployed via OperandRequest, only upgrade and deletion are allowed
+	// +optional
+	SupportStatus string `json:"supportStatus,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=public;private
@@ -90,6 +96,13 @@ const (
 	InstallModeCluster string = "cluster"
 	// InstallModeNamespace means install the operator in one namespace mode.
 	InstallModeNamespace string = "namespace"
+)
+
+const (
+	// MaintainedSupportStatus means NOT supporting fresh deployment for the operator
+	MaintainedSupportStatus string = "maintained"
+	// ContinuousSupportStatus means supporting fresh deployment for the operator
+	ContinuousSupportStatus string = "continuous"
 )
 
 // OperandRegistrySpec defines the desired state of OperandRegistry.

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -266,7 +266,7 @@ func (r *OperandRequest) SetNoSuitableRegistryCondition(name, message string, rt
 	r.setCondition(*c)
 }
 
-// SetOutofScopeCondition creates a NotFoundCondition.
+// SetOutofScopeCondition creates a OutofScopeCondition.
 func (r *OperandRequest) SetOutofScopeCondition(name string, rt ResourceType, cs corev1.ConditionStatus, mu sync.Locker) {
 	mu.Lock()
 	defer mu.Unlock()

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -2026,6 +2026,14 @@ spec:
                             type: object
                           type: array
                       type: object
+                    supportStatus:
+                      description: 'SupportStatus is used to indicate the support
+                        status for services. Valid values are: - "continuous" (default):
+                        operator is supported to be fresh deployed via OperandRequest
+                        from scratch - "maintained" operator is not supported to be
+                        fresh deployed via OperandRequest, only upgrade and deletion
+                        are allowed'
+                      type: string
                     targetNamespaces:
                       description: The target namespace of the OperatorGroups.
                       items:

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -2024,6 +2024,14 @@ spec:
                             type: object
                           type: array
                       type: object
+                    supportStatus:
+                      description: 'SupportStatus is used to indicate the support
+                        status for services. Valid values are: - "continuous" (default):
+                        operator is supported to be fresh deployed via OperandRequest
+                        from scratch - "maintained" operator is not supported to be
+                        fresh deployed via OperandRequest, only upgrade and deletion
+                        are allowed'
+                      type: string
                     targetNamespaces:
                       description: The target namespace of the OperatorGroups.
                       items:

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -86,6 +86,9 @@ func (m *ODLMOperator) GetOperandRegistry(ctx context.Context, key types.Namespa
 		if o.Namespace == "" {
 			reg.Spec.Operators[i].Namespace = key.Namespace
 		}
+		if o.SupportStatus == "" {
+			reg.Spec.Operators[i].SupportStatus = apiv1alpha1.ContinuousSupportStatus
+		}
 		if o.SourceName == "" || o.SourceNamespace == "" {
 			catalogSourceName, catalogSourceNs, err := m.GetCatalogSourceFromPackage(ctx, o.PackageName, o.Namespace, o.Channel, key.Namespace, excludedCatalogSources)
 			if err != nil {

--- a/docs/design/operand-deployment-lifecycle-manager.md
+++ b/docs/design/operand-deployment-lifecycle-manager.md
@@ -66,13 +66,14 @@ spec:
   operators:
   - name: jenkins [3]
     namespace: default [4]
-    channel: alpha [6]
-    packageName: jenkins-operator [7]
-    scope: public [8]
-    sourceName: community-operators [9]
-    sourceNamespace: openshift-marketplace [10]
-    installMode: cluster [11]
-    installPlanApproval: Manual [12]
+    channel: alpha [5]
+    packageName: jenkins-operator [6]
+    scope: public [7]
+    sourceName: community-operators [8]
+    sourceNamespace: openshift-marketplace [9]
+    installMode: cluster [10]
+    installPlanApproval: Manual [11]
+    supportStatus: continuous [12]
 ```
 
 The OperandRegistry Custom Resource (CR) lists OLM Operator information for operands that may be requested for installation and/or access by an application that runs in a namespace. The registry CR specifies:
@@ -88,6 +89,7 @@ The OperandRegistry Custom Resource (CR) lists OLM Operator information for oper
 9. `sourceNamespace` is the namespace of the CatalogSource.
 10. (optional) `installMode` is the install mode of the operator, can be either `namespace` (OLM one namespace) or `cluster` (OLM all namespaces). The default value is `namespace`. Operator is deployed in `openshift-operators` namespace when InstallMode is set to `cluster`.
 11. (optional) `installPlanApproval` is the approval mode for emitted installplan. The default value is `Automatic`.
+12. (optional) `supportStatus` is the support status for services. (1) When SupportStatus is `continous`, operator is supported to be fresh deployed via OperandRequest from scratch. (2) When SupportStatus is `maintained`, operator is not supported to be fresh deployed via OperandRequest, only upgrade and deletion are allowed. The default value is `continous`
 
 ## OperandConfig Spec
 


### PR DESCRIPTION
Introducing new parameter `.spec.operators[*].supportStatus` in OperandRegistry

`supportStatus` is the support status for services.
- When SupportStatus is `continous`, operator is supported to be fresh deployed via OperandRequest from scratch.
- When SupportStatus is `maintained`, operator is not supported to be fresh deployed via OperandRequest, only upgrade and deletion are allowed.
- The default value is `continous`

```
    - sourceNamespace: openshift-marketplace
      supportStatus: maintained  <-------------------
      channel: v3.23
      sourceName: opencloud-operators
      installPlanApproval: Automatic
      name: ibm-platform-api-operator
      packageName: ibm-platform-api-operator-app
      scope: public
      namespace: cs-2
```