### PR TITLE
[future] skip reconcile CR when it only exists in alm-example, not OperandConfig

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -309,12 +309,18 @@ func (r *Reconciler) reconcileCRwithConfig(ctx context.Context, service *operato
 			Namespace: namespace,
 		}, &crFromALM)
 
+		foundInConfig := false
 		for cr := range service.Spec {
 			if strings.EqualFold(crFromALM.GetKind(), cr) {
 				foundMap[cr] = true
+				foundInConfig = true
 			}
 		}
 
+		if !foundInConfig {
+			klog.Warningf("%v in the alm-example doesn't exist in the OperandConfig for %v", crFromALM.GetKind(), csv.GetName())
+			continue
+		}
 		if err != nil && !apierrors.IsNotFound(err) {
 			merr.Add(errors.Wrapf(err, "failed to get the custom resource %s/%s", namespace, name))
 			continue


### PR DESCRIPTION
### How to reproduce error
1. Install existing `future` CatalogSource
2. Install CommonService which brings up ODLM
3. Remove `IBMLicensing` from OperandConfig. We do not want ODLM to create it.
```
kind: OperandConfig
metadata:
  name: common-service
  namespace: cp4i
spec:
  services:
    - name: ibm-licensing-operator
      spec:
        operandBindInfo: {}
```
5. Invoke an OperandRequest containing `ibm-licensing-operator`
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: example-service
  namespace: cp4i
spec:
  requests:
    - operands:
        - name: ibm-licensing-operator
      registry: common-service
```
6. OperandRequest is failed due to `Failed` operandPhase for `ibm-licensing-operator`
```
    - name: ibm-licensing-operator
      phase:
        operandPhase: Failed
        operatorPhase: Running
  phase: Failed
```
7. ODLM pod reports error msg
```
E0210 05:16:15.048563 1 operandrequest_controller.go:146] failed to reconcile Operands for OperandRequest cp4i/example-service: the following errors occurred:
- the following errors occurred:
- failed to get the custom resource cp4i/instance: ibmlicensings.operator.ibm.com "instance" is forbidden: User "system:serviceaccount:cp4i:operand-deployment-lifecycle-manager" cannot get resource "ibmlicensings" in API group "operator.ibm.com" at the cluster scope
```

### Root cause
When we do not want to create a resource for operator, we will not define it in the OperandConfig.

But if this resource exists in the CSV's `alm-example`, ODLM will still try to look for it in the cluster no matter how OperandConfig is configured.

However, ODLM does not have cluster permission to get `IBMLicensing` Resource.

### Verify the fix
1. Patch image for ODLM in CSV: `quay.io/opencloudio/odlm:4b1de60c`
2. Check ODLM's log, there is no error msg, instead warning msg only.
```
I0210 05:25:12.373461 1 operandbindinfo_controller.go:89] Reconciling OperandBindInfo: cp4i/management-ingress
W0210 05:25:12.448847 1 reconcile_operand.go:321] IBMLicensing in the alm-example doesn't exist in the OperandConfig for ibm-licensing-operator.v4.0.0
W0210 05:25:12.461982 1 reconcile_operand.go:321] IBMLicenseServiceReporter in the alm-example doesn't exist in the OperandConfig for ibm-licensing-operator.v4.0.0
```
3. Check the status of OperandRequest
```
    - name: ibm-licensing-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
  phase: Running
```

Signed-off-by: Daniel Fan <fanyuchensx@gmail.com>