### PR TITLE
[LTSR] avoid OperandBindInfo label conflict

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -37,6 +37,9 @@ const (
 	//OpbiNameLabel is the label used to add OperandBindInfo name to the secrets/configmaps watched by ODLM
 	OpbiNameLabel string = "operator.ibm.com/watched-by-opbi-with-name"
 
+	//OpbiShareToNsNumber is the label used to add number of OperandBindInfo to the secrets/configmaps watched by ODLM
+	OpbiNumberLabel string = "operator.ibm.com/watched-by-opbi-with-number"
+
 	//OpbiTypeLabel is the label used to label if secrets/configmaps are "original" or "copy"
 	OpbiTypeLabel string = "operator.ibm.com/managedBy-opbi"
 

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -292,6 +292,10 @@ func (r *Reconciler) copySecret(ctx context.Context, sourceName, targetName, sou
 
 	labels := secret.GetLabels()
 
+	if secret.GetLabels()[constant.OpbiNsLabel] == bindInfoInstance.Namespace && secret.GetLabels()[constant.OpbiNameLabel] == bindInfoInstance.Name {
+		return false, nil
+	}
+
 	oldNumber, numberOK := labels[constant.OpbiNumberLabel]
 	var number string
 	var intVar int
@@ -406,6 +410,10 @@ func (r *Reconciler) copyConfigmap(ctx context.Context, sourceName, targetName, 
 		if err := r.refreshPods(targetNs, targetName, "configmap"); err != nil {
 			return false, errors.Wrapf(err, "failed to refresh pods mounting ConfigMap %s/%s", targetNs, targetName)
 		}
+	}
+
+	if cm.GetLabels()[constant.OpbiNsLabel] == bindInfoInstance.Namespace && cm.GetLabels()[constant.OpbiNameLabel] == bindInfoInstance.Name {
+		return false, nil
 	}
 
 	var intVar int

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -290,11 +290,13 @@ func (r *Reconciler) copySecret(ctx context.Context, sourceName, targetName, sou
 		}
 	}
 
-	lables := secret.GetLabels()
-	oldNumber, numberOK := lables[constant.OpbiNumberLabel]
+	labels := secret.GetLabels()
+
+	oldNumber, numberOK := labels[constant.OpbiNumberLabel]
 	var number string
+	var intVar int
 	if numberOK {
-		intVar, err := strconv.Atoi(oldNumber)
+		intVar, err = strconv.Atoi(oldNumber)
 		if err != nil {
 			klog.Errorf("failed to convert the string in secret %s in the namespace %s: %v", secret.Name, secret.Namespace, err)
 			return false, err
@@ -304,6 +306,12 @@ func (r *Reconciler) copySecret(ctx context.Context, sourceName, targetName, sou
 	} else {
 		oldNumber = "0"
 		number = "1"
+	}
+
+	for i := 0; i <= intVar; i++ {
+		if secret.GetLabels()[constant.OpbiNsLabel+strconv.Itoa(i)] == bindInfoInstance.Namespace && secret.GetLabels()[constant.OpbiNameLabel+strconv.Itoa(i)] == bindInfoInstance.Name {
+			return false, nil
+		}
 	}
 
 	ensureLabelsForSecret(secret, map[string]string{
@@ -400,6 +408,7 @@ func (r *Reconciler) copyConfigmap(ctx context.Context, sourceName, targetName, 
 		}
 	}
 
+	var intVar int
 	lables := cm.GetLabels()
 	oldNumber, numberOK := lables[constant.OpbiNumberLabel]
 	var number string
@@ -414,6 +423,12 @@ func (r *Reconciler) copyConfigmap(ctx context.Context, sourceName, targetName, 
 	} else {
 		oldNumber = "0"
 		number = "1"
+	}
+
+	for i := 0; i <= intVar; i++ {
+		if cm.GetLabels()[constant.OpbiNsLabel+strconv.Itoa(i)] == bindInfoInstance.Namespace && cm.GetLabels()[constant.OpbiNameLabel+strconv.Itoa(i)] == bindInfoInstance.Name {
+			return false, nil
+		}
 	}
 
 	ensureLabelsForConfigMap(cm, map[string]string{

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -301,7 +301,7 @@ func (r *Reconciler) copySecret(ctx context.Context, sourceName, targetName, sou
 			klog.Errorf("failed to convert the string in secret %s in the namespace %s: %v", secret.Name, secret.Namespace, err)
 			return false, err
 		}
-		intVar += 1
+		intVar++
 		number = strconv.Itoa(intVar)
 	} else {
 		oldNumber = "0"
@@ -418,7 +418,7 @@ func (r *Reconciler) copyConfigmap(ctx context.Context, sourceName, targetName, 
 			klog.Errorf("failed to convert the string in configmap: %s in the namespace %s: %v", cm.Name, cm.Namespace, err)
 			return false, err
 		}
-		intVar += 1
+		intVar++
 		number = strconv.Itoa(intVar)
 	} else {
 		oldNumber = "0"


### PR DESCRIPTION
for ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/58807
When two operandBindInfos are watching same secret/configmap, they are adding the same label to the secret/configmap ` operator.ibm.com/watched-by-opbi-with-name: ibm-licensing-bindinfo` 
This pr will try to fix it by adding a number after the label key

test:
1. install cs-operator and odlm
2. create two operandBindInfos for Licensing configmaps and secrets

expect result:
1. operandBindInfo will not fail
2. configmaps and secrets will be copied to another namespace
