### PR TITLE
ODLM support concurrently reconciling multiple resources

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -740,7 +741,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	options := controller.Options{
+		MaxConcurrentReconciles: r.MaxConcurrentReconciles, // Set the desired value for max concurrent reconciles.
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&operatorv1alpha1.OperandBindInfo{}).
 		Watches(
 			&source.Kind{Type: &corev1.ConfigMap{}},

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -36,6 +36,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -398,7 +399,11 @@ func (r *Reconciler) getRequestToConfigMapper(ctx context.Context) handler.MapFu
 // SetupWithManager adds OperandConfig controller to the manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ctx := context.Background()
+	options := controller.Options{
+		MaxConcurrentReconciles: r.MaxConcurrentReconciles, // Set the desired value for max concurrent reconciles.
+	}
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&operatorv1alpha1.OperandConfig{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &operatorv1alpha1.OperandRequest{}}, handler.EnqueueRequestsFromMapFunc(r.getRequestToConfigMapper(ctx)), builder.WithPredicates(predicate.Funcs{
 			CreateFunc: func(e event.CreateEvent) bool {

--- a/controllers/operandregistry/operandregistry_controller.go
+++ b/controllers/operandregistry/operandregistry_controller.go
@@ -27,6 +27,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -114,7 +115,11 @@ func (r *Reconciler) updateStatus(ctx context.Context, instance *operatorv1alpha
 
 // SetupWithManager adds OperandRegistry controller to the manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	options := controller.Options{
+		MaxConcurrentReconciles: r.MaxConcurrentReconciles, // Set the desired value for max concurrent reconciles.
+	}
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&operatorv1alpha1.OperandRegistry{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &operatorv1alpha1.OperandRequest{}}, handler.EnqueueRequestsFromMapFunc(func(a client.Object) []reconcile.Request {
 			or := a.(*operatorv1alpha1.OperandRequest)

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -38,6 +38,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -300,7 +301,11 @@ func (r *Reconciler) getConfigToRequestMapper() handler.MapFunc {
 
 // SetupWithManager adds OperandRequest controller to the manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	options := controller.Options{
+		MaxConcurrentReconciles: r.MaxConcurrentReconciles, // Set the desired value for max concurrent reconciles.
+	}
 	return ctrl.NewControllerManagedBy(mgr).
+		WithOptions(options).
 		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&source.Kind{Type: &olmv1alpha1.Subscription{}}, handler.EnqueueRequestsFromMapFunc(r.getSubToRequestMapper()), builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -45,18 +45,20 @@ type ODLMOperator struct {
 	client.Client
 	client.Reader
 	*rest.Config
-	Recorder record.EventRecorder
-	Scheme   *runtime.Scheme
+	Recorder                record.EventRecorder
+	Scheme                  *runtime.Scheme
+	MaxConcurrentReconciles int
 }
 
 // NewODLMOperator is the method to initialize an Operator struct
 func NewODLMOperator(mgr manager.Manager, name string) *ODLMOperator {
 	return &ODLMOperator{
-		Client:   mgr.GetClient(),
-		Reader:   mgr.GetAPIReader(),
-		Config:   mgr.GetConfig(),
-		Recorder: mgr.GetEventRecorderFor(name),
-		Scheme:   mgr.GetScheme(),
+		Client:                  mgr.GetClient(),
+		Reader:                  mgr.GetAPIReader(),
+		Config:                  mgr.GetConfig(),
+		Recorder:                mgr.GetEventRecorderFor(name),
+		Scheme:                  mgr.GetScheme(),
+		MaxConcurrentReconciles: 5,
 	}
 }
 


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60041
ODLM should be capable of concurrently reconciling two or more OperandRequests to unblock the Keycloak uninstallation process

### Verify

1. Creates an OperandRequest requesting `keycloak-operator`
2. ODLM reconciles OperandRequest to create a new OperandRequest `edb-keycloak-request` to request `edb-keycloak`
3. ODLM reconcile OperandRequest `edb-keycloak-request` to create `edb-keycloak` operator and its operands.
4. Fail to uninstall the `keycloak-operator` even after deleting `keycloak-operator` from the OperandRequest and get error msg:

    ```
    failed to reconcile Operators for OperandRequest keycloak/common-service: the following errors occurred:
    - the following errors occurred:
    - failed to delete k8s resource -- Kind: OperandRequest, NamespacedName: keycloak/edb-keycloak-request: timed out waiting for the condition
    - timeout for cleaning up subscription keycloak-operator
    ```
5. apply the test image: quay.io/yuchen_shen/odlm:reconcile_multiresources
6. `edb-keycloak` and `keycloak-operator` are both deteled
    ```
    I0828 21:41:50.661952       1 reconcile_operator.go:465] Deleting the ClusterServiceVersion, Namespace: keycloak, Name: cloud-native-postgresql.v1.18.5
    I0828 21:41:50.690907       1 reconcile_operator.go:484] Subscription keycloak/edb-keycloak is deleted
    I0828 21:41:51.692470       1 reconcile_operator.go:465] Deleting the ClusterServiceVersion, Namespace: keycloak, Name: keycloak-operator.v22.0.1
    I0828 21:41:51.715218       1 reconcile_operator.go:484] Subscription keycloak/keycloak-operator is deleted 
    ```
### Reference

- Learning Concurrent Reconciling: https://openkruise.io/blog/learning-concurrent-reconciling/
   
