### PR TITLE
Introduce OwnReference API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ VERSION ?= $(shell git describe --exact-match 2> /dev/null || \
 RELEASE_VERSION ?= $(shell cat ./version/version.go | grep "Version =" | awk '{ print $$3}' | tr -d '"')
 LATEST_VERSION ?= latest
 OPERATOR_SDK_VERSION=v1.32.0
-YQ_VERSION=v4.17.2
+YQ_VERSION=v4.42.1
 DEFAULT_CHANNEL ?= v$(shell cat ./version/version.go | grep "Version =" | awk '{ print $$3}' | tr -d '"' | cut -d '.' -f1,2)
 CHANNELS ?= $(DEFAULT_CHANNEL)
 
@@ -208,14 +208,14 @@ bundle-manifests:
 	$(KUSTOMIZE) build config/manifests | $(OPERATOR_SDK) generate bundle \
 	-q --overwrite --version $(OPERATOR_VERSION) $(BUNDLE_METADATA_OPTS)
 	$(OPERATOR_SDK) bundle validate ./bundle
-	$(YQ) eval-all -i '.spec.relatedImages = load("config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml").spec.relatedImages' bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+	$(YQ) eval-all -i '.spec.relatedImages |= load("config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml").spec.relatedImages' bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
 	@# Need to replace fields this way to avoid changing PROJECT name and CSV file name, which may or may not impact CICD automation
 	$(YQ) e -i '.annotations["operators.operatorframework.io.bundle.package.v1"] = "ibm-odlm"' bundle/metadata/annotations.yaml
 	sed -i'' s/operand-deployment-lifecycle-manager/ibm-odlm/ bundle.Dockerfile
 
-generate-all: manifests kustomize operator-sdk ## Generate bundle manifests, metadata and package manifests
+generate-all: yq manifests kustomize operator-sdk ## Generate bundle manifests, metadata and package manifests
 	$(OPERATOR_SDK) generate kustomize manifests -q
-	- make bundle-manifests CHANNELS=v4.2 DEFAULT_CHANNEL=v4.2
+	- make bundle-manifests CHANNELS=v4.3 DEFAULT_CHANNEL=v4.3
 
 ##@ Test
 

--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -49,6 +49,7 @@ type ConfigService struct {
 	Resources []ConfigResource `json:"resources,omitempty"`
 }
 
+// +kubebuilder:pruning:PreserveUnknownFields
 // ConfigResource defines the resource needed for the service
 type ConfigResource struct {
 	// Name is the resource name.
@@ -75,6 +76,28 @@ type ConfigResource struct {
 	// +nullable
 	// +optional
 	Data *runtime.RawExtension `json:"data,omitempty"`
+	// OwnerReferences is the list of owner references.
+	// +optional
+	OwnerReferences []OwnerReference `json:"ownerReferences,omitempty"`
+}
+
+type OwnerReference struct {
+	// API version of the referent.
+	APIVersion string `json:"apiVersion"`
+	// Kind of the referent.
+	Kind string `json:"kind"`
+	// Name of the referent.
+	Name string `json:"name"`
+	// If true, this reference points to the managing controller.
+	// Default is false.
+	// +optional
+	Controller *bool `json:"controller,omitempty"`
+	// If true, AND if the owner has the "foregroundDeletion" finalizer, then
+	// the owner cannot be deleted from the key-value store until this
+	// reference is removed.
+	// Defaults to false.
+	// +optional
+	BlockOwnerDeletion *bool `json:"blockOwnerDeletion,omitempty"`
 }
 
 // OperandConfigStatus defines the observed state of OperandConfig.

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-odlm
 LABEL operators.operatorframework.io.bundle.channels.v1=v4.3
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v4.3
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.29.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -134,7 +134,7 @@ metadata:
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.3.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.29.0
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/operand-deployment-lifecycle-manager
     support: IBM
@@ -149,7 +149,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: OperandBindInfo is the Schema for the operandbindinfoes API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      - description: OperandBindInfo is the Schema for the operandbindinfoes API.
         displayName: OperandBindInfo
         kind: OperandBindInfo
         name: operandbindinfos.operator.ibm.com
@@ -160,7 +160,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperandConfig is the Schema for the operandconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      - description: OperandConfig is the Schema for the operandconfigs API.
         displayName: OperandConfig
         kind: OperandConfig
         name: operandconfigs.operator.ibm.com
@@ -175,7 +175,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperandRegistry is the Schema for the operandregistries API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      - description: OperandRegistry is the Schema for the operandregistries API.
         displayName: OperandRegistry
         kind: OperandRegistry
         name: operandregistries.operator.ibm.com
@@ -195,7 +195,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperandRequest is the Schema for the operandrequests API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      - description: OperandRequest is the Schema for the operandrequests API.
         displayName: OperandRequest
         kind: OperandRequest
         name: operandrequests.operator.ibm.com

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -102,11 +102,41 @@ spec:
                           namespace:
                             description: Namespace is the namespace of the resource.
                             type: string
+                          ownerReferences:
+                            description: OwnerReferences is the list of owner references.
+                            items:
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                blockOwnerDeletion:
+                                  description: If true, AND if the owner has the "foregroundDeletion"
+                                    finalizer, then the owner cannot be deleted from
+                                    the key-value store until this reference is removed.
+                                    Defaults to false.
+                                  type: boolean
+                                controller:
+                                  description: If true, this reference points to the
+                                    managing controller. Default is false.
+                                  type: boolean
+                                kind:
+                                  description: Kind of the referent.
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - apiVersion
+                              - kind
+                              - name
+                              type: object
+                            type: array
                         required:
                         - apiVersion
                         - kind
                         - name
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: array
                     spec:
                       additionalProperties:

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-odlm
   operators.operatorframework.io.bundle.channels.v1: v4.3
   operators.operatorframework.io.bundle.channel.default.v1: v4.3
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.29.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   # Annotations for testing.

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -100,11 +100,41 @@ spec:
                           namespace:
                             description: Namespace is the namespace of the resource.
                             type: string
+                          ownerReferences:
+                            description: OwnerReferences is the list of owner references.
+                            items:
+                              properties:
+                                apiVersion:
+                                  description: API version of the referent.
+                                  type: string
+                                blockOwnerDeletion:
+                                  description: If true, AND if the owner has the "foregroundDeletion"
+                                    finalizer, then the owner cannot be deleted from
+                                    the key-value store until this reference is removed.
+                                    Defaults to false.
+                                  type: boolean
+                                controller:
+                                  description: If true, this reference points to the
+                                    managing controller. Default is false.
+                                  type: boolean
+                                kind:
+                                  description: Kind of the referent.
+                                  type: string
+                                name:
+                                  description: Name of the referent.
+                                  type: string
+                              required:
+                              - apiVersion
+                              - kind
+                              - name
+                              type: object
+                            type: array
                         required:
                         - apiVersion
                         - kind
                         - name
                         type: object
+                        x-kubernetes-preserve-unknown-fields: true
                       type: array
                     spec:
                       additionalProperties:

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: OperandBindInfo is the Schema for the operandbindinfoes API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+    - description: OperandBindInfo is the Schema for the operandbindinfoes API.
       displayName: OperandBindInfo
       kind: OperandBindInfo
       name: operandbindinfos.operator.ibm.com
@@ -39,7 +39,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperandConfig is the Schema for the operandconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+    - description: OperandConfig is the Schema for the operandconfigs API.
       displayName: OperandConfig
       kind: OperandConfig
       name: operandconfigs.operator.ibm.com
@@ -54,7 +54,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperandRegistry is the Schema for the operandregistries API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+    - description: OperandRegistry is the Schema for the operandregistries API.
       displayName: OperandRegistry
       kind: OperandRegistry
       name: operandregistries.operator.ibm.com
@@ -74,7 +74,7 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperandRequest is the Schema for the operandrequests API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+    - description: OperandRequest is the Schema for the operandrequests API.
       displayName: OperandRequest
       kind: OperandRequest
       name: operandrequests.operator.ibm.com

--- a/controllers/operandrequest/reconcile_operand_test.go
+++ b/controllers/operandrequest/reconcile_operand_test.go
@@ -1,0 +1,118 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package operandrequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
+	deploy "github.com/IBM/operand-deployment-lifecycle-manager/controllers/operator"
+)
+
+type MockReader struct {
+	mock.Mock
+}
+
+func (m *MockReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	args := m.Called(ctx, key, obj)
+	return args.Error(0)
+}
+func (m *MockReader) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	args := m.Called(ctx, list, opts)
+	return args.Error(0)
+}
+
+func TestSetOwnerReferences(t *testing.T) {
+	// Create a fake client
+	client := fake.NewClientBuilder().Build()
+
+	// Create a mock reader
+	reader := &MockReader{}
+
+	// Create a reconciler instance
+	r := &Reconciler{
+		ODLMOperator: &deploy.ODLMOperator{
+			Client: client,
+			Reader: reader,
+		},
+	}
+
+	// Create the controlled resource
+	controlledRes := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Pod",
+			"metadata": map[string]interface{}{
+				"name":      "test-pod",
+				"namespace": "test-namespace",
+			},
+		},
+	}
+
+	// Create the owner references
+	ownerReferences := []operatorv1alpha1.OwnerReference{
+		{
+			APIVersion: "v1",
+			Kind:       "Deployment",
+			Name:       "test-deployment",
+			Controller: pointer.BoolPtr(true),
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "Service",
+			Name:       "test-service",
+			Controller: pointer.BoolPtr(false),
+		},
+	}
+
+	// Mock the Get method of the reader
+	reader.On("Get", mock.Anything, types.NamespacedName{Name: "test-deployment", Namespace: "test-namespace"}, mock.AnythingOfType("*unstructured.Unstructured")).Return(nil)
+	reader.On("Get", mock.Anything, types.NamespacedName{Name: "test-service", Namespace: "test-namespace"}, mock.AnythingOfType("*unstructured.Unstructured")).Return(nil)
+
+	// Call the setOwnerReferences function
+	err := r.setOwnerReferences(context.Background(), controlledRes, &ownerReferences)
+
+	// Assert that there are no errors
+	assert.NoError(t, err)
+
+	// Assert that the owner references are set correctly
+	expectedOwnerReferences := []metav1.OwnerReference{
+		{
+			APIVersion:         "v1",
+			Kind:               "Deployment",
+			Name:               "test-deployment",
+			Controller:         pointer.BoolPtr(true),
+			BlockOwnerDeletion: pointer.BoolPtr(true),
+		},
+		{
+			APIVersion: "v1",
+			Kind:       "Service",
+			Name:       "test-service",
+		},
+	}
+	assert.Equal(t, expectedOwnerReferences, controlledRes.GetOwnerReferences())
+}

--- a/go.mod
+++ b/go.mod
@@ -15,12 +15,14 @@ require (
 	github.com/operator-framework/api v0.6.2
 	github.com/operator-framework/operator-lifecycle-manager v0.17.0
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.9.0
 	golang.org/x/mod v0.8.0
 	k8s.io/api v0.24.3
 	k8s.io/apiextensions-apiserver v0.24.2
 	k8s.io/apimachinery v0.24.3
 	k8s.io/client-go v0.24.3
 	k8s.io/klog v1.0.0
+	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 	sigs.k8s.io/controller-runtime v0.12.3
 	sigs.k8s.io/kubebuilder v1.0.9-0.20200805184228-f7a3b65dd250
 )
@@ -66,6 +68,7 @@ require (
 	github.com/operator-framework/operator-registry v1.13.6 // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.12.2 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
@@ -76,6 +79,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.12.0 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.3.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
@@ -99,7 +103,6 @@ require (
 	k8s.io/component-base v0.24.2 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220627174259-011e075b9cb8 // indirect
-	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -917,6 +917,8 @@ github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v0.0.0-20151208002404-e3a8ff8ce365/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
@@ -926,7 +928,8 @@ github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/subosito/gotenv v1.3.0 h1:mjC+YW8QpAdXibNi+vNWgzmgBH4+5l5dCXv8cNysBLI=
 github.com/subosito/gotenv v1.3.0/go.mod h1:YzJjq/33h7nrwdY+iHMhEOEEbW0ovIz0tB6t6PwAXzs=


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61732

Introducing ability to specify OwnerReference for a object created by ODLM, here is the example in OperandConfig. It will set CR with kind `Keycloak` and name `cs-keycloak` as the owner of CR with kind `KeycloakRealmImport` and name `cs-cloudpak-realm`
```
resources:
- apiVersion: k8s.keycloak.org/v2alpha1
  kind: KeycloakRealmImport
  name: cs-cloudpak-realm
  force: false
  ownerReferences:         <----------- new field
     - apiVersion: k8s.keycloak.org/v2alpha1
        kind: Keycloak
        name: cs-keycloak
        controller: false
     - .... # second owner
  data:
    spec:
      keycloakCRName: cs-keycloak
      realm:
        displayName: IBM Cloud Pak
```

### How to test
- Apply OperandConfig CRD changes on the cluster, introducing OwnerReferences field, see file `bundle/manifests/operator.ibm.com_operandconfigs.yaml` for more details
- [Patch OperandConfig to contain the owner info](https://github.com/IBM/ibm-common-service-operator/pull/1870)
- Patch ODLM CSV with the dev build image `quay.io/opencloudio/odlm:c96ea321-dirty`

After creating OperandRequest to deploy `keycloak-operator`, we will see Keycloak is added as the owner of KeycloakRealmImport
<img width="605" alt="Screenshot 2024-03-19 at 10 14 52 AM" src="https://github.com/IBM/operand-deployment-lifecycle-manager/assets/29827416/663f9f60-2532-4ef3-b6cc-8a6d982b7f0d">

