### PR TITLE
Support jsonpath in OperandConfig value reference

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -672,13 +672,11 @@ func (m *ODLMOperator) GetValueRefFromObject(ctx context.Context, instanceType, 
 		return "", nil
 	}
 
-	value, ok, err := unstructured.NestedString(obj.Object, strings.Split(path, ".")...)
+	sanitizedString, err := util.SanitizeObjectString(path, obj.Object)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed to parse path %v from %s %s/%s", path, obj.GetKind(), obj.GetNamespace(), obj.GetName())
-	} else if !ok {
-		return "", errors.Errorf("failed to get path %v from %s %s/%s, the value is not found", path, obj.GetKind(), obj.GetNamespace(), obj.GetName())
 	}
 
-	klog.V(2).Infof("Get value %s from %s %s/%s", value, objKind, obj.GetNamespace(), obj.GetName())
-	return value, nil
+	klog.V(2).Infof("Get value %s from %s %s/%s", sanitizedString, objKind, obj.GetNamespace(), obj.GetName())
+	return sanitizedString, nil
 }


### PR DESCRIPTION
Reuse the jsonpath parsing mechanism from [sharing Service info via OperandBindinfo](https://github.com/IBM/operand-deployment-lifecycle-manager/pull/993), to support jsonpath reference templating in OperandConfig.

How to test
- Deploy a daily CD build as usually in a simple topology mode.
- Update ODLM CSV to replace image to `quay.io/opencloudio/odlm:b94e8737-dirty` and update `ImagePullPolicy` to `Always`
- Deploy resources in the same namespace listed in the bottom
- Verify following object are created
  - ConfigMap named `test-service-my-service`, this is created via OperandBindinfo, to convey the information directly obtained from service `my-service`
    ```yaml
    kind: ConfigMap
    apiVersion: v1
    metadata:
      name: test-service-my-service
    data:
      world: 'https://my-service.yesy-jsonpath.svc:80'
    ```
   - ConfigMap named `test-service-via-reference`, this was generated by OperandConfig value reference templating
     ```yaml
      kind: ConfigMap
      apiVersion: v1
      metadata:
        name: test-service-via-reference
      data:
        SERVICE_ENDPOINT: 'https://my-service.yesy-jsonpath.svc:80'
     ``` 
   - ConfigMap named `test-service-test-service-via-reference`, this is the copy of ConfigMap `test-service-via-reference` done by OperandBindinfo
       ```yaml
       kind: ConfigMap
      apiVersion: v1
      metadata:
        name: test-service-test-service-via-reference
      data:
        SERVICE_ENDPOINT: 'https://my-service.yesy-jsonpath.svc:80'
       ```

#### Create following resources in the namespace
```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRegistry
metadata:
  name: test-jsonpath
spec:
  operators:
    - channel: v4.3
      installPlanApproval: Automatic
      name: ibm-platformui-operator
      packageName: ibm-zen-operator
      scope: public
      sourceName: opencloud-operators
      sourceNamespace: openshift-marketplace
---
kind: OperandConfig
apiVersion: operator.ibm.com/v1alpha1
metadata:
  name: test-jsonpath
spec:
  services:
  - name: ibm-platformui-operator
    resources:
    - apiVersion: v1
      kind: ConfigMap
      force: true
      name: test-service-via-reference
      data:
        data:
          SERVICE_ENDPOINT:
            templatingValueFrom:
              objectRef:
                apiVersion: v1
                kind: Service
                name: my-service
                path: https://+.metadata.name+.+.metadata.namespace+.+svc:+.spec.ports[0].port
---
apiVersion: v1
kind: Service
metadata:
  name: my-service
spec:
  selector:
    app: MyApp
  ports:
    - protocol: TCP
      port: 80
      targetPort: 9376
---
apiVersion: operator.ibm.com/v1alpha1
kind: OperandBindInfo
metadata:
  name: test-service
spec:
  bindings:
    public-my-configmap:
      configmap:  test-service-via-reference
    public-my-service:
      service: 
        name: my-service
        data:
          world: https://+.metadata.name+.+.metadata.namespace+.+svc:+.spec.ports[0].port
  description: Binding information that should be accessible to MongoDB adopters
  operand: ibm-platformui-operator
  registry: test-jsonpath
---
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: common-service
spec:
  requests:
  - operands:
    - name: ibm-platformui-operator
    registry: test-jsonpath
```