### PR TITLE
Remove the status.services entry for an operator if it is removed from an operandrequest

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -410,6 +410,15 @@ func (r *OperandRequest) RemoveMemberCRStatus(name, CRName, CRKind string, mu sy
 	}
 }
 
+func (r *OperandRequest) RemoveServiceStatus(operatorName string, mu sync.Locker){
+	mu.Lock()
+	defer mu.Unlock()
+	pos, s := getServiceStatus(&r.Status, operatorName)
+	if s != nil {
+		r.Status.Services = append(r.Status.Services[:pos], r.Status.Services[pos+1:]...)
+	}
+}
+
 func (r *OperandRequest) SetServiceStatus(ctx context.Context, service ServiceStatus, updater client.StatusClient, mu sync.Locker) error {
 	mu.Lock()
 	defer mu.Unlock()

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -676,13 +676,13 @@ func (r *OperandRequest) CheckServiceStatus() bool {
 			requeue = true
 			return requeue
 		}
-		// var IMOrIAM string
+		var IMOrIAM string
 		exists := false
 		if foundOperand(r.Spec.Requests, "ibm-iam-operator") {
-			// IMOrIAM = "ibm-iam-operator"
+			IMOrIAM = "ibm-iam-operator"
 			exists = true
 		} else if foundOperand(r.Spec.Requests, "ibm-im-operator") {
-			// IMOrIAM = "ibm-im-operator"
+			IMOrIAM = "ibm-im-operator"
 			exists = true
 		}
 
@@ -690,7 +690,7 @@ func (r *OperandRequest) CheckServiceStatus() bool {
 			var imIndex int
 			found := false
 			for i, s := range r.Status.Services {
-				if "ibm-iam-operator" == s.OperatorName { //eventually this should be changed to the variable but the operator name is still listed as iam in practice even when im is requested
+				if IMOrIAM == s.OperatorName { //eventually this should be changed to the variable but the operator name is still listed as iam in practice even when im is requested
 					found = true
 					imIndex = i
 					break

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -410,7 +410,7 @@ func (r *OperandRequest) RemoveMemberCRStatus(name, CRName, CRKind string, mu sy
 	}
 }
 
-func (r *OperandRequest) RemoveServiceStatus(operatorName string, mu sync.Locker){
+func (r *OperandRequest) RemoveServiceStatus(operatorName string, mu sync.Locker) {
 	mu.Lock()
 	defer mu.Unlock()
 	pos, s := getServiceStatus(&r.Status, operatorName)

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -537,6 +537,7 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 				return
 			}
 			requestInstance.RemoveMemberCRStatus(operatorName, opdMember.Name, opdMember.Kind, &r.Mutex)
+			requestInstance.RemoveServiceStatus(operatorName, &r.Mutex)
 		}()
 	}
 	wg.Wait()
@@ -885,6 +886,7 @@ func (r *Reconciler) checkCustomResource(ctx context.Context, requestInstance *o
 				return
 			}
 			requestInstance.RemoveMemberCRStatus(operatorName, opdMember.Name, opdMember.Kind, &r.Mutex)
+			requestInstance.RemoveServiceStatus(operatorName, &r.Mutex)
 		}()
 	}
 	wg.Wait()

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -537,7 +537,6 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 				return
 			}
 			requestInstance.RemoveMemberCRStatus(operatorName, opdMember.Name, opdMember.Kind, &r.Mutex)
-			requestInstance.RemoveServiceStatus(operatorName, &r.Mutex)
 		}()
 	}
 	wg.Wait()
@@ -886,7 +885,6 @@ func (r *Reconciler) checkCustomResource(ctx context.Context, requestInstance *o
 				return
 			}
 			requestInstance.RemoveMemberCRStatus(operatorName, opdMember.Name, opdMember.Kind, &r.Mutex)
-			requestInstance.RemoveServiceStatus(operatorName, &r.Mutex)
 		}()
 	}
 	wg.Wait()

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -423,6 +423,7 @@ func (r *Reconciler) absentOperatorsAndOperands(ctx context.Context, requestInst
 					defer r.Mutex.Unlock()
 					merr.Add(err)
 				}
+				requestInstance.RemoveServiceStatus(fmt.Sprintf("%v", o), &r.Mutex)
 				(*remainingOperands).Remove(o)
 				remainingOp.Remove(o)
 			}()


### PR DESCRIPTION
Previously, if an operator was removed from an operandrequest, its status.services entry would persist. This pr changes that and makes sure the entry is cleaned up on removal. I also addressed the iam/im naming issue and made a change that prevents indefinite reconciling for an operandrequest with im operator instead of iam.

To test:
- install cp3.0
- create operandrequest for im and mongodb (this creates a second opreq that also has mongodb)
- make sure the opreq has the mongo status.services entry
- remove mongodb from the original opreq
- give odlm a minute
- check the opreq again, verify status.services entry for mongodb no longer exists