### PR TITLE
tolerate multi catalogsource for same service

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -204,10 +204,6 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
 		} else {
 
-			sub.Spec.CatalogSource = opt.SourceName
-			sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
-			sub.Spec.Package = opt.PackageName
-
 			// check request annotation in subscription, get all available channels
 			var semverlList []string
 			reg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/request`)
@@ -225,12 +221,20 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 				sub.Spec.Channel = semverlList[0]
 			}
 
-			if opt.InstallPlanApproval != "" && sub.Spec.InstallPlanApproval != opt.InstallPlanApproval {
-				sub.Spec.InstallPlanApproval = opt.InstallPlanApproval
+			// update the spec iff channel in sub matches channel in opreg
+			if sub.Spec.Channel == opt.Channel {
+				sub.Spec.CatalogSource = opt.SourceName
+				sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
+				sub.Spec.Package = opt.PackageName
+
+				if opt.InstallPlanApproval != "" && sub.Spec.InstallPlanApproval != opt.InstallPlanApproval {
+					sub.Spec.InstallPlanApproval = opt.InstallPlanApproval
+				}
+				if opt.SubscriptionConfig != nil {
+					sub.Spec.Config = opt.SubscriptionConfig
+				}
 			}
-			if opt.SubscriptionConfig != nil {
-				sub.Spec.Config = opt.SubscriptionConfig
-			}
+
 		}
 		if compareSub(sub, originalSub) {
 			if err = r.updateSubscription(ctx, requestInstance, sub); err != nil {


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/57978
#### Issue
Upgrade path: v3.22 -> v4.0, catalogsource has been updated to v4 catalogsource in `ibm-iam-operator` sub, even the channel in spec is still `v3.22`
#### Verify
**Case I** 
1. Test image: `quay.io/yuchen_shen/odlm:update_catalogsource`
2. `sub.Spec.source` will keep the old catalogsource 

**Case II**
1. try to change `im-operator` channel back to `v3.22` in opreg
2. apply test image and `sub.Spec.source` will updated to the new one