### PR TITLE
set OwnerReference for resources created by OperandRequest

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -691,16 +691,16 @@ func (r *Reconciler) updateCustomResource(ctx context.Context, existingCR unstru
 			return false, errors.Wrapf(err, "failed to get custom resource -- Kind: %s, NamespacedName: %s/%s", kind, namespace, name)
 		}
 
-		forceUpdate := false
 		if !r.CheckLabel(existingCR, map[string]string{constant.OpreqLabel: "true"}) {
 			return true, nil
-		} else {
-			for _, owner := range owners {
-				if err := controllerutil.SetOwnerReference(owner, &existingCR, r.Scheme); err != nil {
-					return false, errors.Wrapf(err, "failed to set ownerReference for custom resource %s/%s", existingCR.GetNamespace(), existingCR.GetName())
-				}
-				forceUpdate = true
+		}
+
+		forceUpdate := false
+		for _, owner := range owners {
+			if err := controllerutil.SetOwnerReference(owner, &existingCR, r.Scheme); err != nil {
+				return false, errors.Wrapf(err, "failed to set ownerReference for custom resource %s/%s", existingCR.GetNamespace(), existingCR.GetName())
 			}
+			forceUpdate = true
 		}
 
 		configFromALMRaw, err := json.Marshal(configFromALM)


### PR DESCRIPTION
### Context
This is used to address issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/60848

Previously, OperandRequest was set as the CONTROLLER of the resources created by OperandRequest.
When there are multiple OperandRequests the same resources. Only one of OperandRequest could be the controller.
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  name: iaf-zen-test-cr
  namespace: issue60848
  ownerReferences:
    - apiVersion: operator.ibm.com/v1alpha1
      blockOwnerDeletion: true
      controller: true          <------------- only one controller is allowed
      kind: OperandRequest
      name: example-service-2
      uid: c12e3a0d-3ed3-470e-95b5-1534f23ee34f
  labels:
    operator.ibm.com/opreq-control: 'true'
spec:
  size: starterset
```

The PR will set OperandRequest as the Owner of resources only. And k8s allows multiple Owner for one resources.
```
apiVersion: operator.ibm.com/v3
kind: CommonService
metadata:
  resourceVersion: '210987042'
  name: iaf-zen-test-cr
  namespace: issue60848
  ownerReferences:
    - apiVersion: operator.ibm.com/v1alpha1
      kind: OperandRequest    <---------- First OperandRequest
      name: example-service
      uid: e0301110-09a4-4f93-91f3-3af89b9a75ff
    - apiVersion: operator.ibm.com/v1alpha1
      kind: OperandRequest      <---------- Second OperandRequest
      name: example-service-2
      uid: e65b1007-3089-4ea1-8c1b-65b1c4c5be20
  labels:
    operator.ibm.com/opreq-control: 'true'
spec:
  size: starterset
status:
  configStatus:
    catalogName: opencloud-operators
    catalogNamespace: openshift-marketplace
    operatorDeployed: true
    operatorNamespace: issue60848
    servicesDeployed: true
    servicesNamespace: issue60848
    topologyConfigurableCRs:
      - apiVersion: operator.ibm.com/v3
        kind: CommonService
        namespace: issue60848
        objectName: common-service
  phase: Succeeded
```

### How to test
1. Deploy CS daily as usually in a simple topology mode.
2. Update ODLM CSV to replace image to `quay.io/opencloudio/odlm:ffcfedcb-dirty` and update ImagePullPolicy to `Always`
3. Create two OperandRequests which will request the same resource in the same namespace where ODLM is deployed(only simple topology is sufficient)
  - In order to simply the testing process, I create CS CR along with Zen Operator installation instead of ZenService in OperandRequest
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - apiVersion: operator.ibm.com/v3
              instanceName: iaf-zen-test-cr
              kind: CommonService
              name: ibm-platformui-operator
              spec:
                size: starterset
            - name: ibm-platformui-operator
          registry: common-service
    ---
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: example-service-2
    spec:
      requests:
        - operands:
            - apiVersion: operator.ibm.com/v3
              instanceName: iaf-zen-test-cr
              kind: CommonService
              name: ibm-platformui-operator
              spec:
                size: starterset
            - name: ibm-platformui-operator
          registry: common-service
    ``` 
4. After two OperandRequests are created, we could inspect CS CR created by OperandRequest
    ```bash
    > oc get commonservice iaf-zen-test-cr -n issue60848 -oyaml

    apiVersion: operator.ibm.com/v3
    kind: CommonService
    metadata:
      creationTimestamp: "2023-10-18T04:41:07Z"
      generation: 1
      labels:
        operator.ibm.com/opreq-control: "true"
      name: iaf-zen-test-cr
      namespace: issue60848
      ownerReferences:
      - apiVersion: operator.ibm.com/v1alpha1
        kind: OperandRequest
        name: example-service        <-------- first OperandRequest
        uid: e0301110-09a4-4f93-91f3-3af89b9a75ff
      - apiVersion: operator.ibm.com/v1alpha1
        kind: OperandRequest
        name: example-service-2.  <-------- second OperandRequest
        uid: e65b1007-3089-4ea1-8c1b-65b1c4c5be20
      resourceVersion: "210987042"
      uid: f5c0fc2c-1095-4626-9f61-594e78044c78
    spec:
      size: starterset
    ```
5. Test uninstallation
   - Remove second OperandRequest `example-service-2`, CommonService CR `iaf-zen-test-cr` should exist in the cluster, but it should only have one OwnerReference left.
   - Remove first OperandRequest `example-service2`, CommonService CR `iaf-zen-test-cr` should be removed as well because all of its owner has been removed.