### PR TITLE
allow to add multiple owners to cm/secret

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -417,7 +417,7 @@ func (r *Reconciler) reconcileCRwithRequest(ctx context.Context, requestInstance
 	crFromRequest.SetNamespace(requestKey.Namespace)
 	crFromRequest.SetAPIVersion(operand.APIVersion)
 	crFromRequest.SetKind(operand.Kind)
-	// Set the OperandRequest as the controller of the CR from request
+	// Set the OperandRequest as the owner of the CR from request
 	if err := controllerutil.SetOwnerReference(requestInstance, &crFromRequest, r.Scheme); err != nil {
 		merr.Add(errors.Wrapf(err, "failed to set ownerReference for custom resource %s/%s", requestKey.Namespace, name))
 	}

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -282,11 +282,18 @@ func EnsureLabelsForService(s *corev1.Service, labels map[string]string) {
 }
 
 func CompareSecret(secret *corev1.Secret, existingSecret *corev1.Secret) (needUpdate bool) {
-	return !equality.Semantic.DeepEqual(secret.GetLabels(), existingSecret.GetLabels()) || !equality.Semantic.DeepEqual(secret.Type, existingSecret.Type) || !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data) || !equality.Semantic.DeepEqual(secret.StringData, existingSecret.StringData) || !equality.Semantic.DeepEqual(secret.GetOwnerReferences(), existingSecret.GetOwnerReferences())
+	return !equality.Semantic.DeepEqual(secret.GetLabels(), existingSecret.GetLabels()) ||
+		!equality.Semantic.DeepEqual(secret.Type, existingSecret.Type) ||
+		!equality.Semantic.DeepEqual(secret.Data, existingSecret.Data) ||
+		!equality.Semantic.DeepEqual(secret.StringData, existingSecret.StringData) ||
+		!equality.Semantic.DeepEqual(secret.GetOwnerReferences(), existingSecret.GetOwnerReferences())
 }
 
 func CompareConfigMap(configMap *corev1.ConfigMap, existingConfigMap *corev1.ConfigMap) (needUpdate bool) {
-	return !equality.Semantic.DeepEqual(configMap.GetLabels(), existingConfigMap.GetLabels()) || !equality.Semantic.DeepEqual(configMap.Data, existingConfigMap.Data) || !equality.Semantic.DeepEqual(configMap.BinaryData, existingConfigMap.BinaryData) || !equality.Semantic.DeepEqual(configMap.GetOwnerReferences(), existingConfigMap.GetOwnerReferences())
+	return !equality.Semantic.DeepEqual(configMap.GetLabels(), existingConfigMap.GetLabels()) ||
+		!equality.Semantic.DeepEqual(configMap.Data, existingConfigMap.Data) ||
+		!equality.Semantic.DeepEqual(configMap.BinaryData, existingConfigMap.BinaryData) ||
+		!equality.Semantic.DeepEqual(configMap.GetOwnerReferences(), existingConfigMap.GetOwnerReferences())
 }
 
 // SanitizeObjectString takes a string, i.e. .metadata.namespace, and a K8s object

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -282,11 +282,11 @@ func EnsureLabelsForService(s *corev1.Service, labels map[string]string) {
 }
 
 func CompareSecret(secret *corev1.Secret, existingSecret *corev1.Secret) (needUpdate bool) {
-	return !equality.Semantic.DeepEqual(secret.GetLabels(), existingSecret.GetLabels()) || !equality.Semantic.DeepEqual(secret.Type, existingSecret.Type) || !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data) || !equality.Semantic.DeepEqual(secret.StringData, existingSecret.StringData)
+	return !equality.Semantic.DeepEqual(secret.GetLabels(), existingSecret.GetLabels()) || !equality.Semantic.DeepEqual(secret.Type, existingSecret.Type) || !equality.Semantic.DeepEqual(secret.Data, existingSecret.Data) || !equality.Semantic.DeepEqual(secret.StringData, existingSecret.StringData) || !equality.Semantic.DeepEqual(secret.GetOwnerReferences(), existingSecret.GetOwnerReferences())
 }
 
 func CompareConfigMap(configMap *corev1.ConfigMap, existingConfigMap *corev1.ConfigMap) (needUpdate bool) {
-	return !equality.Semantic.DeepEqual(configMap.GetLabels(), existingConfigMap.GetLabels()) || !equality.Semantic.DeepEqual(configMap.Data, existingConfigMap.Data) || !equality.Semantic.DeepEqual(configMap.BinaryData, existingConfigMap.BinaryData)
+	return !equality.Semantic.DeepEqual(configMap.GetLabels(), existingConfigMap.GetLabels()) || !equality.Semantic.DeepEqual(configMap.Data, existingConfigMap.Data) || !equality.Semantic.DeepEqual(configMap.BinaryData, existingConfigMap.BinaryData) || !equality.Semantic.DeepEqual(configMap.GetOwnerReferences(), existingConfigMap.GetOwnerReferences())
 }
 
 // SanitizeObjectString takes a string, i.e. .metadata.namespace, and a K8s object


### PR DESCRIPTION
### Context
This is used to address issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61126

All the ConfigMaps and Secrets, which are copied by OperandBindinfo to the namespace where OperandRequest is located, will have OperandRequest as the OwnerReference.
Previously, OperandRequest was set as the CONTROLLER of those cm or secrets.
When there are multiple OperandRequests the same resources. Only one of OperandRequest could be the controller.
```
kind: Secret
apiVersion: v1
metadata:
  name: keycloak-bindinfo-cs-keycloak-tls-secret
  namespace: ibm-common-services
  labels:
    controller.cert-manager.io/fao: 'true'
    ibm-common-services.keycloak-bindinfo/bindinfo: 'true'
    operator.ibm.com/managedBy-opbi: copy
    operator.ibm.com/referenced-by-odlm-resource: OperandConfig.ibm-common-services.common-service
    operator.ibm.com/watched-by-cert-manager: ''
    operator.ibm.com/watched-by-odlm: 'true'
  ownerReferences:
    - apiVersion: operator.ibm.com/v1alpha1
      kind: OperandRequest
      name: keycloak-2
      uid: 4a73bb17-8032-458a-baea-0fcc0c28d22a
      blockOwnerDeletion: true
      controller: true          <------------- only one controller is allowed
type: kubernetes.io/tls
```

The PR will set OperandRequest as the Owner of resources only. And k8s allows multiple Owner for one resources.
```
kind: Secret
apiVersion: v1
metadata:
  name: keycloak-bindinfo-cs-keycloak-tls-secret
  namespace: ibm-common-services
  labels:
    controller.cert-manager.io/fao: 'true'
    ibm-common-services.keycloak-bindinfo/bindinfo: 'true'
    operator.ibm.com/managedBy-opbi: copy
    operator.ibm.com/referenced-by-odlm-resource: OperandConfig.ibm-common-services.common-service
    operator.ibm.com/watched-by-cert-manager: ''
    operator.ibm.com/watched-by-odlm: 'true'
  ownerReferences:
   - apiVersion: operator.ibm.com/v1alpha1
      kind: OperandRequest.            <---------- First OperandRequest
      name: keycloak-2
      uid: 4a73bb17-8032-458a-baea-0fcc0c28d22a
   - apiVersion: operator.ibm.com/v1alpha1
      kind: OperandRequest
      name: keycloak-1                     <---------- Second OperandRequest
      uid: bf1d7f23-742b-42de-85a1-a8acc76c41d6
type: kubernetes.io/tls
```

### How to test
1. Deploy CS daily as usually in a simple topology mode.
2. Update ODLM CSV to replace image to `quay.io/yuchen_shen/odlm:multiple_ownerreference` and update ImagePullPolicy to `Always`
3. Create two OperandRequests which will request the `keycloak-operator`
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: keycloak-2
      namespace: ibm-common-services
    spec:
      requests:
        - operands:
            - name: keycloak-operator
          registry: common-service
    ---
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: keycloak-1
      namespace: ibm-common-services
    spec:
      requests:
        - operands:
            - name: keycloak-operator
          registry: common-service
    ``` 
4. After two OperandRequests are created, we could inspect `keycloak-bindinfo-cs-keycloak-tls-secret` secret with two owner reference as above.

