### PR TITLE
Add OperandBindinfo example into alm-example

### DIFF
--- a/api/v1alpha1/operandbindinfo_types.go
+++ b/api/v1alpha1/operandbindinfo_types.go
@@ -95,7 +95,8 @@ type OperandBindInfo struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Spec   OperandBindInfoSpec   `json:"spec,omitempty"`
+	Spec OperandBindInfoSpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandBindInfoStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -102,7 +102,8 @@ type OperandConfig struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Spec   OperandConfigSpec   `json:"spec,omitempty"`
+	Spec OperandConfigSpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandConfigStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -151,7 +151,8 @@ type OperandRegistry struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Spec   OperandRegistrySpec   `json:"spec,omitempty"`
+	Spec OperandRegistrySpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandRegistryStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -251,7 +251,8 @@ type OperandRequest struct {
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Spec   OperandRequestSpec   `json:"spec,omitempty"`
+	Spec OperandRequestSpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandRequestStatus `json:"status,omitempty"`
 }
 

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -6,6 +6,29 @@ metadata:
       [
         {
           "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OperandBindInfo",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "operand-deployment-lifecycle-manager",
+              "app.kubernetes.io/managed-by": "operand-deployment-lifecycle-manager",
+              "app.kubernetes.io/name": "operand-deployment-lifecycle-manager"
+            },
+            "name": "example-service"
+          },
+          "spec": {
+            "bindings": {
+              "public": {
+                "configmap": "mongodb-configmap",
+                "secret": "mongodb-secret"
+              }
+            },
+            "description": "Binding information that should be accessible to MongoDB adopters",
+            "operand": "mongodb-atlas-kubernetes",
+            "registry": "example-service"
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandConfig",
           "metadata": {
             "labels": {

--- a/bundle/manifests/operator.ibm.com_operandbindinfos.yaml
+++ b/bundle/manifests/operator.ibm.com_operandbindinfos.yaml
@@ -100,6 +100,7 @@ spec:
                   type: string
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -143,6 +143,7 @@ spec:
                 description: ServiceStatus defines all the status of a operator.
                 type: object
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -2197,6 +2197,7 @@ spec:
                   OperandRegistry.
                 type: string
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/operator.ibm.com_operandbindinfos.yaml
+++ b/config/crd/bases/operator.ibm.com_operandbindinfos.yaml
@@ -98,6 +98,7 @@ spec:
                   type: string
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -141,6 +141,7 @@ spec:
                 description: ServiceStatus defines all the status of a operator.
                 type: object
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -2195,6 +2195,7 @@ spec:
                   OperandRegistry.
                 type: string
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - operator_v1alpha1_operandrequest.yaml
 - operator_v1alpha1_operandregistry.yaml
 - operator_v1alpha1_operandconfig.yaml
+- operator_v1alpha1_operandbindinfo.yaml

--- a/config/samples/operator_v1alpha1_operandbindinfo.yaml
+++ b/config/samples/operator_v1alpha1_operandbindinfo.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandBindInfo
+metadata:
+  labels:
+    app.kubernetes.io/instance: "operand-deployment-lifecycle-manager"
+    app.kubernetes.io/managed-by: "operand-deployment-lifecycle-manager"
+    app.kubernetes.io/name: "operand-deployment-lifecycle-manager"
+  name: example-service
+spec:
+  bindings:
+    public:
+      secret: mongodb-secret
+      configmap: mongodb-configmap
+  description: Binding information that should be accessible to MongoDB adopters
+  operand: mongodb-atlas-kubernetes
+  registry: example-service

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -82,7 +82,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		existingInstance := &operatorv1alpha1.OperandRequest{}
 		if err := r.Client.Get(ctx, req.NamespacedName, existingInstance); err != nil && !apierrors.IsNotFound(err) {
 			// Error reading the latest object - requeue the request.
-			reconcileErr = utilerrors.NewAggregate([]error{reconcileErr, fmt.Errorf("c from server: %v", err)})
+			reconcileErr = utilerrors.NewAggregate([]error{reconcileErr, fmt.Errorf("error while get latest OperandRequest.Status from server: %v", err)})
 		}
 
 		if reflect.DeepEqual(existingInstance.Status, requestInstance.Status) {


### PR DESCRIPTION
Fix validation error from operator-sdk
```
WARN[0000] Warning: Value operator.ibm.com/v1alpha1, Kind=OperandBindInfo: provided API should have an example annotation 
```