### PR TITLE
Read Object from k8s API directly instead of cache to avoid getting outdated object

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -689,7 +689,7 @@ func (m *ODLMOperator) GetValueRefFromObject(ctx context.Context, instanceType, 
 	var obj unstructured.Unstructured
 	obj.SetAPIVersion(objAPIVersion)
 	obj.SetKind(objKind)
-	if err := m.Client.Get(ctx, types.NamespacedName{Name: objName, Namespace: objNs}, &obj); err != nil {
+	if err := m.Reader.Get(ctx, types.NamespacedName{Name: objName, Namespace: objNs}, &obj); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("%s %s/%s is not found", objKind, objNs, objName)
 			return "", nil


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62214

### Context
Once Route `keycloak` is created by ODLM, and ODLM would revoke `Client.Get()` request to read the `host` from Route object. However, the Route object is instantly reconciled by openshift controller after it is created. As a result, Route Object stored in the ODLM's cache is outdated, and ODLM is not able to update it with error `the object has been modified; please apply your changes to the latest version and try again`

```
E0221 16:32:21.723501 1 manager.go:587] Failed to get value reference from Object 4-5-test/keycloak with path .spec.host: failed to update Route 4-5-test/keycloak: Operation cannot be fulfilled on routes.route.openshift.io "keycloak": the object has been modified; please apply your changes to the latest version and try again
E0221 16:32:21.723558 1 manager.go:479] Failed to get value reference from Object for OperandConfig 4-5-test/common-service on field hostname: failed to update Route 4-5-test/keycloak: Operation cannot be fulfilled on routes.route.openshift.io "keycloak": the object has been modified; please apply your changes to the latest version and try again
E0221 16:32:21.723581 1 reconcile_operand.go:243] Failed to parse value reference in resource 4-5-test/cs-keycloak: failed to update Route 4-5-test/keycloak: Operation cannot be fulfilled on routes.route.openshift.io "keycloak": the object has been modified; please apply your changes to the latest version and try again
```

### Solution
Use `Reader.Get()` to always get the object from the cluster