### PR TITLE
add new value no-op in installmode replace supportStatus

### DIFF
--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -40,6 +40,7 @@ type Operator struct {
 	// Valid values are:
 	// - "namespace" (default): operator is deployed in namespace of OperandRegistry;
 	// - "cluster": operator is deployed in "openshift-operators" namespace;
+	// - "no-op": operator is not supported to be fresh deployed;
 	// +optional
 	InstallMode string `json:"installMode,omitempty"`
 	// The namespace in which operator should be deployed when InstallMode is empty or set to "namespace".
@@ -71,12 +72,6 @@ type Operator struct {
 	// SubscriptionConfig is used to override operator configuration.
 	// +optional
 	SubscriptionConfig *olmv1alpha1.SubscriptionConfig `json:"subscriptionConfig,omitempty"`
-	// SupportStatus is used to indicate the support status for services.
-	// Valid values are:
-	// - "continuous" (default): operator is supported to be fresh deployed via OperandRequest from scratch
-	// - "maintained" operator is not supported to be fresh deployed via OperandRequest, only upgrade and deletion are allowed
-	// +optional
-	SupportStatus string `json:"supportStatus,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=public;private
@@ -96,13 +91,8 @@ const (
 	InstallModeCluster string = "cluster"
 	// InstallModeNamespace means install the operator in one namespace mode.
 	InstallModeNamespace string = "namespace"
-)
-
-const (
-	// MaintainedSupportStatus means NOT supporting fresh deployment for the operator
-	MaintainedSupportStatus string = "maintained"
-	// ContinuousSupportStatus means supporting fresh deployment for the operator
-	ContinuousSupportStatus string = "continuous"
+	// InstallModeNoop means not create the subscription for the operator
+	InstallModeNoop string = "no-op"
 )
 
 // OperandRegistrySpec defines the desired state of OperandRegistry.

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -27,6 +27,7 @@ import (
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 
 // Operator defines the desired state of Operators.
+// +kubebuilder:pruning:PreserveUnknownFields
 type Operator struct {
 	// A unique name for the operator whose operand may be deployed.
 	Name string `json:"name"`
@@ -100,7 +101,6 @@ type OperandRegistrySpec struct {
 	// Operators is a list of operator OLM definition.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Operators Registry List"
 	// +optional
-	// +kubebuilder:pruning:PreserveUnknownFields
 	Operators []Operator `json:"operators,omitempty"`
 }
 

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -100,6 +100,7 @@ type OperandRegistrySpec struct {
 	// Operators is a list of operator OLM definition.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Operators Registry List"
 	// +optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Operators []Operator `json:"operators,omitempty"`
 }
 

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -63,10 +63,12 @@ spec:
                       description: Description of a common service.
                       type: string
                     installMode:
-                      description: 'The install mode of an operator, either namespace
-                        or cluster. Valid values are: - "namespace" (default): operator
+                      description: 'The install mode of an operator, could be namespace, 
+                        cluster or no-op. Valid values are: - "namespace" (default): operator
                         is deployed in namespace of OperandRegistry; - "cluster":
-                        operator is deployed in "openshift-operators" namespace;'
+                        operator is deployed in "openshift-operators" namespace; - "no-op":
+                        operator is not supported to be fresh deployed via OperandRequest, 
+                        only upgrade and deletion are allowed;'
                       type: string
                     installPlanApproval:
                       description: 'Approval mode for emitted InstallPlans. Valid
@@ -2026,14 +2028,6 @@ spec:
                             type: object
                           type: array
                       type: object
-                    supportStatus:
-                      description: 'SupportStatus is used to indicate the support
-                        status for services. Valid values are: - "continuous" (default):
-                        operator is supported to be fresh deployed via OperandRequest
-                        from scratch - "maintained" operator is not supported to be
-                        fresh deployed via OperandRequest, only upgrade and deletion
-                        are allowed'
-                      type: string
                     targetNamespaces:
                       description: The target namespace of the OperatorGroups.
                       items:

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -2038,6 +2038,7 @@ spec:
                   - name
                   - packageName
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
             type: object
             x-kubernetes-preserve-unknown-fields: true

--- a/common/config/.golangci.yml
+++ b/common/config/.golangci.yml
@@ -1,6 +1,6 @@
 service:
   # When updating this, also update the version stored in docker/build-tools/Dockerfile in the multicloudlab/tools repo.
-  golangci-lint-version: 1.18.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   deadline: 20m

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -61,10 +61,12 @@ spec:
                       description: Description of a common service.
                       type: string
                     installMode:
-                      description: 'The install mode of an operator, either namespace
-                        or cluster. Valid values are: - "namespace" (default): operator
+                      description: 'The install mode of an operator, could be namespace
+                        cluster, or no-op. Valid values are: - "namespace" (default): operator
                         is deployed in namespace of OperandRegistry; - "cluster":
-                        operator is deployed in "openshift-operators" namespace;'
+                        operator is deployed in "openshift-operators" namespace; - "no-op":
+                        operator is not supported to be fresh deployed via OperandRequest, 
+                        only upgrade and deletion are allowed;'
                       type: string
                     installPlanApproval:
                       description: 'Approval mode for emitted InstallPlans. Valid
@@ -2024,14 +2026,6 @@ spec:
                             type: object
                           type: array
                       type: object
-                    supportStatus:
-                      description: 'SupportStatus is used to indicate the support
-                        status for services. Valid values are: - "continuous" (default):
-                        operator is supported to be fresh deployed via OperandRequest
-                        from scratch - "maintained" operator is not supported to be
-                        fresh deployed via OperandRequest, only upgrade and deletion
-                        are allowed'
-                      type: string
                     targetNamespaces:
                       description: The target namespace of the OperatorGroups.
                       items:

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -2036,8 +2036,8 @@ spec:
                   - name
                   - packageName
                   type: object
+                  x-kubernetes-preserve-unknown-fields: true
                 type: array
-                x-kubernetes-preserve-unknown-fields: true
             type: object
             x-kubernetes-preserve-unknown-fields: true
           status:

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -2037,6 +2037,7 @@ spec:
                   - packageName
                   type: object
                 type: array
+                x-kubernetes-preserve-unknown-fields: true
             type: object
             x-kubernetes-preserve-unknown-fields: true
           status:

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -168,7 +168,7 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			if opt.SupportStatus == operatorv1alpha1.MaintainedSupportStatus {
+			if opt.InstallMode == operatorv1alpha1.InstallModeNoop {
 				requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opt.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
 				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, mu)
 			} else {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -86,9 +86,6 @@ func (m *ODLMOperator) GetOperandRegistry(ctx context.Context, key types.Namespa
 		if o.Namespace == "" {
 			reg.Spec.Operators[i].Namespace = key.Namespace
 		}
-		if o.SupportStatus == "" {
-			reg.Spec.Operators[i].SupportStatus = apiv1alpha1.ContinuousSupportStatus
-		}
 		if o.SourceName == "" || o.SourceNamespace == "" {
 			catalogSourceName, catalogSourceNs, err := m.GetCatalogSourceFromPackage(ctx, o.PackageName, o.Namespace, o.Channel, key.Namespace, excludedCatalogSources)
 			if err != nil {

--- a/docs/design/operand-deployment-lifecycle-manager.md
+++ b/docs/design/operand-deployment-lifecycle-manager.md
@@ -73,7 +73,6 @@ spec:
     sourceNamespace: openshift-marketplace [9]
     installMode: cluster [10]
     installPlanApproval: Manual [11]
-    supportStatus: continuous [12]
 ```
 
 The OperandRegistry Custom Resource (CR) lists OLM Operator information for operands that may be requested for installation and/or access by an application that runs in a namespace. The registry CR specifies:
@@ -87,9 +86,8 @@ The OperandRegistry Custom Resource (CR) lists OLM Operator information for oper
 7. (optional) `scope` is an indicator, either public or private, that dictates whether deployment can be requested from other namespaces (public) or only from the namespace of this OperandRegistry (private). The default value is private.
 8. `sourceName` is the name of the CatalogSource.
 9. `sourceNamespace` is the namespace of the CatalogSource.
-10. (optional) `installMode` is the install mode of the operator, can be either `namespace` (OLM one namespace) or `cluster` (OLM all namespaces). The default value is `namespace`. Operator is deployed in `openshift-operators` namespace when InstallMode is set to `cluster`.
+10. (optional) `installMode` is the install mode of the operator, can be `namespace` (OLM one namespace), `cluster` (OLM all namespaces) or `no-op` (discontinued service). The default value is `namespace`. Operator is deployed in `openshift-operators` namespace when InstallMode is set to `cluster`.
 11. (optional) `installPlanApproval` is the approval mode for emitted installplan. The default value is `Automatic`.
-12. (optional) `supportStatus` is the support status for services. (1) When SupportStatus is `continous`, operator is supported to be fresh deployed via OperandRequest from scratch. (2) When SupportStatus is `maintained`, operator is not supported to be fresh deployed via OperandRequest, only upgrade and deletion are allowed. The default value is `continous`
 
 ## OperandConfig Spec
 


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57399
### Context

- Since CP2 OperandRegistry CRD is not fully forward compatibility, `supportStatus` value from CP3 OperandRegistry will be pruned if an CP2 OperandRegistry CRD is applied in the cluster.
- As a result, we are not able to keep `supportStatus` parameter alive when there is CP3 instance installed, instead there is a new value `installMode:no-op` will be introduced to replace the functionality of `supportStatus` parameter.
- If `installMode:no-op`: operator is not supported to be fresh deployed via OperandRequest, only upgrade and deletion are allowed.

### How to reproduce

1. Firstly, install IBM foundational services 4.0 (Topology C with `cloudpak-control` and `cloudpak-data` ns), and there will be `supportStatus` description in OperandRegistry CRD.
    ```
    supportStatus:
      description: >-
        SupportStatus is used to indicate the support status
        for services. Valid values are: - "continuous"
        (default): operator is supported to be fresh deployed
        via OperandRequest from scratch - "maintained"
        operator is not supported to be fresh deployed via
        OperandRequest, only upgrade and deletion are allowed
      type: string
    ```

    There is `supportStatus: maintained` in `common-service` OperandRegistry in `cloudpal-data` ns.
    ```
    spec:
      operators:
        - sourceNamespace: openshift-marketplace
          supportStatus: maintained        <------------
          channel: v3.23
          sourceName: opencloud-operators
          installPlanApproval: Automatic
          name: ibm-licensing-operator
          packageName: ibm-licensing-operator-app
          scope: public
          namespace: cloudpak-control
    ```
2. Secondly, install IBM foundational services 3.23.1 the `supportStatus` description in OperandRegistry CRD will be pruned.
    The`supportStatus: maintained` in `common-service` OperandRegistry in `cloudpal-data` ns is also been removed.
    ```
    spec:
      operators:
        - channel: v3.23
          installPlanApproval: Automatic
          name: ibm-licensing-operator
          namespace: cloudpak-control
          packageName: ibm-licensing-operator-app
          scope: public
          sourceName: opencloud-operators
          sourceNamespace: openshift-marketplace
    ```
### How to verify fix
1. Firstly, install IBM foundational services 4.0 with Topology C
2. Delete `common-service` OperandRegistry
3. Replaced cs and ODLM image with `quay.io/yuchen_shen/cs_operator:tombstone` and `quay.io/yuchen_shen/odlm:tombstone`

     new value `installMode:no-on` in Opreg:

    ```
    spec:
      operators:
        - sourceNamespace: openshift-marketplace
          channel: v3.23
          sourceName: opencloud-operators
          installPlanApproval: Automatic
          name: ibm-licensing-operator
          packageName: ibm-licensing-operator-app
          scope: public
          namespace: cloudpak-control
          installMode: no-op       <----------
    ```

    Type is `NotFound` in Opreq

    ```
    status:
      conditions:
          -  lastTransitionTime: '2023-03-13T21:35:03Z'
              lastUpdateTime: '2023-03-13T21:35:03Z'
              message: ibm-licensing-operator is in maintenance status    <----------
              reason: operandregistry is not suitable
              status: 'True'
              type: NotFound      <------------
    ```
4. Install foundational services 3.23.1, new `common-service` Opreq and Opreg will be created for CP2, and the origin Opreg and Opreq in `cloudpak-data` will not be changed.

