### PR TITLE
Skip OperandRequest for OperandBindinfo if the OperandRequest is in the deletion status

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -179,6 +179,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 			}
 			merr.Add(err)
 			continue
+		} else if !requestInstance.ObjectMeta.DeletionTimestamp.IsZero() {
+			klog.Warningf("OperandRequest %s/%s is being deleted, skip the OperandBindInfo %s/%s", requestInstance.Namespace, requestInstance.Name, bindInfoInstance.Namespace, bindInfoInstance.Name)
+			continue
 		}
 		// Get binding information from OperandRequest
 		secretReq, cmReq := getBindingInfofromRequest(bindInfoInstance, requestInstance)


### PR DESCRIPTION
issue:  https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61333

### Context
When ODLM reconciles OperandBindinfo to copy ConfigMap/Secret to namespaces where the OperandRequests are located, it also counts the namespace that are being deleted. However, ODLM is not able to create any new ConfigMap/Secret in a namespace which is be terminating.
```
E1122 11:17:23.547665       1 operandbindinfo_controller.go:237] failed to reconcile the OperandBindinfo ibm-common-services/keycloak-bindinfo: the following errors occurred:
  - failed to create ConfigMap cp4i-e2e-general-joy/cs-keycloak-service: configmaps "keycloak-bindinfo-cs-keycloak-service" is forbidden: unable to create new content in namespace cp4i-e2e-general-joy because it is being terminated
```

### Test
After applying the new image `quay.io/opencloudio/odlm:0ac0bd84-dirty` in ODLM CSV and deleting one namespace `cp4i-2` with an OperandRequest hanging, ODLM will skip that OperandRequest because it is being deleted.

```
I0221 18:27:20.715071 1 operandbindinfo_controller.go:453] Configmap cs-keycloak-route is copied from the namespace ibm-common-services to the namespace cp4i-3
I0221 18:27:20.723951 1 operandbindinfo_controller.go:453] Configmap cs-keycloak-service is copied from the namespace ibm-common-services to the namespace cp4i-3
I0221 18:27:20.735585 1 operandbindinfo_controller.go:351] Secret cs-keycloak-tls-secret is copied from the namespace ibm-common-services to secret keycloak-bindinfo-cs-keycloak-tls-secret in the namespace cp4i-3
I0221 18:27:20.744144 1 operandbindinfo_controller.go:453] Configmap cs-keycloak-route is copied from the namespace ibm-common-services to the namespace cp4i
I0221 18:27:20.752546 1 operandbindinfo_controller.go:453] Configmap cs-keycloak-service is copied from the namespace ibm-common-services to the namespace cp4i
I0221 18:27:20.762434 1 operandbindinfo_controller.go:351] Secret cs-keycloak-tls-secret is copied from the namespace ibm-common-services to secret keycloak-bindinfo-cs-keycloak-tls-secret in the namespace cp4i
W0221 18:27:20.762470 1 operandbindinfo_controller.go:183] OperandRequest cp4i-2/example-service is being deleted, skip the OperandBindInfo ibm-common-services/keycloak-bindinfo
```