### PR TITLE
Add additional explicitly listed permission

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -594,9 +594,9 @@ spec:
                 app.kubernetes.io/instance: operand-deployment-lifecycle-manager
                 app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
                 app.kubernetes.io/name: operand-deployment-lifecycle-manager
-                productName: IBM_Cloud_Platform_Common_Services
                 intent: projected-odlm
                 name: operand-deployment-lifecycle-manager
+                productName: IBM_Cloud_Platform_Common_Services
             spec:
               affinity:
                 nodeAffinity:
@@ -680,9 +680,13 @@ spec:
           - operator.ibm.com
           resources:
           - operandconfigs
+          - operandconfigs/status
           - operandregistries
+          - operandregistries/status
           - operandrequests
+          - operandrequests/status
           - operandbindinfos
+          - operandbindinfos/status
           verbs:
           - create
           - delete
@@ -697,6 +701,7 @@ spec:
           - configmaps
           - secrets
           - services
+          - namespaces
           verbs:
           - create
           - delete
@@ -709,6 +714,31 @@ spec:
           - route.openshift.io
           resources:
           - routes
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - operatorgroups
+          - installplans
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - k8s.keycloak.org
+          resources:
+          - keycloaks
           verbs:
           - create
           - delete

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: "operand-deployment-lifecycle-manager"
     app.kubernetes.io/managed-by: "operand-deployment-lifecycle-manager"
     app.kubernetes.io/name: "operand-deployment-lifecycle-manager"
+    productName: IBM_Cloud_Platform_Common_Services
   name: operand-deployment-lifecycle-manager
   namespace: system
 spec:
@@ -24,6 +25,7 @@ spec:
         app.kubernetes.io/instance: operand-deployment-lifecycle-manager
         app.kubernetes.io/managed-by: "operand-deployment-lifecycle-manager"
         app.kubernetes.io/name: "operand-deployment-lifecycle-manager"
+        productName: IBM_Cloud_Platform_Common_Services
         intent: projected-odlm
       annotations:
         productName: "IBM Cloud Platform Common Services"

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,9 +40,13 @@ rules:
   - operator.ibm.com
   resources:
   - operandconfigs
+  - operandconfigs/status
   - operandregistries
+  - operandregistries/status
   - operandrequests
+  - operandrequests/status
   - operandbindinfos
+  - operandbindinfos/status
 - verbs:
   - create
   - delete
@@ -57,6 +61,7 @@ rules:
   - configmaps
   - secrets
   - services
+  - namespaces
 - verbs:
   - create
   - delete
@@ -69,3 +74,28 @@ rules:
   - route.openshift.io
   resources:
   - routes
+- verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  apiGroups:
+  - operators.coreos.com
+  resources:
+  - operatorgroups
+  - installplans
+- verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+  apiGroups:
+  - k8s.keycloak.org
+  resources:
+  - keycloaks


### PR DESCRIPTION
ODLM needs those additional permission after its wildcard permission is gone
- namespace
- operandrequest/status
- operatorgroup
- installplan
- keycloak

```
W1016 20:19:20.207113 1 reconcile_operator.go:296] failed to create the namespace cloudpak-data, please make sure it exists: namespaces is forbidden: User "system:serviceaccount:cloudpak-control:operand-deployment-lifecycle-manager" cannot create resource "namespaces" in API group "" at the cluster scope
...
W1016 19:52:37.601695    1 operandrequest_controller.go:121] No permission to update OperandRequest
...
E1016 20:04:23.080461       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/reflector.go:167: Failed to watch *v1.OperatorGroup: failed to list *v1.OperatorGroup: operatorgroups.operators.coreos.com is forbidden: User "system:serviceaccount:cloudpak-control:operand-deployment-lifecycle-manager" cannot list resource "operatorgroups" in API group "operators.coreos.com" in the namespace "cloudpak-data"
...
W1016 20:31:33.683401 1 reflector.go:324] pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/reflector.go:167: failed to list *v1alpha1.InstallPlan: installplans.operators.coreos.com is forbidden: User "system:serviceaccount:cloudpak-control:operand-deployment-lifecycle-manager" cannot list resource "installplans" in API group "operators.coreos.com" in the namespace "cloudpak-data"
...
I1016 20:33:56.143585 1 reconcile_operand.go:259] ODLM doesn't have enough permission to reconcile k8s resource -- Kind: Keycloak, NamespacedName: cloudpak-data/cs-keycloak

```