### PR TITLE
Reduce CPU and Memory usage

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -60,7 +60,7 @@ func NewODLMOperator(mgr manager.Manager, name string) *ODLMOperator {
 		Config:                  mgr.GetConfig(),
 		Recorder:                mgr.GetEventRecorderFor(name),
 		Scheme:                  mgr.GetScheme(),
-		MaxConcurrentReconciles: 10,
+		MaxConcurrentReconciles: 3,
 	}
 }
 
@@ -366,7 +366,7 @@ func (m *ODLMOperator) GetClusterServiceVersion(ctx context.Context, sub *olmv1a
 		Name:      csvName,
 		Namespace: csvNamespace,
 	}
-	if err := m.Client.Get(ctx, csvKey, csv); err != nil {
+	if err := m.Reader.Get(ctx, csvKey, csv); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("ClusterServiceVersion %s is not ready. Will check it when it is stable", sub.Name)
 			return nil, nil


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61611

- Decrease the number of max concurrent reconciliation to 3, to avoid high CPU usage
- Use k8s Reader interface to get CSV from subscription, instead of Client interface. It avoids store all CSVs in the cache, to reduce memory usage in All Namespaces Mode.


```
> oc get csv -A | wc -l                                                    
    1458
```

### Use `Client` Interface to get CSV, it stores CSV in cache
```
Every 2.0s: oc adm top pods -l name=operand-deployment-lifecycle-manager                                                                                                Daniels-MBP: Wed Jan 10 21:13:31 2024

NAME                                                    CPU(cores)   MEMORY(bytes)
operand-deployment-lifecycle-manager-6ff4db75ff-rp6zd   0m           264Mi
```

### Use `Reader` Interface to get CSV, it does not store CSV in cache
```
Every 2.0s: oc adm top pods -l name=operand-deployment-lifecycle-manager                                                                                                Daniels-MBP: Wed Jan 10 20:53:49 2024

NAME                                                    CPU(cores)   MEMORY(bytes)
operand-deployment-lifecycle-manager-68c44d9d66-dfwf6   1m           24Mi
```