### PR TITLE
Enable deep JSON merging for Kubernetes resources when updating them

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1059,6 +1059,20 @@ func (r *Reconciler) updateK8sResource(ctx context.Context, existingK8sRes unstr
 
 		if k8sResConfig != nil {
 
+			k8sResConfigDecoded := make(map[string]interface{})
+			k8sResConfigUnmarshalErr := json.Unmarshal(k8sResConfig.Raw, &k8sResConfigDecoded)
+			if k8sResConfigUnmarshalErr != nil {
+				klog.Errorf("failed to unmarshal k8s Resource Config: %v", k8sResConfigUnmarshalErr)
+			}
+
+			// Convert k8s resource spec in OperandConfig to string
+			k8sResConfigRaw, err := json.Marshal(k8sResConfigDecoded["spec"])
+			if err != nil {
+				klog.Error(err)
+				return false, err
+			}
+
+			// Convert existing k8s resource spec to string
 			existingK8sResRaw, err := json.Marshal(existingK8sRes.Object["spec"])
 			if err != nil {
 				klog.Error(err)
@@ -1066,7 +1080,7 @@ func (r *Reconciler) updateK8sResource(ctx context.Context, existingK8sRes unstr
 			}
 
 			// Merge spec from existing CR and OperandConfig spec
-			updatedExistingK8sRes := util.MergeCR(existingK8sResRaw, k8sResConfig.Raw)
+			updatedExistingK8sRes := util.MergeCR(existingK8sResRaw, k8sResConfigRaw)
 
 			r.EnsureAnnotation(existingK8sRes, newAnnotations)
 			r.EnsureLabel(existingK8sRes, newLabels)

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1077,6 +1077,9 @@ func (r *Reconciler) updateK8sResource(ctx context.Context, existingK8sRes unstr
 
 			r.EnsureAnnotation(existingK8sRes, newAnnotations)
 			r.EnsureLabel(existingK8sRes, newLabels)
+			if err := r.setOwnerReferences(ctx, &existingK8sRes, ownerReferences); err != nil {
+				return false, errors.Wrapf(err, "failed to set ownerReferences for k8s resource -- Kind: %s, NamespacedName: %s/%s", kind, namespace, name)
+			}
 
 			if reflect.DeepEqual(existingK8sRes.Object, updatedExistingK8sRes) {
 				return true, nil

--- a/controllers/util/merge.go
+++ b/controllers/util/merge.go
@@ -72,6 +72,25 @@ func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interf
 					checkKeyBeforeMerging(newKey, defaultMapRef[newKey], changedMapRef[newKey], finalMap[key].(map[string]interface{}))
 				}
 			}
+		case []interface{}:
+			if changedMap == nil {
+				finalMap[key] = defaultMap
+			} else if _, ok := changedMap.([]interface{}); ok { //Check that the changed map value is also a slice []interface
+				defaultMapRef := defaultMap
+				changedMapRef := changedMap.([]interface{})
+				for i := range defaultMapRef {
+					if _, ok := defaultMapRef[i].(map[string]interface{}); ok {
+						for newKey := range defaultMapRef[i].(map[string]interface{}) {
+							// check if the changedMapRef[i] is nil
+							if changedMapRef[i] == nil {
+								changedMapRef[i] = map[string]interface{}{}
+							}
+							checkKeyBeforeMerging(newKey, defaultMapRef[i].(map[string]interface{})[newKey], changedMapRef[i].(map[string]interface{})[newKey], finalMap[key].([]interface{})[i].(map[string]interface{}))
+						}
+					}
+				}
+			}
+
 		default:
 			//Check if the value was set, otherwise set it
 			if changedMap == nil {

--- a/controllers/util/merge.go
+++ b/controllers/util/merge.go
@@ -80,17 +80,17 @@ func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interf
 				changedMapRef := changedMap.([]interface{})
 				for i := range defaultMapRef {
 					if _, ok := defaultMapRef[i].(map[string]interface{}); ok {
-						for newKey := range defaultMapRef[i].(map[string]interface{}) {
-							// check if the changedMapRef[i] is nil
-							if changedMapRef[i] == nil {
-								changedMapRef[i] = map[string]interface{}{}
+						if len(changedMapRef) <= i {
+							finalMap[key] = append(finalMap[key].([]interface{}), defaultMapRef[i])
+						} else {
+
+							for newKey := range defaultMapRef[i].(map[string]interface{}) {
+								checkKeyBeforeMerging(newKey, defaultMapRef[i].(map[string]interface{})[newKey], changedMapRef[i].(map[string]interface{})[newKey], finalMap[key].([]interface{})[i].(map[string]interface{}))
 							}
-							checkKeyBeforeMerging(newKey, defaultMapRef[i].(map[string]interface{})[newKey], changedMapRef[i].(map[string]interface{})[newKey], finalMap[key].([]interface{})[i].(map[string]interface{}))
 						}
 					}
 				}
 			}
-
 		default:
 			//Check if the value was set, otherwise set it
 			if changedMap == nil {


### PR DESCRIPTION
Issue: https://github.ibm.com/ibmprivatecloud/roadmap/issues/61283

### Context 
For this enhancement, we allow users to perform additional customizations on Kubernetes resources created ODLM. ODLM will compare the existing Custom Resource in the cluster with the template in the OperandConfig, field by field. It will retain the fields that are not defined in OperandConfig instead of overwriting them.

### How to test
Test image: quay.io/yuchen_shen/odlm:deep_merge

#### CASE I: Test for map-type values
**resource: `keycloak-edb-cluster` Cluster CR**
Before apply the image 
- Remove `description` section under `.data.spec` for `keycloak-edb-cluster` service in OperandConfig, and restart ODLM pod, will observe the `description: EDB Database with IBM License Key` will be removed from Cluster CR

After apply the test image
- Add `description: EDB Database with IBM License Key` back to existing Cluster CR, keep description section removed in the OperandConfig, and restart ODLM pod, will observe the description will be retained in `keycloak-edb-cluster` CR

#### CASE II: Test for slice-type values
**resource: `edb-license-role` Role CR**
After apply the image 
- Adding or deleting rules to Role CR and restarting the ODLM pod will result in the observation that the newly added or deleted rules revert back to exactly what is specified in OperandConfig.
- Adding a new set of rules, which is not defined in OperandConfig, it will keep the new rules in the role.
