### PR TITLE
update status for services marked as tombstone

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -170,7 +170,7 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		if apierrors.IsNotFound(err) {
 			if opt.SupportStatus == operatorv1alpha1.MaintainedSupportStatus {
 				requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opt.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
-				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorNotFound, operatorv1alpha1.ServiceNotFound, mu)
+				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, mu)
 			} else {
 				// Subscription does not exist, create a new one
 				if err = r.createSubscription(ctx, requestInstance, opt, registryKey); err != nil {


### PR DESCRIPTION
We will have services marked as tombstone showing `Running` Status for both operator and operand
```
status:
  members:
    - name: ibm-cert-manager-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
  phase: Running
```

Meanwhile, made some tradeoffs on `Conditions`, we will have no-op operators with
- the `Ready` condition to be `True`, showing `operator is ready`

```
status:
  conditions:
    - lastTransitionTime: '2023-02-15T20:39:28Z'
      lastUpdateTime: '2023-02-15T20:39:28Z'
      message: operator ibm-cert-manager-operator is ready
      reason: operator is ready
      status: 'True'
      type: Ready
```

- the `NotFound` condition to be `Ture`, showing `operator is in maintenance status`
```
status:
  conditions:
    - lastTransitionTime: '2023-02-15T20:39:28Z'
      lastUpdateTime: '2023-02-15T20:39:28Z'
      message: ibm-cert-manager-operator is in maintenance status
      reason: operandregistry is not suitable
      status: 'True'
      type: NotFound
```