### PR TITLE
Add OperandBindinfo example into alm-example

### DIFF
--- a/api/v1alpha1/operandbindinfo_types.go
+++ b/api/v1alpha1/operandbindinfo_types.go
@@ -94,7 +94,9 @@ type OperandBindInfo struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   OperandBindInfoSpec   `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec OperandBindInfoSpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandBindInfoStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -101,7 +101,9 @@ type OperandConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   OperandConfigSpec   `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec OperandConfigSpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandConfigStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -146,7 +146,9 @@ type OperandRegistry struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   OperandRegistrySpec   `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec OperandRegistrySpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandRegistryStatus `json:"status,omitempty"`
 }
 

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -212,7 +212,9 @@ type OperandRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 
-	Spec   OperandRequestSpec   `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
+	Spec OperandRequestSpec `json:"spec,omitempty"`
+	// +kubebuilder:pruning:PreserveUnknownFields
 	Status OperandRequestStatus `json:"status,omitempty"`
 }
 

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -6,6 +6,29 @@ metadata:
       [
         {
           "apiVersion": "operator.ibm.com/v1alpha1",
+          "kind": "OperandBindInfo",
+          "metadata": {
+            "labels": {
+              "app.kubernetes.io/instance": "operand-deployment-lifecycle-manager",
+              "app.kubernetes.io/managed-by": "operand-deployment-lifecycle-manager",
+              "app.kubernetes.io/name": "operand-deployment-lifecycle-manager"
+            },
+            "name": "example-service"
+          },
+          "spec": {
+            "bindings": {
+              "public": {
+                "configmap": "mongodb-configmap",
+                "secret": "mongodb-secret"
+              }
+            },
+            "description": "Binding information that should be accessible to MongoDB adopters",
+            "operand": "mongodb-atlas-kubernetes",
+            "registry": "example-service"
+          }
+        },
+        {
+          "apiVersion": "operator.ibm.com/v1alpha1",
           "kind": "OperandConfig",
           "metadata": {
             "labels": {
@@ -59,7 +82,7 @@ metadata:
                 "installMode": "cluster",
                 "name": "jaeger",
                 "namespace": "default",
-                "packageName": "jaeger"
+                "packageName": "jaeger",
                 "sourceName": "community-operators",
                 "sourceNamespace": "openshift-marketplace"
               },
@@ -110,9 +133,9 @@ metadata:
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based
       API to manage the lifecycle of operands.
     olm.skipRange: '>=1.2.0 <1.21.8'
-    operators.operatorframework.io/builder: operator-sdk-v1.11.0+git
-    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.operatorframework.io/builder: operator-sdk-v1.24.0
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/operand-deployment-lifecycle-manager
     support: IBM
   labels:

--- a/bundle/manifests/operator.ibm.com_operandbindinfos.yaml
+++ b/bundle/manifests/operator.ibm.com_operandbindinfos.yaml
@@ -49,7 +49,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: OperandBindInfoSpec defines the desired state of OperandBindInfo.
             properties:
               bindings:
@@ -88,6 +87,7 @@ spec:
             - operand
             - registry
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandBindInfoStatus defines the observed state of OperandBindInfo.
             properties:
@@ -100,6 +100,7 @@ spec:
                   type: string
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -49,7 +49,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: OperandConfigSpec defines the desired state of OperandConfig.
             properties:
               services:
@@ -123,6 +122,7 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandConfigStatus defines the observed state of OperandConfig.
             properties:
@@ -143,6 +143,7 @@ spec:
                 description: ServiceStatus defines all the status of a operator.
                 type: object
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -49,7 +49,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: OperandRegistrySpec defines the desired state of OperandRegistry.
             properties:
               operators:
@@ -2038,6 +2037,7 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandRegistryStatus defines the observed state of OperandRegistry.
             properties:
@@ -2108,6 +2108,7 @@ spec:
                   OperandRegistry.
                 type: string
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-odlm
   operators.operatorframework.io.bundle.channels.v1: v3.20
   operators.operatorframework.io.bundle.channel.default.v1: v3.20
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.10.0+git
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.24.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/crd/bases/operator.ibm.com_operandbindinfos.yaml
+++ b/config/crd/bases/operator.ibm.com_operandbindinfos.yaml
@@ -47,7 +47,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: OperandBindInfoSpec defines the desired state of OperandBindInfo.
             properties:
               bindings:
@@ -86,6 +85,7 @@ spec:
             - operand
             - registry
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandBindInfoStatus defines the observed state of OperandBindInfo.
             properties:
@@ -98,6 +98,7 @@ spec:
                   type: string
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -47,7 +47,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: OperandConfigSpec defines the desired state of OperandConfig.
             properties:
               services:
@@ -121,6 +120,7 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandConfigStatus defines the observed state of OperandConfig.
             properties:
@@ -141,6 +141,7 @@ spec:
                 description: ServiceStatus defines all the status of a operator.
                 type: object
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -47,7 +47,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: OperandRegistrySpec defines the desired state of OperandRegistry.
             properties:
               operators:
@@ -2036,6 +2035,7 @@ spec:
                   type: object
                 type: array
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandRegistryStatus defines the observed state of OperandRegistry.
             properties:
@@ -2106,6 +2106,7 @@ spec:
                   OperandRegistry.
                 type: string
             type: object
+            x-kubernetes-preserve-unknown-fields: true
         type: object
     served: true
     storage: true

--- a/config/crd/bases/operator.ibm.com_operandrequests.yaml
+++ b/config/crd/bases/operator.ibm.com_operandrequests.yaml
@@ -47,7 +47,6 @@ spec:
           metadata:
             type: object
           spec:
-            x-kubernetes-preserve-unknown-fields: true
             description: The OperandRequestSpec identifies one or more specific operands
               (from a specific Registry) that should actually be installed.
             properties:
@@ -131,6 +130,7 @@ spec:
             required:
             - requests
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           status:
             description: OperandRequestStatus defines the observed state of OperandRequest.
             properties:

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -11,9 +11,9 @@ metadata:
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based
       API to manage the lifecycle of operands.
     olm.skipRange: '>=1.2.0 <1.21.8'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    operators.openshift.io/infrastructure-features: '["disconnected"]'
     repository: https://github.com/IBM/operand-deployment-lifecycle-manager
     support: IBM
   labels:

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -3,3 +3,4 @@ resources:
 - operator_v1alpha1_operandrequest.yaml
 - operator_v1alpha1_operandregistry.yaml
 - operator_v1alpha1_operandconfig.yaml
+- operator_v1alpha1_operandbindinfo.yaml

--- a/config/samples/operator_v1alpha1_operandbindinfo.yaml
+++ b/config/samples/operator_v1alpha1_operandbindinfo.yaml
@@ -1,0 +1,16 @@
+apiVersion: operator.ibm.com/v1alpha1
+kind: OperandBindInfo
+metadata:
+  labels:
+    app.kubernetes.io/instance: "operand-deployment-lifecycle-manager"
+    app.kubernetes.io/managed-by: "operand-deployment-lifecycle-manager"
+    app.kubernetes.io/name: "operand-deployment-lifecycle-manager"
+  name: example-service
+spec:
+  bindings:
+    public:
+      secret: mongodb-secret
+      configmap: mongodb-configmap
+  description: Binding information that should be accessible to MongoDB adopters
+  operand: mongodb-atlas-kubernetes
+  registry: example-service


### PR DESCRIPTION
fix for travis build failed: https://v3.travis.ibm.com/github/IBMPrivateCloud/charts/jobs/6971895#L898
```
[ERROR]: bundle content validation failed: Bundle validation errors: Error: Value operator.ibm.com/v1alpha1, Kind=OperandRequest: example must have a provided API,Error: Value operator.ibm.com/v1alpha1, Kind=OperandBindInfo: example must have a provided API (CASEProcessingError)
ERROR: merge failed
```