### PR TITLE
Enhance error handling for uninstall procedure

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -519,6 +519,7 @@ func (r *Reconciler) absentOperatorsAndOperands(ctx context.Context, requestInst
 					r.Mutex.Lock()
 					defer r.Mutex.Unlock()
 					merr.Add(err)
+					return // return here to avoid removing the operand from remainingOperands
 				}
 				requestInstance.RemoveServiceStatus(fmt.Sprintf("%v", o), &r.Mutex)
 				(*remainingOperands).Remove(o)

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -60,7 +60,7 @@ func NewODLMOperator(mgr manager.Manager, name string) *ODLMOperator {
 		Config:                  mgr.GetConfig(),
 		Recorder:                mgr.GetEventRecorderFor(name),
 		Scheme:                  mgr.GetScheme(),
-		MaxConcurrentReconciles: 5,
+		MaxConcurrentReconciles: 10,
 	}
 }
 


### PR DESCRIPTION
To address issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61390

Make several enhancements:
1. Increase the number of OperandRequests which could be reconciled by ODLM simultaneously to 10
2. Better Error handling to avoid removing operand from remainingOperands set, to keep track of failed uninstallation
3. In parent OperandRequest uninstallation reconciliation, skip waiting for its child OperandRequest to be deleted when this child OperandRequest is a "internal" OperandRequest as the operand of services.
   - For example, `keycloak-operator` has a "internal" OperandRequest requesting `edb-keycloak` as the dependency of Keycloak operator.