### PR TITLE
skip sub updating for discontinued services

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -199,9 +199,10 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		if opt.InstallMode == operatorv1alpha1.InstallModeNoop {
 			requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opt.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
 			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, mu)
-		} else {
+
 			//set operator channel back to previous one if it is tombstone service
 			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
+		} else {
 
 			sub.Spec.CatalogSource = opt.SourceName
 			sub.Spec.CatalogSourceNamespace = opt.SourceNamespace

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -232,14 +232,9 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 			if err = r.updateSubscription(ctx, requestInstance, sub); err != nil {
 				requestInstance.SetMemberStatus(opt.Name, operatorv1alpha1.OperatorFailed, "", mu)
 				return err
+			}
+			requestInstance.SetMemberStatus(opt.Name, operatorv1alpha1.OperatorUpdating, "", mu)
 		}
-
-		// Subscription updates for not discontinued services
-		if err = r.updateSubscription(ctx, requestInstance, sub); err != nil {
-			requestInstance.SetMemberStatus(opt.Name, operatorv1alpha1.OperatorFailed, "", mu)
-			return err
-		}
-		requestInstance.SetMemberStatus(opt.Name, operatorv1alpha1.OperatorUpdating, "", mu)
 	} else {
 		// Subscription existing and not managed by OperandRequest controller
 		klog.V(1).Infof("Subscription %s in namespace %s isn't created by ODLM. Ignore update/delete it.", sub.Name, sub.Namespace)

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -194,13 +194,15 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		}
 		sub.Annotations[registryKey.Namespace+"."+registryKey.Name+"/registry"] = "true"
 		sub.Annotations[registryKey.Namespace+"."+registryKey.Name+"/config"] = "true"
+		sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = opt.Channel
 
 		if opt.InstallMode == operatorv1alpha1.InstallModeNoop {
 			requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opt.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
 			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, mu)
 		} else {
-			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = opt.Channel
-
+			//set operator channel back to previous one if it is tombstone service
+			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
+			
 			sub.Spec.CatalogSource = opt.SourceName
 			sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
 			sub.Spec.Package = opt.PackageName

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -194,12 +194,13 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		}
 		sub.Annotations[registryKey.Namespace+"."+registryKey.Name+"/registry"] = "true"
 		sub.Annotations[registryKey.Namespace+"."+registryKey.Name+"/config"] = "true"
-		sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = opt.Channel
 
 		if opt.InstallMode == operatorv1alpha1.InstallModeNoop {
 			requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opt.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
 			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, mu)
 		} else {
+			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = opt.Channel
+
 			sub.Spec.CatalogSource = opt.SourceName
 			sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
 			sub.Spec.Package = opt.PackageName

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -202,7 +202,7 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		} else {
 			//set operator channel back to previous one if it is tombstone service
 			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
-			
+
 			sub.Spec.CatalogSource = opt.SourceName
 			sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
 			sub.Spec.Package = opt.PackageName


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57777
### Context
If there is an direct upgrade from `v3.22` to `v4.0` for Bedrock in AirGap env, to avoid the channels of those discontinued services being switched to `v3.23` by ODLM, and blocking upgrade, we are going to let ODLM not update operator/subscription if their subscription already exist
