### PR TITLE
[4.2] Sort Catalogsource by priority in ODLM

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -111,9 +111,9 @@ metadata:
       API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.1.0'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.24.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/operand-deployment-lifecycle-manager
     support: IBM
   labels:
@@ -539,6 +539,15 @@ spec:
     mediatype: image/png
   install:
     spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          verbs:
+          - get
+        serviceAccountName: operand-deployment-lifecycle-manager
       deployments:
       - label:
           app.kubernetes.io/instance: operand-deployment-lifecycle-manager

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -12,9 +12,9 @@ metadata:
       API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.1.0'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/operand-deployment-lifecycle-manager
     support: IBM
   labels:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,4 +1,14 @@
-
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: operand-deployment-lifecycle-manager
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -1,4 +1,17 @@
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: operand-deployment-lifecycle-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: operand-deployment-lifecycle-manager
+subjects:
+- kind: ServiceAccount
+  name: operand-deployment-lifecycle-manager
+  namespace: system
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operand-deployment-lifecycle-manager

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -107,6 +107,7 @@ type CatalogSource struct {
 	Namespace         string
 	OpNamespace       string
 	RegistryNamespace string
+	Priority          int
 }
 
 type sortableCatalogSource []CatalogSource
@@ -114,14 +115,7 @@ type sortableCatalogSource []CatalogSource
 func (s sortableCatalogSource) Len() int      { return len(s) }
 func (s sortableCatalogSource) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s sortableCatalogSource) Less(i, j int) bool {
-	// Check if the catalogsource is in the same namespace as OperandRegistry
-	inRegistryNsI, inRegistryNsJ := s[i].Namespace == s[i].RegistryNamespace, s[j].Namespace == s[j].RegistryNamespace
-	if inRegistryNsI && !inRegistryNsJ {
-		return true
-	}
-	if !inRegistryNsI && inRegistryNsJ {
-		return false
-	}
+
 	// Check if the catalogsource is in the same namespace as operator
 	inOpNsI, inOpNsJ := s[i].Namespace == s[i].OpNamespace, s[j].Namespace == s[j].OpNamespace
 	if inOpNsI && !inOpNsJ {
@@ -129,6 +123,12 @@ func (s sortableCatalogSource) Less(i, j int) bool {
 	}
 	if !inOpNsI && inOpNsJ {
 		return false
+	}
+	// Compare catalogsource priorities first, higher priority comes first
+	iPriority, jPriority := s[i].Priority, s[j].Priority
+	klog.Infof("iPriority: %v, jPriority: %v", iPriority, jPriority)
+	if iPriority != jPriority {
+		return iPriority > jPriority
 	}
 	// If their namespaces are the same, then compare the name of the catalogsource
 	if s[i].Namespace == s[j].Namespace {
@@ -164,7 +164,11 @@ func (m *ODLMOperator) GetCatalogSourceFromPackage(ctx context.Context, packageN
 			if !channelCheck(channel, pm.Status.Channels) || (excludedCatalogSources != nil && util.Contains(excludedCatalogSources, pm.Status.CatalogSource)) {
 				continue
 			}
-			catalogSourceCandidate = append(catalogSourceCandidate, CatalogSource{Name: pm.Status.CatalogSource, Namespace: pm.Status.CatalogSourceNamespace, OpNamespace: namespace, RegistryNamespace: registryNs})
+			catalogsource := &olmv1alpha1.CatalogSource{}
+			if err := m.Reader.Get(ctx, types.NamespacedName{Name: pm.Status.CatalogSource, Namespace: pm.Status.CatalogSourceNamespace}, catalogsource); err != nil {
+				klog.Warning(err)
+			}
+			catalogSourceCandidate = append(catalogSourceCandidate, CatalogSource{Name: pm.Status.CatalogSource, Namespace: pm.Status.CatalogSourceNamespace, OpNamespace: namespace, RegistryNamespace: registryNs, Priority: catalogsource.Spec.Priority})
 		}
 		if len(catalogSourceCandidate) == 0 {
 			klog.Errorf("Not found PackageManifest %s in the namespace %s has channel %s", packageName, namespace, channel)

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -126,7 +126,7 @@ func (s sortableCatalogSource) Less(i, j int) bool {
 	}
 	// Compare catalogsource priorities first, higher priority comes first
 	iPriority, jPriority := s[i].Priority, s[j].Priority
-	klog.Infof("iPriority: %v, jPriority: %v", iPriority, jPriority)
+	klog.V(2).Infof("iPriority: %v, jPriority: %v", iPriority, jPriority)
 	if iPriority != jPriority {
 		return iPriority > jPriority
 	}
@@ -167,6 +167,7 @@ func (m *ODLMOperator) GetCatalogSourceFromPackage(ctx context.Context, packageN
 			catalogsource := &olmv1alpha1.CatalogSource{}
 			if err := m.Reader.Get(ctx, types.NamespacedName{Name: pm.Status.CatalogSource, Namespace: pm.Status.CatalogSourceNamespace}, catalogsource); err != nil {
 				klog.Warning(err)
+				continue
 			}
 			catalogSourceCandidate = append(catalogSourceCandidate, CatalogSource{Name: pm.Status.CatalogSource, Namespace: pm.Status.CatalogSourceNamespace, OpNamespace: namespace, RegistryNamespace: registryNs, Priority: catalogsource.Spec.Priority})
 		}


### PR DESCRIPTION
for issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/54725
ODLM will prioritize CatalogSource for operator based on CatalogSource `.spec.priority` provided from OLM.

#### Current sequence of sorting order:

1. CatalogSources in the operator's namespace have a higher priority than those in other namespaces.
2. Within the same namespace, CatalogSources with higher priority values come first.
3. If both have the same namespace and priority, the CatalogSources are sorted based on their names in lexicographical order.

#### Test

1. test image: quay.io/yuchen_shen/odlm:catalog_prority
2. create `ibm-operator-catalog` in `openshift-marketplace` ns and give `.spec.priority` to `10`,  and same time create `cloud-native-postgresql-catalog` 
3. will see in sub `cloud-native-postgresql`, the catalogsource is `ibm-operator-catalog` as priority value 10 > 0(default)

