### PR TITLE
[4.2] delete Kubernetes resource with background propagation

### DIFF
--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mohae/deepcopy"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -331,7 +332,7 @@ func (r *Reconciler) deleteK8sReousce(ctx context.Context, k8sAPIVersion, k8sKin
 	} else {
 		if r.CheckLabel(k8sUnstruct, map[string]string{constant.OpreqLabel: "true"}) {
 			klog.V(3).Infof("Deleting k8s resource -- Kind: %s, NamespacedName: %s/%s", k8sKind, k8sNamespace, k8sName)
-			k8sDeleteError := r.Delete(ctx, &k8sUnstruct)
+			k8sDeleteError := r.Delete(ctx, &k8sUnstruct, client.PropagationPolicy(metav1.DeletePropagationBackground))
 			if k8sDeleteError != nil && !apierrors.IsNotFound(k8sDeleteError) {
 				return errors.Wrapf(k8sDeleteError, "failed to delete k8s resource -- Kind: %s, NamespacedName: %s/%s", k8sKind, k8sNamespace, k8sName)
 			}

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -33,6 +33,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -40,6 +41,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	"k8s.io/klog"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
@@ -1086,7 +1088,7 @@ func (r *Reconciler) deleteK8sResource(ctx context.Context, existingK8sRes unstr
 	} else {
 		if r.CheckLabel(k8sResShouldBeDeleted, map[string]string{constant.OpreqLabel: "true"}) && !r.CheckLabel(k8sResShouldBeDeleted, map[string]string{constant.NotUninstallLabel: "true"}) {
 			klog.V(3).Infof("Deleting k8s resource: %s from kind: %s", name, kind)
-			err := r.Delete(ctx, &k8sResShouldBeDeleted)
+			err := r.Delete(ctx, &k8sResShouldBeDeleted, client.PropagationPolicy(metav1.DeletePropagationBackground))
 			if err != nil && !apierrors.IsNotFound(err) {
 				return errors.Wrapf(err, "failed to delete k8s resource -- Kind: %s, NamespacedName: %s/%s", kind, namespace, name)
 			}


### PR DESCRIPTION
for issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/59717

#### Implement ####
- Using `background cascading deletion` to clean up the jobs and its related pods
- Set `DeletePropagationBackground` to specify the propagation policy for the deletion, this policy indicates that the deletion should happen in the background, and it won't wait for dependent resources to be deleted first.

#### Test ####

1. test image replaced in ODLM: quay.io/yuchen_shen/odlm:delete_job_pod
2. create single `cloud-native-postgresql-opreq` operandrequest, and waiting `postgresql-operator-controller-manager` and `create-postgres-license-config` two pods ready
3. delete `cloud-native-postgresql-opreq` operandrequest, will see two above pods are also deteled.

#### Reference ####

- [Garbage Collection](https://kubernetes.io/docs/concepts/architecture/garbage-collection/)
- [Use background cascading deletion](https://kubernetes.io/docs/tasks/administer-cluster/use-cascading-deletion/#use-background-cascading-deletion)
