### PR TITLE
Remove annotation patch to avoid status lost

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -474,10 +474,10 @@ func (r *OperandRequest) setOperandReadyCondition(operandPhase ServicePhase, nam
 }
 
 // FreshMemberStatus cleanup Member status from the Member status list.
-func (r *OperandRequest) FreshMemberStatus(failedDeletedOperands *gset.Set) {
+func (r *OperandRequest) FreshMemberStatus(remainingOp *gset.Set) {
 	newMembers := []MemberStatus{}
 	for index, m := range r.Status.Members {
-		if foundOperand(r.Spec.Requests, m.Name) || (*failedDeletedOperands).Contains(m.Name) {
+		if foundOperand(r.Spec.Requests, m.Name) || (*remainingOp).Contains(m.Name) {
 			newMembers = append(newMembers, r.Status.Members[index])
 		}
 	}

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -208,7 +208,10 @@ func (r *Reconciler) addFinalizer(ctx context.Context, cr *operatorv1alpha1.Oper
 
 func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
 	klog.V(1).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
-	failedDeletedOperands := gset.NewSet()
+	remainingOperands := gset.NewSet()
+	for _, m := range requestInstance.Status.Members {
+		remainingOperands.Add(m.Name)
+	}
 	existingSub := &olmv1alpha1.SubscriptionList{}
 
 	opts := []client.ListOption{
@@ -222,7 +225,7 @@ func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operat
 		return nil
 	}
 	// Delete all the subscriptions that created by current request
-	if err := r.absentOperatorsAndOperands(ctx, requestInstance, &failedDeletedOperands); err != nil {
+	if err := r.absentOperatorsAndOperands(ctx, requestInstance, &remainingOperands); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
When controller patches the `metadata` section for OperandRequest, it actually overwrites its status section as well which is not expected.
Here is an example, when I add new `ibm-cert-manager-operator` into `.spec`, controller adds it into `requestInstance.status.members` section before patching.
However, this new added field in `status` disappears after patching `metadata` section.

```
I0330 02:40:45.011550 1 reconcile_operator.go:117] Before Patch, requestInstance status is [{ibm-im-operator {Running Running} []} {ibm-cert-manager-operator {Installing } []}]
I0330 02:40:45.011577 1 reconcile_operator.go:122] After Patch, requestInstance status is [{ibm-im-operator {Running Running} []}]
```

After some evaluations, I noticed that there is no really usage on this annotation `operator.ibm.com/operandregistry-is-not-found: 'false'`. If the `OperandRegistry` is not found, it be reflected from OperandRequest `status`.
As a result, I remove this annotation from OperandRequest in order to avoid any data loss on OperandRequest status which has highly impact on installation and uninstallation
