### PR TITLE
add finalizers permission

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -681,12 +681,16 @@ spec:
           resources:
           - operandconfigs
           - operandconfigs/status
+          - operandconfigs/finalizers
           - operandregistries
           - operandregistries/status
+          - operandregistries/finalizers
           - operandrequests
           - operandrequests/status
+          - operandrequests/finalizers
           - operandbindinfos
           - operandbindinfos/status
+          - operandbindinfos/finalizers
           verbs:
           - create
           - delete

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,12 +41,16 @@ rules:
   resources:
   - operandconfigs
   - operandconfigs/status
+  - operandconfigs/finalizers
   - operandregistries
   - operandregistries/status
+  - operandregistries/finalizers
   - operandrequests
   - operandrequests/status
+  - operandrequests/finalizers
   - operandbindinfos
   - operandbindinfos/status
+  - operandbindinfos/finalizers
 - verbs:
   - create
   - delete


### PR DESCRIPTION
This fix is used to solve the permission error happened when createing ZenService:
```
E1019 18:51:37.406849 1 operandbindinfo_controller.go:202] failed to reconcile the OperandBindinfo nss-cp/ibm-zen-bindinfo: the following errors occurred:
- failed to create secret nss-cp/zen-ca-cert-secret: secrets "zen-ca-cert-secret" is forbidden: cannot set blockOwnerDeletion if an ownerReference refers to a resource you can't set finalizers on: , <nil>
I1019 18:51:49.396182 1 operandrequest_controller.go:125] Reconciling OperandRequest: nss-cp/ibm-iam-service
```