### PR TITLE
handle operator namespace could be optional in OperandRegistry

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -79,9 +79,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	defer func() {
 		// get the latest instance from the server and check if the status has changed
 		existingInstance := &operatorv1alpha1.OperandRequest{}
-		if err := r.Client.Get(ctx, req.NamespacedName, existingInstance); err != nil {
+		if err := r.Client.Get(ctx, req.NamespacedName, existingInstance); err != nil && !apierrors.IsNotFound(err) {
 			// Error reading the latest object - requeue the request.
-			reconcileErr = utilerrors.NewAggregate([]error{reconcileErr, fmt.Errorf("error while get latest OperandRequest.Status from server: %v", err)})
+			reconcileErr = utilerrors.NewAggregate([]error{reconcileErr, fmt.Errorf("c from server: %v", err)})
 		}
 
 		if reflect.DeepEqual(existingInstance.Status, requestInstance.Status) {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -87,7 +87,7 @@ func (m *ODLMOperator) GetOperandRegistry(ctx context.Context, key types.Namespa
 			reg.Spec.Operators[i].Namespace = key.Namespace
 		}
 		if o.SourceName == "" || o.SourceNamespace == "" {
-			catalogSourceName, catalogSourceNs, err := m.GetCatalogSourceFromPackage(ctx, o.PackageName, o.Namespace, o.Channel, key.Namespace, excludedCatalogSources)
+			catalogSourceName, catalogSourceNs, err := m.GetCatalogSourceFromPackage(ctx, o.PackageName, reg.Spec.Operators[i].Namespace, o.Channel, key.Namespace, excludedCatalogSources)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fix bug for missing operator ns when retrieving CatalogSource from packagemanifest to address the ODLM permission issue
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60042
#### Verified
1. create keycloak operator in OperandReigstry without `namespace`
    ```
    - channel: stable
      installPlanApproval: Automatic
      name: edb-keycloak
      packageName: cloud-native-postgresql
      scope: public
    ```
2. get pending status for keycloak operandrequest
    ```
    status:
      members:
        - name: keycloak-operator
          phase:
            operandPhase: Not Found
            operatorPhase: Not Found
      phase: Pending
    ```
3. error msg in ODLM pod log
    ```
    E0821 04:58:58.540533 1 reconcile_operator.go:87] Failed to get suitable OperandRegistry keycloak-simple/keycloak-registry: packagemanifests.packages.operators.coreos.com "cloud-native-postgresql" is forbidden: User "system:serviceaccount:keycloak-simple:operand-deployment-lifecycle-manager" cannot list resource "packagemanifests" in API group "packages.operators.coreos.com" at the cluster scope
    E0821 04:58:58.541656 1 operandrequest_controller.go:148] failed to reconcile Operators for OperandRequest keycloak-simple/keycloak-request: packagemanifests.packages.operators.coreos.com "cloud-native-postgresql" is forbidden: User "system:serviceaccount:keycloak-simple:operand-deployment-lifecycle-manager" cannot list resource "packagemanifests" in API group "packages.operators.coreos.com" at the cluster scope
    E0821 04:58:58.551331 1 operandconfig_controller.go:83] failed to update the status for OperandConfig keycloak-simple/keycloak-registry : packagemanifests.packages.operators.coreos.com "cloud-native-postgresql" is forbidden: User "system:serviceaccount:keycloak-simple:operand-deployment-lifecycle-manager" cannot list resource "packagemanifests" in API group "packages.operators.coreos.com" at the cluster scope
    ```
4. fix the code, opreq status comes back to `running`.
     test image: quay.io/yuchen_shen/odlm:opreg_optn

