### PR TITLE
check for status.services, im service status

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -495,6 +495,10 @@ func foundOperand(requests []Request, name string) bool {
 	return false
 }
 
+func (r *OperandRequest) operandRequested(name string) bool {
+	return foundOperand(r.Spec.Requests, name)
+}
+
 func getMemberStatus(status *OperandRequestStatus, name string) (int, *MemberStatus) {
 	for i, m := range status.Members {
 		if name == m.Name {

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -495,7 +495,7 @@ func foundOperand(requests []Request, name string) bool {
 	return false
 }
 
-func (r *OperandRequest) operandRequested(name string) bool {
+func (r *OperandRequest) OperandRequested(name string) bool {
 	return foundOperand(r.Spec.Requests, name)
 }
 

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -653,7 +653,7 @@ func (r *OperandRequest) UpdateLabels() bool {
 
 func (r *OperandRequest) CheckServiceStatus() bool {
 	requeue := false
-	monitoredServices := []string{"ibm-iam-operator", "ibm-commonui-operator", "ibm-mongodb-operator", "ibm-im-operator"}
+	monitoredServices := []string{"ibm-iam-operator", "ibm-idp-config-ui-operator", "ibm-mongodb-operator", "ibm-im-operator"}
 	servicesRequested := false
 	for _, serviceName := range monitoredServices {
 		if foundOperand(r.Spec.Requests, serviceName) {

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -495,10 +496,6 @@ func foundOperand(requests []Request, name string) bool {
 	return false
 }
 
-func (r *OperandRequest) OperandRequested(name string) bool {
-	return foundOperand(r.Spec.Requests, name)
-}
-
 func getMemberStatus(status *OperandRequestStatus, name string) (int, *MemberStatus) {
 	for i, m := range status.Members {
 		if name == m.Name {
@@ -652,6 +649,59 @@ func (r *OperandRequest) UpdateLabels() bool {
 		}
 	}
 	return isUpdated
+}
+
+func (r *OperandRequest) CheckServiceStatus() bool {
+	requeue := false
+	monitoredServices := []string{"ibm-iam-operator", "ibm-commonui-operator", "ibm-mongodb-operator", "ibm-im-operator"}
+	servicesRequested := false
+	for _, serviceName := range monitoredServices {
+		if foundOperand(r.Spec.Requests, serviceName){
+			servicesRequested = true
+			break
+		}
+	}
+	if servicesRequested {
+		if len(r.Status.Services) == 0  {
+			klog.Info("Waiting for status.services to be instantiated ...")
+			requeue = true
+			return requeue
+		} else {
+			// var IMOrIAM string
+			exists := false
+			if foundOperand(r.Spec.Requests, "ibm-iam-operator") {
+				// IMOrIAM = "ibm-iam-operator"
+				exists = true
+			} else if foundOperand(r.Spec.Requests, "ibm-im-operator") {
+				// IMOrIAM = "ibm-im-operator"
+				exists = true
+			}
+
+			if exists {
+				var imIndex int
+				found := false
+				for i, s := range r.Status.Services {
+					if "ibm-iam-operator" == s.OperatorName { //eventually this should be changed to the variable but the operator name is still listed as iam in practice even when im is requested
+						found = true
+						imIndex = i
+						break
+					}
+				}
+				if found {
+					if r.Status.Services[imIndex].Status != "Ready" {
+						klog.Info("Waiting for IM service to be Ready ...")
+						requeue = true
+						return requeue
+					}
+				} else {
+					klog.Info("Waiting for IM service status ...")
+					requeue = true
+					return requeue
+				}
+			}
+		}
+	}
+	return requeue
 }
 
 // GetAllRegistryReconcileRequest gets all the Registry ReconcileRequest.

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -656,48 +656,47 @@ func (r *OperandRequest) CheckServiceStatus() bool {
 	monitoredServices := []string{"ibm-iam-operator", "ibm-commonui-operator", "ibm-mongodb-operator", "ibm-im-operator"}
 	servicesRequested := false
 	for _, serviceName := range monitoredServices {
-		if foundOperand(r.Spec.Requests, serviceName){
+		if foundOperand(r.Spec.Requests, serviceName) {
 			servicesRequested = true
 			break
 		}
 	}
 	if servicesRequested {
-		if len(r.Status.Services) == 0  {
+		if len(r.Status.Services) == 0 {
 			klog.Info("Waiting for status.services to be instantiated ...")
 			requeue = true
 			return requeue
-		} else {
-			// var IMOrIAM string
-			exists := false
-			if foundOperand(r.Spec.Requests, "ibm-iam-operator") {
-				// IMOrIAM = "ibm-iam-operator"
-				exists = true
-			} else if foundOperand(r.Spec.Requests, "ibm-im-operator") {
-				// IMOrIAM = "ibm-im-operator"
-				exists = true
-			}
+		}
+		// var IMOrIAM string
+		exists := false
+		if foundOperand(r.Spec.Requests, "ibm-iam-operator") {
+			// IMOrIAM = "ibm-iam-operator"
+			exists = true
+		} else if foundOperand(r.Spec.Requests, "ibm-im-operator") {
+			// IMOrIAM = "ibm-im-operator"
+			exists = true
+		}
 
-			if exists {
-				var imIndex int
-				found := false
-				for i, s := range r.Status.Services {
-					if "ibm-iam-operator" == s.OperatorName { //eventually this should be changed to the variable but the operator name is still listed as iam in practice even when im is requested
-						found = true
-						imIndex = i
-						break
-					}
+		if exists {
+			var imIndex int
+			found := false
+			for i, s := range r.Status.Services {
+				if "ibm-iam-operator" == s.OperatorName { //eventually this should be changed to the variable but the operator name is still listed as iam in practice even when im is requested
+					found = true
+					imIndex = i
+					break
 				}
-				if found {
-					if r.Status.Services[imIndex].Status != "Ready" {
-						klog.Info("Waiting for IM service to be Ready ...")
-						requeue = true
-						return requeue
-					}
-				} else {
-					klog.Info("Waiting for IM service status ...")
+			}
+			if found {
+				if r.Status.Services[imIndex].Status != "Ready" {
+					klog.Info("Waiting for IM service to be Ready ...")
 					requeue = true
 					return requeue
 				}
+			} else {
+				klog.Info("Waiting for IM service status ...")
+				requeue = true
+				return requeue
 			}
 		}
 	}

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -157,7 +157,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	if requestInstance.CheckServiceStatus() {
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	}
-	
+
 	klog.V(1).Infof("Finished reconciling OperandRequest: %s", req.NamespacedName)
 	return ctrl.Result{RequeueAfter: constant.DefaultSyncPeriod}, nil
 }

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -153,34 +153,54 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	}
 
-	//need to make sure the services section is present, justt checking length may not be enough
-	if len(requestInstance.Status.Services) == 0  {
-		klog.Info("Waiting for status.services to be instantiated ...")
-		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
-	} else {
-		if requestInstance.OperandRequested("ibm-im-operator") {
-			var imIndex int
-			found := false
-			for i, s := range requestInstance.Status.Services {
-				if "ibm-im-operator" == s.OperatorName {
-					found = true
-					imIndex = i
-					break
-				}
+	//need to make sure the services section is present, just checking length may not be enough
+	//need to make this accept that there may not be commonui, mongo or im requested
+	//Services that can output a status.service to be included in OperandRequest
+	monitoredServices := []string{"ibm-iam-operator", "ibm-commonui-operator", "ibm-mongodb-operator", "ibm-im-operator"}
+	servicesRequested := false
+	for _, serviceName := range MonitoredServices {
+		if requestInstance.OperandRequested(serviceName){
+			servicesRequested = true
+			break
+		}
+	}
+	if servicesRequested {
+		if len(requestInstance.Status.Services) == 0  {
+			klog.Info("Waiting for status.services to be instantiated ...")
+			return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
+		} else {
+			var IMOrIAM string
+			exists := false
+			if requestInstance.OperandRequested("ibm-iam-operator") {
+				IMOrIAM = "ibm-iam-operator"
+				exists = true
+			} else if requestInstance.OperandRequested("ibm-im-operator") {
+				IMOrIAM = "ibm-im-operator"
+				exists = true
 			}
-			if found == true {
-				if requestInstance.Status.Services[imIndex].Status != "Ready" {
-					klog.Info("Waiting for IM service to be Ready ...")
+			if exists {
+				var imIndex int
+				found := false
+				for i, s := range requestInstance.Status.Services {
+					if "ibm-iam-operator" == s.OperatorName { //eventually this should be changed to the variable but the operator name is still listed as iam in practice even when im is requested
+						found = true
+						imIndex = i
+						break
+					}
+				}
+				if found == true {
+					if requestInstance.Status.Services[imIndex].Status != "Ready" {
+						klog.Info("Waiting for IM service to be Ready ...")
+						return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
+					}
+				} else {
+					klog.Info("Waiting for IM service status ...")
 					return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 				}
-			} else {
-				klog.Info("Waiting for IM service status ...")
-				return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 			}
 		}
-		
 	}
-
+	
 	klog.V(1).Infof("Finished reconciling OperandRequest: %s", req.NamespacedName)
 	return ctrl.Result{RequeueAfter: constant.DefaultSyncPeriod}, nil
 }

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -158,24 +158,27 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		klog.Info("Waiting for status.services to be instantiated ...")
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	} else {
-		var imIndex int
-		found := false
-		for i, s := range requestInstance.Status.Services {
-			if "ibm-im-operator" == s.OperatorName {
-				found = true
-				imIndex = i
-				break
+		if requestInstance.operandRequested("ibm-im-operator") {
+			var imIndex int
+			found := false
+			for i, s := range requestInstance.Status.Services {
+				if "ibm-im-operator" == s.OperatorName {
+					found = true
+					imIndex = i
+					break
+				}
 			}
-		}
-		if found == true {
-			if requestInstance.Status.Services[imIndex].Status != "Ready" {
-				klog.Info("Waiting for IM service to be Ready ...")
+			if found == true {
+				if requestInstance.Status.Services[imIndex].Status != "Ready" {
+					klog.Info("Waiting for IM service to be Ready ...")
+					return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
+				}
+			} else {
+				klog.Info("Waiting for IM service status ...")
 				return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 			}
-		} else {
-			klog.Info("Waiting for IM service status ...")
-			return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 		}
+		
 	}
 
 	klog.V(1).Infof("Finished reconciling OperandRequest: %s", req.NamespacedName)

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	//Services that can output a status.service to be included in OperandRequest
 	monitoredServices := []string{"ibm-iam-operator", "ibm-commonui-operator", "ibm-mongodb-operator", "ibm-im-operator"}
 	servicesRequested := false
-	for _, serviceName := range MonitoredServices {
+	for _, serviceName := range monitoredServices {
 		if requestInstance.OperandRequested(serviceName){
 			servicesRequested = true
 			break
@@ -169,15 +169,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			klog.Info("Waiting for status.services to be instantiated ...")
 			return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 		} else {
-			var IMOrIAM string
+			// var IMOrIAM string
 			exists := false
 			if requestInstance.OperandRequested("ibm-iam-operator") {
-				IMOrIAM = "ibm-iam-operator"
+				// IMOrIAM = "ibm-iam-operator"
 				exists = true
 			} else if requestInstance.OperandRequested("ibm-im-operator") {
-				IMOrIAM = "ibm-im-operator"
+				// IMOrIAM = "ibm-im-operator"
 				exists = true
 			}
+
 			if exists {
 				var imIndex int
 				found := false

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -153,6 +153,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	}
 
+	//need to make sure the services section is present, justt checking length may not be enough
+	if len(requestInstance.Status.Services) == 0  {
+		klog.Info("Waiting for status.services to be instantiated ...")
+		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
+	} else {
+		var imIndex int
+		found := false
+		for i, s := range requestInstance.Status.Services {
+			if "ibm-im-operator" == s.OperatorName {
+				found = true
+				imIndex = i
+				break
+			}
+		}
+		if found == true {
+			if requestInstance.Status.Services[imIndex].Status != "Ready" {
+				klog.Info("Waiting for IM service to be Ready ...")
+				return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
+			}
+		} else {
+			klog.Info("Waiting for IM service status ...")
+			return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
+		}
+	}
+
 	klog.V(1).Infof("Finished reconciling OperandRequest: %s", req.NamespacedName)
 	return ctrl.Result{RequeueAfter: constant.DefaultSyncPeriod}, nil
 }

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -158,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		klog.Info("Waiting for status.services to be instantiated ...")
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	} else {
-		if requestInstance.operandRequested("ibm-im-operator") {
+		if requestInstance.OperandRequested("ibm-im-operator") {
 			var imIndex int
 			found := false
 			for i, s := range requestInstance.Status.Services {


### PR DESCRIPTION
Issue 58155 has found that ODLM may not instantiate status.services on first pass through for reconciling an operandrequest. This pr adds a check to see if status.service exists and to see if im is ready. If either of these checks fails, the operandrequest is requeued.

I have been testing the changes with a 4.0 deployment and so far so good. I'm going to try cleaning it up before merging as it's a little ugly compared to the other checks here.

Testing:
- install bedrock 4.0, just cs operator and odlm
- replace odlm image with this one (can build with makefile or ask me and I'll send you an image)
- create operand request with just im
- watch im operand request, make sure it is eventually (in a relatively short time frame) updated to include status.services
- watch odlm logs to see if it's behaving as expected
- im opreq will create ibm-iam-request that has common ui and mongo, watch to make sure this opreq eventually has its status.service as well. It should not have the "waiting on im" log message in odlm

To rerun, you can delete the operandrequests, wait for everything to uninstall, then re-create the im operandrequest

Note: DO NOT restart the odlm operator after applying the operand request. It is a workaround in making sure the operand requests are reconciled to include status.service and could muddy the results of the test.