### PR TITLE
Support uninstallation on intra-dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,6 @@ BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
-# Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
-
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -199,7 +196,7 @@ deploy-e2e: kustomize ## Deploy controller in the configured Kubernetes cluster 
 ##@ Generate code and manifests
 
 manifests: controller-gen ## Generate manifests e.g. CRD, RBAC etc.
-	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=operand-deployment-lifecycle-manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	$(CONTROLLER_GEN) crd rbac:roleName=operand-deployment-lifecycle-manager webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 generate: controller-gen ## Generate code e.g. API etc.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

--- a/api/v1alpha1/operandbindinfo_types.go
+++ b/api/v1alpha1/operandbindinfo_types.go
@@ -118,7 +118,7 @@ type OperandBindInfoStatus struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 
-// OperandBindInfo is the Schema for the operandbindinfoes API.
+// OperandBindInfo is the Schema for the operandbindinfoes API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=operandbindinfos,shortName=opbi,scope=Namespaced
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=.metadata.creationTimestamp

--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -117,7 +117,7 @@ type CrStatus struct {
 	CrStatus map[string]ServicePhase `json:"customResourceStatus,omitempty"`
 }
 
-// OperandConfig is the Schema for the operandconfigs API.
+// OperandConfig is the Schema for the operandconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=operandconfigs,shortName=opcon,scope=Namespaced

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -148,7 +148,7 @@ type ReconcileRequest struct {
 // +kubebuilder:printcolumn:name="Created At",type=string,JSONPath=.metadata.creationTimestamp
 // +operator-sdk:csv:customresourcedefinitions:displayName="OperandRegistry"
 
-// OperandRegistry is the Schema for the operandregistries API.
+// OperandRegistry is the Schema for the operandregistries API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
 type OperandRegistry struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -245,7 +245,7 @@ type MemberStatus struct {
 // +kubebuilder:printcolumn:name="Created At",type=string,JSONPath=.metadata.creationTimestamp
 // +operator-sdk:csv:customresourcedefinitions:displayName="OperandRequest"
 
-// OperandRequest is the Schema for the operandrequests API.
+// OperandRequest is the Schema for the operandrequests API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
 type OperandRequest struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -68,7 +68,7 @@ type OperatorConfigStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 
-// OperatorConfig is the Schema for the operatorconfigs API
+// OperatorConfig is the Schema for the operatorconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
 type OperatorConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=ibm-odlm
 LABEL operators.operatorframework.io.bundle.channels.v1=v4.3
 LABEL operators.operatorframework.io.bundle.channel.default.v1=v4.3
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.29.0
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.32.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -149,7 +149,7 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: OperandBindInfo is the Schema for the operandbindinfoes API.
+      - description: OperandBindInfo is the Schema for the operandbindinfoes API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         displayName: OperandBindInfo
         kind: OperandBindInfo
         name: operandbindinfos.operator.ibm.com
@@ -160,7 +160,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperandConfig is the Schema for the operandconfigs API.
+      - description: OperandConfig is the Schema for the operandconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         displayName: OperandConfig
         kind: OperandConfig
         name: operandconfigs.operator.ibm.com
@@ -175,7 +175,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperandRegistry is the Schema for the operandregistries API.
+      - description: OperandRegistry is the Schema for the operandregistries API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         displayName: OperandRegistry
         kind: OperandRegistry
         name: operandregistries.operator.ibm.com
@@ -195,7 +195,7 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperandRequest is the Schema for the operandrequests API.
+      - description: OperandRequest is the Schema for the operandrequests API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         displayName: OperandRequest
         kind: OperandRequest
         name: operandrequests.operator.ibm.com

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,12 +129,12 @@ metadata:
     categories: Developer Tools, Monitoring, Logging & Tracing, Security
     certified: "false"
     containerImage: icr.io/cpopen/odlm:latest
-    createdAt: "2024-03-29T03:10:47Z"
+    createdAt: "2024-04-02T02:16:34Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.3.0'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
-    operators.operatorframework.io/builder: operator-sdk-v1.29.0
+    operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/IBM/operand-deployment-lifecycle-manager
     support: IBM
@@ -215,7 +215,9 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - kind: OperatorConfig
+      - description: OperatorConfig is the Schema for the operatorconfigs API
+        displayName: Operator Config
+        kind: OperatorConfig
         name: operatorconfigs.operator.ibm.com
         version: v1alpha1
   description: |-
@@ -567,19 +569,19 @@ spec:
       clusterPermissions:
         - rules:
             - apiGroups:
+                - operator.ibm.com
+              resources:
+                - auditloggings
+                - certmanagers
+              verbs:
+                - delete
+                - get
+            - apiGroups:
                 - operators.coreos.com
               resources:
                 - catalogsources
               verbs:
                 - get
-            - apiGroups:
-                - operator.ibm.com
-              resources:
-                - certmanagers
-                - auditloggings
-              verbs:
-                - get
-                - delete
           serviceAccountName: operand-deployment-lifecycle-manager
       deployments:
         - label:
@@ -675,9 +677,37 @@ spec:
       permissions:
         - rules:
             - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - namespaces
+                - secrets
+                - services
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
                 - '*'
               resources:
                 - '*'
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - k8s.keycloak.org
+              resources:
+                - keycloakrealmimports
+                - keycloaks
               verbs:
                 - create
                 - delete
@@ -690,47 +720,50 @@ spec:
                 - operator.ibm.com
               resources:
                 - operandconfigs
-                - operandconfigs/status
                 - operandconfigs/finalizers
+                - operandconfigs/status
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
                 - operandregistries
-                - operandregistries/status
                 - operandregistries/finalizers
+                - operandregistries/status
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
                 - operandrequests
-                - operandrequests/status
                 - operandrequests/finalizers
-                - operandbindinfos
-                - operandbindinfos/status
-                - operandbindinfos/finalizers
+                - operandrequests/status
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
                 - operatorconfigs
-                - operatorconfigs/status
                 - operatorconfigs/finalizers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - secrets
-                - services
-                - namespaces
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - routes
+                - operatorconfigs/status
               verbs:
                 - create
                 - delete
@@ -742,8 +775,8 @@ spec:
             - apiGroups:
                 - operators.coreos.com
               resources:
-                - operatorgroups
-                - installplans
+                - clusterserviceversions
+                - subscriptions
               verbs:
                 - create
                 - delete
@@ -753,9 +786,10 @@ spec:
                 - update
                 - watch
             - apiGroups:
-                - k8s.keycloak.org
+                - operators.coreos.com
               resources:
-                - keycloaks
+                - installplans
+                - operatorgroups
               verbs:
                 - create
                 - delete
@@ -769,6 +803,18 @@ spec:
               resources:
                 - packagemanifests
               verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+              verbs:
+                - create
+                - delete
                 - get
                 - list
                 - patch

--- a/bundle/manifests/operator.ibm.com_operandbindinfos.yaml
+++ b/bundle/manifests/operator.ibm.com_operandbindinfos.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: operand-deployment-lifecycle-manager
@@ -35,16 +35,24 @@ spec:
     schema:
       openAPIV3Schema:
         description: OperandBindInfo is the Schema for the operandbindinfoes API.
+          Documentation For additional details regarding install parameters check
+          https://ibm.biz/icpfs39install. License By installing this product you accept
+          the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -53,12 +61,13 @@ spec:
             properties:
               bindings:
                 additionalProperties:
-                  description: Bindable is a Kubernetes resources to be shared from
-                    one namespace to another. List of supported resources are Secrets,
-                    Configmaps, Services, and Routes. Secrets and Configmaps will
-                    be copied such that a new Secret/Configmap with exactly the same
-                    data will be created in the target namespace. Services and Routes
-                    data will be copied into a configmap in the target namespace.
+                  description: |-
+                    Bindable is a Kubernetes resources to be shared from one namespace to another.
+                    List of supported resources are Secrets, Configmaps, Services, and Routes.
+                    Secrets and Configmaps will be copied such that a new Secret/Configmap with
+                    exactly the same data will be created in the target namespace.
+                    Services and Routes data will be copied into a configmap in the target
+                    namespace.
                   properties:
                     configmap:
                       description: The configmap identifies an existing configmap
@@ -66,15 +75,16 @@ spec:
                         of the OperandRequest.
                       type: string
                     route:
-                      description: Route data will be shared by copying it into a
-                        configmap which is then created in the target namespace
+                      description: |-
+                        Route data will be shared by copying it into a configmap which is then
+                        created in the target namespace
                       properties:
                         data:
                           additionalProperties:
                             type: string
-                          description: Data is a key-value pair where the value is
-                            a YAML path to a value in the OpenShift Route, e.g. .spec.host
-                            or .spec.tls.termination
+                          description: |-
+                            Data is a key-value pair where the value is a YAML path to a value in the
+                            OpenShift Route, e.g. .spec.host or .spec.tls.termination
                           type: object
                         name:
                           description: Name is the name of the OpenShift Route resource
@@ -85,15 +95,16 @@ spec:
                         exists, the ODLM will share to the namespace of the OperandRequest.
                       type: string
                     service:
-                      description: Service data will be shared by copying it into
-                        a configmap which is then created in the target namespace
+                      description: |-
+                        Service data will be shared by copying it into a configmap which is then
+                        created in the target namespace
                       properties:
                         data:
                           additionalProperties:
                             type: string
-                          description: Data is a key-value pair where the value is
-                            a YAML path to a value in the Kubernetes Service, e.g.
-                            .spec.ports[0]port
+                          description: |-
+                            Data is a key-value pair where the value is a YAML path to a value in the
+                            Kubernetes Service, e.g. .spec.ports[0]port
                           type: object
                         name:
                           description: Name is the name of the Kubernetes Service
@@ -107,7 +118,8 @@ spec:
               description:
                 type: string
               operand:
-                description: The deployed service identifies itself with its operand.
+                description: |-
+                  The deployed service identifies itself with its operand.
                   This must match the name in the OperandRegistry in the current namespace.
                 type: string
               registry:
@@ -115,9 +127,9 @@ spec:
                   CR from which this operand deployment is being requested.
                 type: string
               registryNamespace:
-                description: Specifies the namespace in which the OperandRegistry
-                  reside. The default is the current namespace in which the request
-                  is defined.
+                description: |-
+                  Specifies the namespace in which the OperandRegistry reside.
+                  The default is the current namespace in which the request is defined.
                 type: string
             required:
             - operand
@@ -146,5 +158,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: operand-deployment-lifecycle-manager
@@ -34,17 +34,24 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OperandConfig is the Schema for the operandconfigs API.
+        description: OperandConfig is the Schema for the operandconfigs API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -110,14 +117,16 @@ spec:
                                   description: API version of the referent.
                                   type: string
                                 blockOwnerDeletion:
-                                  description: If true, AND if the owner has the "foregroundDeletion"
-                                    finalizer, then the owner cannot be deleted from
-                                    the key-value store until this reference is removed.
+                                  description: |-
+                                    If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                    the owner cannot be deleted from the key-value store until this
+                                    reference is removed.
                                     Defaults to false.
                                   type: boolean
                                 controller:
-                                  description: If true, this reference points to the
-                                    managing controller. Default is false.
+                                  description: |-
+                                    If true, this reference points to the managing controller.
+                                    Default is false.
                                   type: boolean
                                 kind:
                                   description: Kind of the referent.
@@ -183,5 +192,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: operand-deployment-lifecycle-manager
@@ -35,16 +35,24 @@ spec:
     schema:
       openAPIV3Schema:
         description: OperandRegistry is the Schema for the operandregistries API.
+          Documentation For additional details regarding install parameters check
+          https://ibm.biz/icpfs39install. License By installing this product you accept
+          the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -63,27 +71,28 @@ spec:
                       description: Description of a common service.
                       type: string
                     installMode:
-                      description: 'The install mode of an operator, either namespace
-                        or cluster. Valid values are: - "namespace" (default): operator
-                        is deployed in namespace of OperandRegistry; - "cluster":
-                        operator is deployed in "openshift-operators" namespace; -
-                        "no-op": operator is not supported to be fresh deployed;'
+                      description: |-
+                        The install mode of an operator, either namespace or cluster.
+                        Valid values are:
+                        - "namespace" (default): operator is deployed in namespace of OperandRegistry;
+                        - "cluster": operator is deployed in "openshift-operators" namespace;
+                        - "no-op": operator is not supported to be fresh deployed;
                       type: string
                     installPlanApproval:
-                      description: 'Approval mode for emitted InstallPlans. Valid
-                        values are: - "Automatic" (default): operator will be installed
-                        automatically; - "Manual": operator installation will be pending
-                        until users approve it;'
+                      description: |-
+                        Approval mode for emitted InstallPlans.
+                        Valid values are:
+                        - "Automatic" (default): operator will be installed automatically;
+                        - "Manual": operator installation will be pending until users approve it;
                       type: string
                     name:
                       description: A unique name for the operator whose operand may
                         be deployed.
                       type: string
                     namespace:
-                      description: The namespace in which operator should be deployed
-                        when InstallMode is empty or set to "namespace". If the namespace
-                        is not set, the operator namespace is the same as OperandRegistry
-                        Namespace
+                      description: |-
+                        The namespace in which operator should be deployed when InstallMode is empty or set to "namespace".
+                        If the namespace is not set, the operator namespace is the same as OperandRegistry Namespace
                       type: string
                     operatorConfig:
                       description: OperatorConfig is the name of the OperatorConfig
@@ -92,10 +101,11 @@ spec:
                       description: Name of the package that defines the applications.
                       type: string
                     scope:
-                      description: 'A scope indicator, either public or private. Valid
-                        values are: - "private" (default): deployment only request
-                        from the containing names; - "public": deployment can be requested
-                        from other namespaces;'
+                      description: |-
+                        A scope indicator, either public or private.
+                        Valid values are:
+                        - "private" (default): deployment only request from the containing names;
+                        - "public": deployment can be requested from other namespaces;
                       enum:
                       - public
                       - private
@@ -116,8 +126,9 @@ spec:
                         configuration.
                       properties:
                         env:
-                          description: Env is a list of environment variables to set
-                            in the container. Cannot be updated.
+                          description: |-
+                            Env is a list of environment variables to set in the container.
+                            Cannot be updated.
                           items:
                             description: EnvVar represents an environment variable
                               present in a Container.
@@ -127,17 +138,16 @@ spec:
                                   be a C_IDENTIFIER.
                                 type: string
                               value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previously defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Defaults to
-                                  "".'
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -150,10 +160,10 @@ spec:
                                         description: The key to select.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -162,12 +172,11 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                     properties:
                                       apiVersion:
                                         description: Version of the schema the FieldPath
@@ -180,12 +189,11 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                     properties:
                                       containerName:
                                         description: 'Container name: required for
@@ -205,6 +213,7 @@ spec:
                                     required:
                                     - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     description: Selects a key of a secret in the
                                       pod's namespace
@@ -214,10 +223,10 @@ spec:
                                           from.  Must be a valid secret key.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret or
@@ -226,19 +235,20 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                             - name
                             type: object
                           type: array
                         envFrom:
-                          description: EnvFrom is a list of sources to populate environment
-                            variables in the container. The keys defined within a
-                            source must be a C_IDENTIFIER. All invalid keys will be
-                            reported as an event when the container is starting. When
-                            a key exists in multiple sources, the value associated
-                            with the last source will take precedence. Values defined
-                            by an Env with a duplicate key will take precedence. Immutable.
+                          description: |-
+                            EnvFrom is a list of sources to populate environment variables in the container.
+                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                            will be reported as an event when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take precedence.
+                            Values defined by an Env with a duplicate key will take precedence.
+                            Immutable.
                           items:
                             description: EnvFromSource represents the source of a
                               set of ConfigMaps
@@ -247,16 +257,17 @@ spec:
                                 description: The ConfigMap to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: Specify whether the ConfigMap must
                                       be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 description: An optional identifier to prepend to
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -265,29 +276,32 @@ spec:
                                 description: The Secret to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: Specify whether the Secret must be
                                       defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          description: 'NodeSelector is a selector which must be true
-                            for the pod to fit on a node. Selector which must match
-                            a node''s labels for the pod to be scheduled on that node.
-                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                          description: |-
+                            NodeSelector is a selector which must be true for the pod to fit on a node.
+                            Selector which must match a node's labels for the pod to be scheduled on that node.
+                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                           type: object
                         resources:
-                          description: 'Resources represents compute resources required
-                            by this container. Immutable. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: |-
+                            Resources represents compute resources required by this container.
+                            Immutable.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                           properties:
                             limits:
                               additionalProperties:
@@ -296,8 +310,9 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               type: object
                             requests:
                               additionalProperties:
@@ -306,25 +321,26 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               type: object
                           type: object
                         selector:
-                          description: Selector is the label selector for pods to
-                            be configured. Existing ReplicaSets whose pods are selected
-                            by this will be the ones affected by this deployment.
+                          description: |-
+                            Selector is the label selector for pods to be configured.
+                            Existing ReplicaSets whose pods are
+                            selected by this will be the ones affected by this deployment.
                             It must match the pod template's labels.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -332,17 +348,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -354,53 +369,49 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         tolerations:
                           description: Tolerations are the pod's tolerations.
                           items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect>
-                              using the matching operator <operator>.
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to
-                                  match. Empty means match all taint effects. When
-                                  specified, allowed values are NoSchedule, PreferNoSchedule
-                                  and NoExecute.
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration
-                                  applies to. Empty means match all taint keys. If
-                                  the key is empty, operator must be Exists; this
-                                  combination means to match all values and all keys.
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship
-                                  to the value. Valid operators are Exists and Equal.
-                                  Defaults to Equal. Exists is equivalent to wildcard
-                                  for value, so that a pod can tolerate all taints
-                                  of a particular category.
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period
-                                  of time the toleration (which must be of effect
-                                  NoExecute, otherwise this field is ignored) tolerates
-                                  the taint. By default, it is not set, which means
-                                  tolerate the taint forever (do not evict). Zero
-                                  and negative values will be treated as 0 (evict
-                                  immediately) by the system.
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration
-                                  matches to. If the operator is Exists, the value
-                                  should be empty, otherwise just a regular string.
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
                                 type: string
                             type: object
                           type: array
@@ -411,34 +422,36 @@ spec:
                               within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
+                                description: |-
+                                  mountPropagation determines how mounts are propagated from the host
+                                  to container and the other way around.
+                                  When not set, MountPropagationNone is used.
+                                  This field is beta in 1.10.
                                 type: string
                               name:
                                 description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
+                                description: |-
+                                  Mounted read-only if true, read-write otherwise (false or unspecified).
+                                  Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
+                                description: |-
+                                  Path within the volume from which the container's volume should be mounted.
+                                  Defaults to "" (volume's root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
+                                description: |-
+                                  Expanded path within the volume from which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root).
+                                  SubPathExpr and SubPath are mutually exclusive.
                                 type: string
                             required:
                             - mountPath
@@ -452,40 +465,36 @@ spec:
                               that may be accessed by any container in the pod.
                             properties:
                               awsElasticBlockStore:
-                                description: 'awsElasticBlockStore represents an AWS
-                                  Disk resource that is attached to a kubelet''s host
-                                  machine and then exposed to the pod. More info:
-                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                description: |-
+                                  awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type of
-                                      the volume that you want to mount. Tip: Ensure
-                                      that the filesystem type is supported by the
-                                      host operating system. Examples: "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
-                                    description: 'partition is the partition in the
-                                      volume that you want to mount. If omitted, the
-                                      default is to mount by volume name. Examples:
-                                      For volume /dev/sda1, you specify the partition
-                                      as "1". Similarly, the volume partition for
-                                      /dev/sda is "0" (or you can leave the property
-                                      empty).'
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                     format: int32
                                     type: integer
                                   readOnly:
-                                    description: 'readOnly value true will force the
-                                      readOnly setting in VolumeMounts. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      readOnly value true will force the readOnly setting in VolumeMounts.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     type: boolean
                                   volumeID:
-                                    description: 'volumeID is unique ID of the persistent
-                                      disk resource in AWS (Amazon EBS volume). More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     type: string
                                 required:
                                 - volumeID
@@ -507,10 +516,10 @@ spec:
                                       the blob storage
                                     type: string
                                   fsType:
-                                    description: fsType is Filesystem type to mount.
-                                      Must be a filesystem type supported by the host
-                                      operating system. Ex. "ext4", "xfs", "ntfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   kind:
                                     description: 'kind expected values are Shared:
@@ -520,9 +529,9 @@ spec:
                                       set). defaults to shared'
                                     type: string
                                   readOnly:
-                                    description: readOnly Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                 required:
                                 - diskName
@@ -533,9 +542,9 @@ spec:
                                   mount on the host and bind mount to the pod.
                                 properties:
                                   readOnly:
-                                    description: readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretName:
                                     description: secretName is the  name of secret
@@ -554,8 +563,9 @@ spec:
                                   the host that shares a pod's lifetime
                                 properties:
                                   monitors:
-                                    description: 'monitors is Required: Monitors is
-                                      a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      monitors is Required: Monitors is a collection of Ceph monitors
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     items:
                                       type: string
                                     type: array
@@ -565,67 +575,72 @@ spec:
                                       is /'
                                     type: string
                                   readOnly:
-                                    description: 'readOnly is Optional: Defaults to
-                                      false (read/write). ReadOnly here will force
-                                      the ReadOnly setting in VolumeMounts. More info:
-                                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     type: boolean
                                   secretFile:
-                                    description: 'secretFile is Optional: SecretFile
-                                      is the path to key ring for User, default is
-                                      /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     type: string
                                   secretRef:
-                                    description: 'secretRef is Optional: SecretRef
-                                      is reference to the authentication secret for
-                                      User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
-                                    description: 'user is optional: User is the rados
-                                      user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      user is optional: User is the rados user name, default is admin
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     type: string
                                 required:
                                 - monitors
                                 type: object
                               cinder:
-                                description: 'cinder represents a cinder volume attached
-                                  and mounted on kubelets host machine. More info:
-                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                description: |-
+                                  cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Examples: "ext4",
-                                      "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                      if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     type: string
                                   readOnly:
-                                    description: 'readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     type: boolean
                                   secretRef:
-                                    description: 'secretRef is optional: points to
-                                      a secret object containing parameters used to
-                                      connect to OpenStack.'
+                                    description: |-
+                                      secretRef is optional: points to a secret object containing parameters used to connect
+                                      to OpenStack.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeID:
-                                    description: 'volumeID used to identify the volume
-                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      volumeID used to identify the volume in cinder.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     type: string
                                 required:
                                 - volumeID
@@ -635,31 +650,25 @@ spec:
                                   should populate this volume
                                 properties:
                                   defaultMode:
-                                    description: 'defaultMode is optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description: Maps a string key to a path within
                                         a volume.
@@ -668,25 +677,21 @@ spec:
                                           description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -694,61 +699,60 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: optional specify whether the ConfigMap
                                       or its keys must be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               csi:
                                 description: csi (Container Storage Interface) represents
                                   ephemeral storage that is handled by certain external
                                   CSI drivers (Beta feature).
                                 properties:
                                   driver:
-                                    description: driver is the name of the CSI driver
-                                      that handles this volume. Consult with your
-                                      admin for the correct name as registered in
-                                      the cluster.
+                                    description: |-
+                                      driver is the name of the CSI driver that handles this volume.
+                                      Consult with your admin for the correct name as registered in the cluster.
                                     type: string
                                   fsType:
-                                    description: fsType to mount. Ex. "ext4", "xfs",
-                                      "ntfs". If not provided, the empty value is
-                                      passed to the associated CSI driver which will
-                                      determine the default filesystem to apply.
+                                    description: |-
+                                      fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                      If not provided, the empty value is passed to the associated CSI driver
+                                      which will determine the default filesystem to apply.
                                     type: string
                                   nodePublishSecretRef:
-                                    description: nodePublishSecretRef is a reference
-                                      to the secret object containing sensitive information
-                                      to pass to the CSI driver to complete the CSI
+                                    description: |-
+                                      nodePublishSecretRef is a reference to the secret object containing
+                                      sensitive information to pass to the CSI driver to complete the CSI
                                       NodePublishVolume and NodeUnpublishVolume calls.
-                                      This field is optional, and  may be empty if
-                                      no secret is required. If the secret object
-                                      contains more than one secret, all secret references
-                                      are passed.
+                                      This field is optional, and  may be empty if no secret is required. If the
+                                      secret object contains more than one secret, all secret references are passed.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   readOnly:
-                                    description: readOnly specifies a read-only configuration
-                                      for the volume. Defaults to false (read/write).
+                                    description: |-
+                                      readOnly specifies a read-only configuration for the volume.
+                                      Defaults to false (read/write).
                                     type: boolean
                                   volumeAttributes:
                                     additionalProperties:
                                       type: string
-                                    description: volumeAttributes stores driver-specific
-                                      properties that are passed to the CSI driver.
-                                      Consult your driver's documentation for supported
-                                      values.
+                                    description: |-
+                                      volumeAttributes stores driver-specific properties that are passed to the CSI
+                                      driver. Consult your driver's documentation for supported values.
                                     type: object
                                 required:
                                 - driver
@@ -758,18 +762,15 @@ spec:
                                   the pod that should populate this volume
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits to use on created
-                                      files by default. Must be a Optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
+                                    description: |-
+                                      Optional: mode bits to use on created files by default. Must be a
+                                      Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
@@ -797,18 +798,15 @@ spec:
                                           required:
                                           - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
@@ -820,10 +818,9 @@ spec:
                                             with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
                                               description: 'Container name: required
@@ -845,127 +842,131 @@ spec:
                                           required:
                                           - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                       - path
                                       type: object
                                     type: array
                                 type: object
                               emptyDir:
-                                description: 'emptyDir represents a temporary directory
-                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                description: |-
+                                  emptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 properties:
                                   medium:
-                                    description: 'medium represents what type of storage
-                                      medium should back this directory. The default
-                                      is "" which means to use the node''s default
-                                      medium. Must be an empty string (default) or
-                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
                                   sizeLimit:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'sizeLimit is the total amount of
-                                      local storage required for this EmptyDir volume.
-                                      The size limit is also applicable for memory
-                                      medium. The maximum usage on memory medium EmptyDir
-                                      would be the minimum value between the SizeLimit
-                                      specified here and the sum of memory limits
-                                      of all containers in a pod. The default is nil
-                                      which means that the limit is undefined. More
-                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
                               ephemeral:
-                                description: "ephemeral represents a volume that is
-                                  handled by a cluster storage driver. The volume's
-                                  lifecycle is tied to the pod that defines it - it
-                                  will be created before the pod starts, and deleted
-                                  when the pod is removed. \n Use this if: a) the
-                                  volume is only needed while the pod runs, b) features
-                                  of normal volumes like restoring from snapshot or
-                                  capacity    tracking are needed, c) the storage
-                                  driver is specified through a storage class, and
-                                  d) the storage driver supports dynamic volume provisioning
-                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more    information on the connection between
-                                  this volume type    and PersistentVolumeClaim).
-                                  \n Use PersistentVolumeClaim or one of the vendor-specific
-                                  APIs for volumes that persist for longer than the
-                                  lifecycle of an individual pod. \n Use CSI for light-weight
-                                  local ephemeral volumes if the CSI driver is meant
-                                  to be used that way - see the documentation of the
-                                  driver for more information. \n A pod can use both
-                                  types of ephemeral volumes and persistent volumes
-                                  at the same time."
+                                description: |-
+                                  ephemeral represents a volume that is handled by a cluster storage driver.
+                                  The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                  and deleted when the pod is removed.
+
+
+                                  Use this if:
+                                  a) the volume is only needed while the pod runs,
+                                  b) features of normal volumes like restoring from snapshot or capacity
+                                     tracking are needed,
+                                  c) the storage driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning through
+                                     a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                     information on the connection between this volume type
+                                     and PersistentVolumeClaim).
+
+
+                                  Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the lifecycle
+                                  of an individual pod.
+
+
+                                  Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                  be used that way - see the documentation of the driver for
+                                  more information.
+
+
+                                  A pod can use both types of ephemeral volumes and
+                                  persistent volumes at the same time.
                                 properties:
                                   volumeClaimTemplate:
-                                    description: "Will be used to create a stand-alone
-                                      PVC to provision the volume. The pod in which
-                                      this EphemeralVolumeSource is embedded will
-                                      be the owner of the PVC, i.e. the PVC will be
-                                      deleted together with the pod.  The name of
-                                      the PVC will be `<pod name>-<volume name>` where
-                                      `<volume name>` is the name from the `PodSpec.Volumes`
-                                      array entry. Pod validation will reject the
-                                      pod if the concatenated name is not valid for
-                                      a PVC (for example, too long). \n An existing
-                                      PVC with that name that is not owned by the
-                                      pod will *not* be used for the pod to avoid
-                                      using an unrelated volume by mistake. Starting
-                                      the pod is then blocked until the unrelated
-                                      PVC is removed. If such a pre-created PVC is
-                                      meant to be used by the pod, the PVC has to
-                                      updated with an owner reference to the pod once
-                                      the pod exists. Normally this should not be
-                                      necessary, but it may be useful when manually
-                                      reconstructing a broken cluster. \n This field
-                                      is read-only and no changes will be made by
-                                      Kubernetes to the PVC after it has been created.
-                                      \n Required, must not be nil."
+                                    description: |-
+                                      Will be used to create a stand-alone PVC to provision the volume.
+                                      The pod in which this EphemeralVolumeSource is embedded will be the
+                                      owner of the PVC, i.e. the PVC will be deleted together with the
+                                      pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes` array
+                                      entry. Pod validation will reject the pod if the concatenated name
+                                      is not valid for a PVC (for example, too long).
+
+
+                                      An existing PVC with that name that is not owned by the pod
+                                      will *not* be used for the pod to avoid using an unrelated
+                                      volume by mistake. Starting the pod is then blocked until
+                                      the unrelated PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to updated with an
+                                      owner reference to the pod once the pod exists. Normally
+                                      this should not be necessary, but it may be useful when
+                                      manually reconstructing a broken cluster.
+
+
+                                      This field is read-only and no changes will be made by Kubernetes
+                                      to the PVC after it has been created.
+
+
+                                      Required, must not be nil.
                                     properties:
                                       metadata:
-                                        description: May contain labels and annotations
-                                          that will be copied into the PVC when creating
-                                          it. No other fields are allowed and will
-                                          be rejected during validation.
+                                        description: |-
+                                          May contain labels and annotations that will be copied into the PVC
+                                          when creating it. No other fields are allowed and will be rejected during
+                                          validation.
                                         type: object
                                       spec:
-                                        description: The specification for the PersistentVolumeClaim.
-                                          The entire content is copied unchanged into
-                                          the PVC that gets created from this template.
-                                          The same fields as in a PersistentVolumeClaim
+                                        description: |-
+                                          The specification for the PersistentVolumeClaim. The entire content is
+                                          copied unchanged into the PVC that gets created from this
+                                          template. The same fields as in a PersistentVolumeClaim
                                           are also valid here.
                                         properties:
                                           accessModes:
-                                            description: 'accessModes contains the
-                                              desired access modes the volume should
-                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            description: |-
+                                              accessModes contains the desired access modes the volume should have.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                             items:
                                               type: string
                                             type: array
                                           dataSource:
-                                            description: 'dataSource field can be
-                                              used to specify either: * An existing
-                                              VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            description: |-
+                                              dataSource field can be used to specify either:
+                                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                               * An existing PVC (PersistentVolumeClaim)
-                                              If the provisioner or an external controller
-                                              can support the specified data source,
-                                              it will create a new volume based on
-                                              the contents of the specified data source.
-                                              If the AnyVolumeDataSource feature gate
-                                              is enabled, this field will always have
-                                              the same contents as the DataSourceRef
-                                              field.'
+                                              If the provisioner or an external controller can support the specified data source,
+                                              it will create a new volume based on the contents of the specified data source.
+                                              If the AnyVolumeDataSource feature gate is enabled, this field will always have
+                                              the same contents as the DataSourceRef field.
                                             properties:
                                               apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
                                                 type: string
                                               kind:
                                                 description: Kind is the type of resource
@@ -979,44 +980,32 @@ spec:
                                             - kind
                                             - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           dataSourceRef:
-                                            description: 'dataSourceRef specifies
-                                              the object from which to populate the
-                                              volume with data, if a non-empty volume
-                                              is desired. This may be any local object
-                                              from a non-empty API group (non core
-                                              object) or a PersistentVolumeClaim object.
-                                              When this field is specified, volume
-                                              binding will only succeed if the type
-                                              of the specified object matches some
-                                              installed volume populator or dynamic
-                                              provisioner. This field will replace
-                                              the functionality of the DataSource
-                                              field and as such if both fields are
-                                              non-empty, they must have the same value.
-                                              For backwards compatibility, both fields
-                                              (DataSource and DataSourceRef) will
-                                              be set to the same value automatically
-                                              if one of them is empty and the other
-                                              is non-empty. There are two important
-                                              differences between DataSource and DataSourceRef:
-                                              * While DataSource only allows two specific
-                                              types of objects, DataSourceRef   allows
-                                              any non-core object, as well as PersistentVolumeClaim
-                                              objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef   preserves
-                                              all values, and generates an error if
-                                              a disallowed value is   specified. (Beta)
-                                              Using this field requires the AnyVolumeDataSource
-                                              feature gate to be enabled.'
+                                            description: |-
+                                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                              volume is desired. This may be any local object from a non-empty API group (non
+                                              core object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume binding will only succeed if the type of
+                                              the specified object matches some installed volume populator or dynamic
+                                              provisioner.
+                                              This field will replace the functionality of the DataSource field and as such
+                                              if both fields are non-empty, they must have the same value. For backwards
+                                              compatibility, both fields (DataSource and DataSourceRef) will be set to the same
+                                              value automatically if one of them is empty and the other is non-empty.
+                                              There are two important differences between DataSource and DataSourceRef:
+                                              * While DataSource only allows two specific types of objects, DataSourceRef
+                                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                                              * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                                preserves all values, and generates an error if a disallowed value is
+                                                specified.
+                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                             properties:
                                               apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
                                                 type: string
                                               kind:
                                                 description: Kind is the type of resource
@@ -1030,16 +1019,14 @@ spec:
                                             - kind
                                             - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           resources:
-                                            description: 'resources represents the
-                                              minimum resources the volume should
-                                              have. If RecoverVolumeExpansionFailure
-                                              feature is enabled users are allowed
-                                              to specify resource requirements that
-                                              are lower than previous value but must
-                                              still be higher than capacity recorded
-                                              in the status field of the claim. More
-                                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            description: |-
+                                              resources represents the minimum resources the volume should have.
+                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              that are lower than previous value but must still be higher than capacity recorded in the
+                                              status field of the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -1048,9 +1035,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: 'Limits describes the
-                                                  maximum amount of compute resources
-                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -1059,13 +1046,11 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: 'Requests describes the
-                                                  minimum amount of compute resources
-                                                  required. If Requests is omitted
-                                                  for a container, it defaults to
-                                                  Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           selector:
@@ -1077,10 +1062,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1088,21 +1072,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1115,26 +1093,22 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           storageClassName:
-                                            description: 'storageClassName is the
-                                              name of the StorageClass required by
-                                              the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            description: |-
+                                              storageClassName is the name of the StorageClass required by the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                             type: string
                                           volumeMode:
-                                            description: volumeMode defines what type
-                                              of volume is required by the claim.
-                                              Value of Filesystem is implied when
-                                              not included in claim spec.
+                                            description: |-
+                                              volumeMode defines what type of volume is required by the claim.
+                                              Value of Filesystem is implied when not included in claim spec.
                                             type: string
                                           volumeName:
                                             description: volumeName is the binding
@@ -1152,21 +1126,20 @@ spec:
                                   then exposed to the pod.
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. TODO: how do we prevent errors
-                                      in the filesystem from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   lun:
                                     description: 'lun is Optional: FC target lun number'
                                     format: int32
                                     type: integer
                                   readOnly:
-                                    description: 'readOnly is Optional: Defaults to
-                                      false (read/write). ReadOnly here will force
-                                      the ReadOnly setting in VolumeMounts.'
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   targetWWNs:
                                     description: 'targetWWNs is Optional: FC target
@@ -1175,29 +1148,27 @@ spec:
                                       type: string
                                     type: array
                                   wwids:
-                                    description: 'wwids Optional: FC volume world
-                                      wide identifiers (wwids) Either wwids or combination
-                                      of targetWWNs and lun must be set, but not both
-                                      simultaneously.'
+                                    description: |-
+                                      wwids Optional: FC volume world wide identifiers (wwids)
+                                      Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               flexVolume:
-                                description: flexVolume represents a generic volume
-                                  resource that is provisioned/attached using an exec
-                                  based plugin.
+                                description: |-
+                                  flexVolume represents a generic volume resource that is
+                                  provisioned/attached using an exec based plugin.
                                 properties:
                                   driver:
                                     description: driver is the name of the driver
                                       to use for this volume.
                                     type: string
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". The default filesystem depends on FlexVolume
-                                      script.
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                     type: string
                                   options:
                                     additionalProperties:
@@ -1206,26 +1177,26 @@ spec:
                                       holds extra command options if any.'
                                     type: object
                                   readOnly:
-                                    description: 'readOnly is Optional: defaults to
-                                      false (read/write). ReadOnly here will force
-                                      the ReadOnly setting in VolumeMounts.'
+                                    description: |-
+                                      readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretRef:
-                                    description: 'secretRef is Optional: secretRef
-                                      is reference to the secret object containing
-                                      sensitive information to pass to the plugin
-                                      scripts. This may be empty if no secret object
-                                      is specified. If the secret object contains
-                                      more than one secret, all secrets are passed
-                                      to the plugin scripts.'
+                                    description: |-
+                                      secretRef is Optional: secretRef is reference to the secret object containing
+                                      sensitive information to pass to the plugin scripts. This may be
+                                      empty if no secret object is specified. If the secret object
+                                      contains more than one secret, all secrets are passed to the plugin
+                                      scripts.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                 - driver
                                 type: object
@@ -1235,9 +1206,9 @@ spec:
                                   Flocker control service being running
                                 properties:
                                   datasetName:
-                                    description: datasetName is Name of the dataset
-                                      stored as metadata -> name on the dataset for
-                                      Flocker should be considered as deprecated
+                                    description: |-
+                                      datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                      should be considered as deprecated
                                     type: string
                                   datasetUUID:
                                     description: datasetUUID is the UUID of the dataset.
@@ -1245,57 +1216,54 @@ spec:
                                     type: string
                                 type: object
                               gcePersistentDisk:
-                                description: 'gcePersistentDisk represents a GCE Disk
-                                  resource that is attached to a kubelet''s host machine
-                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                description: |-
+                                  gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 properties:
                                   fsType:
-                                    description: 'fsType is filesystem type of the
-                                      volume that you want to mount. Tip: Ensure that
-                                      the filesystem type is supported by the host
-                                      operating system. Examples: "ext4", "xfs", "ntfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fsType is filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
-                                    description: 'partition is the partition in the
-                                      volume that you want to mount. If omitted, the
-                                      default is to mount by volume name. Examples:
-                                      For volume /dev/sda1, you specify the partition
-                                      as "1". Similarly, the volume partition for
-                                      /dev/sda is "0" (or you can leave the property
-                                      empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     format: int32
                                     type: integer
                                   pdName:
-                                    description: 'pdName is unique name of the PD
-                                      resource in GCE. Used to identify the disk in
-                                      GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     type: boolean
                                 required:
                                 - pdName
                                 type: object
                               gitRepo:
-                                description: 'gitRepo represents a git repository
-                                  at a particular revision. DEPRECATED: GitRepo is
-                                  deprecated. To provision a container with a git
-                                  repo, mount an EmptyDir into an InitContainer that
-                                  clones the repo using git, then mount the EmptyDir
-                                  into the Pod''s container.'
+                                description: |-
+                                  gitRepo represents a git repository at a particular revision.
+                                  DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                  EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                  into the Pod's container.
                                 properties:
                                   directory:
-                                    description: directory is the target directory
-                                      name. Must not contain or start with '..'.  If
-                                      '.' is supplied, the volume directory will be
-                                      the git repository.  Otherwise, if specified,
-                                      the volume will contain the git repository in
+                                    description: |-
+                                      directory is the target directory name.
+                                      Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                      git repository.  Otherwise, if specified, the volume will contain the git repository in
                                       the subdirectory with the given name.
                                     type: string
                                   repository:
@@ -1309,54 +1277,61 @@ spec:
                                 - repository
                                 type: object
                               glusterfs:
-                                description: 'glusterfs represents a Glusterfs mount
-                                  on the host that shares a pod''s lifetime. More
-                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                description: |-
+                                  glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                 properties:
                                   endpoints:
-                                    description: 'endpoints is the endpoint name that
-                                      details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    description: |-
+                                      endpoints is the endpoint name that details Glusterfs topology.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                     type: string
                                   path:
-                                    description: 'path is the Glusterfs volume path.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    description: |-
+                                      path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the Glusterfs
-                                      volume to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    description: |-
+                                      readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                     type: boolean
                                 required:
                                 - endpoints
                                 - path
                                 type: object
                               hostPath:
-                                description: 'hostPath represents a pre-existing file
-                                  or directory on the host machine that is directly
-                                  exposed to the container. This is generally used
-                                  for system agents or other privileged things that
-                                  are allowed to see the host machine. Most containers
-                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  --- TODO(jonesdl) We need to restrict who can use
-                                  host directory mounts and who can/can not mount
-                                  host directories as read/write.'
+                                description: |-
+                                  hostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  ---
+                                  TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                  mount host directories as read/write.
                                 properties:
                                   path:
-                                    description: 'path of the directory on the host.
-                                      If the path is a symlink, it will follow the
-                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                   type:
-                                    description: 'type for HostPath Volume Defaults
-                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                 required:
                                 - path
                                 type: object
                               iscsi:
-                                description: 'iscsi represents an ISCSI Disk resource
-                                  that is attached to a kubelet''s host machine and
-                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                description: |-
+                                  iscsi represents an ISCSI Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://examples.k8s.io/volumes/iscsi/README.md
                                 properties:
                                   chapAuthDiscovery:
                                     description: chapAuthDiscovery defines whether
@@ -1367,63 +1342,60 @@ spec:
                                       iSCSI Session CHAP authentication
                                     type: boolean
                                   fsType:
-                                    description: 'fsType is the filesystem type of
-                                      the volume that you want to mount. Tip: Ensure
-                                      that the filesystem type is supported by the
-                                      host operating system. Examples: "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   initiatorName:
-                                    description: initiatorName is the custom iSCSI
-                                      Initiator Name. If initiatorName is specified
-                                      with iscsiInterface simultaneously, new iSCSI
-                                      interface <target portal>:<volume name> will
-                                      be created for the connection.
+                                    description: |-
+                                      initiatorName is the custom iSCSI Initiator Name.
+                                      If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                      <target portal>:<volume name> will be created for the connection.
                                     type: string
                                   iqn:
                                     description: iqn is the target iSCSI Qualified
                                       Name.
                                     type: string
                                   iscsiInterface:
-                                    description: iscsiInterface is the interface Name
-                                      that uses an iSCSI transport. Defaults to 'default'
-                                      (tcp).
+                                    description: |-
+                                      iscsiInterface is the interface Name that uses an iSCSI transport.
+                                      Defaults to 'default' (tcp).
                                     type: string
                                   lun:
                                     description: lun represents iSCSI Target Lun number.
                                     format: int32
                                     type: integer
                                   portals:
-                                    description: portals is the iSCSI Target Portal
-                                      List. The portal is either an IP or ip_addr:port
-                                      if the port is other than default (typically
-                                      TCP ports 860 and 3260).
+                                    description: |-
+                                      portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
                                     items:
                                       type: string
                                     type: array
                                   readOnly:
-                                    description: readOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
                                     type: boolean
                                   secretRef:
                                     description: secretRef is the CHAP Secret for
                                       iSCSI target and initiator authentication
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   targetPortal:
-                                    description: targetPortal is iSCSI Target Portal.
-                                      The Portal is either an IP or ip_addr:port if
-                                      the port is other than default (typically TCP
-                                      ports 860 and 3260).
+                                    description: |-
+                                      targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
                                     type: string
                                 required:
                                 - iqn
@@ -1431,43 +1403,51 @@ spec:
                                 - targetPortal
                                 type: object
                               name:
-                                description: 'name of the volume. Must be a DNS_LABEL
-                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               nfs:
-                                description: 'nfs represents an NFS mount on the host
-                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 properties:
                                   path:
-                                    description: 'path that is exported by the NFS
-                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the NFS
-                                      export to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     type: boolean
                                   server:
-                                    description: 'server is the hostname or IP address
-                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     type: string
                                 required:
                                 - path
                                 - server
                                 type: object
                               persistentVolumeClaim:
-                                description: 'persistentVolumeClaimVolumeSource represents
-                                  a reference to a PersistentVolumeClaim in the same
-                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                description: |-
+                                  persistentVolumeClaimVolumeSource represents a reference to a
+                                  PersistentVolumeClaim in the same namespace.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                 properties:
                                   claimName:
-                                    description: 'claimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this
-                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     type: string
                                   readOnly:
-                                    description: readOnly Will force the ReadOnly
-                                      setting in VolumeMounts. Default false.
+                                    description: |-
+                                      readOnly Will force the ReadOnly setting in VolumeMounts.
+                                      Default false.
                                     type: boolean
                                 required:
                                 - claimName
@@ -1478,11 +1458,10 @@ spec:
                                   host machine
                                 properties:
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified.
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   pdID:
                                     description: pdID is the ID that identifies Photon
@@ -1496,15 +1475,15 @@ spec:
                                   volume attached and mounted on kubelets host machine
                                 properties:
                                   fsType:
-                                    description: fSType represents the filesystem
-                                      type to mount Must be a filesystem type supported
-                                      by the host operating system. Ex. "ext4", "xfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fSType represents the filesystem type to mount
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   readOnly:
-                                    description: readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   volumeID:
                                     description: volumeID uniquely identifies a Portworx
@@ -1518,16 +1497,13 @@ spec:
                                   secrets, configmaps, and downward API
                                 properties:
                                   defaultMode:
-                                    description: defaultMode are the mode bits used
-                                      to set permissions on created files by default.
-                                      Must be an octal value between 0000 and 0777
-                                      or a decimal value between 0 and 511. YAML accepts
-                                      both octal and decimal values, JSON requires
-                                      decimal values for mode bits. Directories within
-                                      the path are not affected by this setting. This
-                                      might be in conflict with other options that
-                                      affect the file mode, like fsGroup, and the
-                                      result can be other mode bits set.
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   sources:
@@ -1541,20 +1517,14 @@ spec:
                                             the configMap data to project
                                           properties:
                                             items:
-                                              description: items if unspecified, each
-                                                key-value pair in the Data field of
-                                                the referenced ConfigMap will be projected
-                                                into the volume as a file whose name
-                                                is the key and content is the value.
-                                                If specified, the listed keys will
-                                                be projected into the specified paths,
-                                                and unlisted keys will not be present.
-                                                If a key is specified which is not
-                                                present in the ConfigMap, the volume
-                                                setup will error unless it is marked
-                                                optional. Paths must be relative and
-                                                may not contain the '..' path or start
-                                                with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description: Maps a string key to
                                                   a path within a volume.
@@ -1564,30 +1534,21 @@ spec:
                                                       project.
                                                     type: string
                                                   mode:
-                                                    description: 'mode is Optional:
-                                                      mode bits used to set permissions
-                                                      on this file. Must be an octal
-                                                      value between 0000 and 0777
-                                                      or a decimal value between 0
-                                                      and 511. YAML accepts both octal
-                                                      and decimal values, JSON requires
-                                                      decimal values for mode bits.
-                                                      If not specified, the volume
-                                                      defaultMode will be used. This
-                                                      might be in conflict with other
-                                                      options that affect the file
-                                                      mode, like fsGroup, and the
-                                                      result can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description: path is the relative
-                                                      path of the file to map the
-                                                      key to. May not be an absolute
-                                                      path. May not contain the path
-                                                      element '..'. May not start
-                                                      with the string '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                 - key
@@ -1595,10 +1556,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: optional specify whether
@@ -1606,6 +1567,7 @@ spec:
                                                 defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         downwardAPI:
                                           description: downwardAPI information about
                                             the downwardAPI data to project
@@ -1638,21 +1600,15 @@ spec:
                                                     required:
                                                     - fieldPath
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file, must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
@@ -1665,12 +1621,9 @@ spec:
                                                       not start with ''..'''
                                                     type: string
                                                   resourceFieldRef:
-                                                    description: 'Selects a resource
-                                                      of the container: only resources
-                                                      limits and requests (limits.cpu,
-                                                      limits.memory, requests.cpu
-                                                      and requests.memory) are currently
-                                                      supported.'
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                     properties:
                                                       containerName:
                                                         description: 'Container name:
@@ -1693,6 +1646,7 @@ spec:
                                                     required:
                                                     - resource
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                 required:
                                                 - path
                                                 type: object
@@ -1703,20 +1657,14 @@ spec:
                                             secret data to project
                                           properties:
                                             items:
-                                              description: items if unspecified, each
-                                                key-value pair in the Data field of
-                                                the referenced Secret will be projected
-                                                into the volume as a file whose name
-                                                is the key and content is the value.
-                                                If specified, the listed keys will
-                                                be projected into the specified paths,
-                                                and unlisted keys will not be present.
-                                                If a key is specified which is not
-                                                present in the Secret, the volume
-                                                setup will error unless it is marked
-                                                optional. Paths must be relative and
-                                                may not contain the '..' path or start
-                                                with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description: Maps a string key to
                                                   a path within a volume.
@@ -1726,30 +1674,21 @@ spec:
                                                       project.
                                                     type: string
                                                   mode:
-                                                    description: 'mode is Optional:
-                                                      mode bits used to set permissions
-                                                      on this file. Must be an octal
-                                                      value between 0000 and 0777
-                                                      or a decimal value between 0
-                                                      and 511. YAML accepts both octal
-                                                      and decimal values, JSON requires
-                                                      decimal values for mode bits.
-                                                      If not specified, the volume
-                                                      defaultMode will be used. This
-                                                      might be in conflict with other
-                                                      options that affect the file
-                                                      mode, like fsGroup, and the
-                                                      result can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description: path is the relative
-                                                      path of the file to map the
-                                                      key to. May not be an absolute
-                                                      path. May not contain the path
-                                                      element '..'. May not start
-                                                      with the string '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                 - key
@@ -1757,10 +1696,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: optional field specify
@@ -1768,38 +1707,33 @@ spec:
                                                 be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           description: serviceAccountToken is information
                                             about the serviceAccountToken data to
                                             project
                                           properties:
                                             audience:
-                                              description: audience is the intended
-                                                audience of the token. A recipient
-                                                of a token must identify itself with
-                                                an identifier specified in the audience
-                                                of the token, and otherwise should
-                                                reject the token. The audience defaults
-                                                to the identifier of the apiserver.
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: expirationSeconds is the
-                                                requested duration of validity of
-                                                the service account token. As the
-                                                token approaches expiration, the kubelet
-                                                volume plugin will proactively rotate
-                                                the service account token. The kubelet
-                                                will start trying to rotate the token
-                                                if the token is older than 80 percent
-                                                of its time to live or if the token
-                                                is older than 24 hours.Defaults to
-                                                1 hour and must be at least 10 minutes.
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
                                               format: int64
                                               type: integer
                                             path:
-                                              description: path is the path relative
-                                                to the mount point of the file to
-                                                project the token into.
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
                                               type: string
                                           required:
                                           - path
@@ -1812,29 +1746,30 @@ spec:
                                   the host that shares a pod's lifetime
                                 properties:
                                   group:
-                                    description: group to map volume access to Default
-                                      is no group
+                                    description: |-
+                                      group to map volume access to
+                                      Default is no group
                                     type: string
                                   readOnly:
-                                    description: readOnly here will force the Quobyte
-                                      volume to be mounted with read-only permissions.
+                                    description: |-
+                                      readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                       Defaults to false.
                                     type: boolean
                                   registry:
-                                    description: registry represents a single or multiple
-                                      Quobyte Registry services specified as a string
-                                      as host:port pair (multiple entries are separated
-                                      with commas) which acts as the central registry
-                                      for volumes
+                                    description: |-
+                                      registry represents a single or multiple Quobyte Registry services
+                                      specified as a string as host:port pair (multiple entries are separated with commas)
+                                      which acts as the central registry for volumes
                                     type: string
                                   tenant:
-                                    description: tenant owning the given Quobyte volume
-                                      in the Backend Used with dynamically provisioned
-                                      Quobyte volumes, value is set by the plugin
+                                    description: |-
+                                      tenant owning the given Quobyte volume in the Backend
+                                      Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                     type: string
                                   user:
-                                    description: user to map volume access to Defaults
-                                      to serivceaccount user
+                                    description: |-
+                                      user to map volume access to
+                                      Defaults to serivceaccount user
                                     type: string
                                   volume:
                                     description: volume is a string that references
@@ -1845,59 +1780,68 @@ spec:
                                 - volume
                                 type: object
                               rbd:
-                                description: 'rbd represents a Rados Block Device
-                                  mount on the host that shares a pod''s lifetime.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                description: |-
+                                  rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type of
-                                      the volume that you want to mount. Tip: Ensure
-                                      that the filesystem type is supported by the
-                                      host operating system. Examples: "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   image:
-                                    description: 'image is the rados image name. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      image is the rados image name.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   keyring:
-                                    description: 'keyring is the path to key ring
-                                      for RBDUser. Default is /etc/ceph/keyring. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      keyring is the path to key ring for RBDUser.
+                                      Default is /etc/ceph/keyring.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   monitors:
-                                    description: 'monitors is a collection of Ceph
-                                      monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      monitors is a collection of Ceph monitors.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     items:
                                       type: string
                                     type: array
                                   pool:
-                                    description: 'pool is the rados pool name. Default
-                                      is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      pool is the rados pool name.
+                                      Default is rbd.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: boolean
                                   secretRef:
-                                    description: 'secretRef is name of the authentication
-                                      secret for RBDUser. If provided overrides keyring.
-                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      secretRef is name of the authentication secret for RBDUser. If provided
+                                      overrides keyring.
+                                      Default is nil.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
-                                    description: 'user is the rados user name. Default
-                                      is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      user is the rados user name.
+                                      Default is admin.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                 required:
                                 - image
@@ -1908,10 +1852,11 @@ spec:
                                   volume attached and mounted on Kubernetes nodes.
                                 properties:
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Default is "xfs".
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs".
+                                      Default is "xfs".
                                     type: string
                                   gateway:
                                     description: gateway is the host address of the
@@ -1923,31 +1868,31 @@ spec:
                                       storage.
                                     type: string
                                   readOnly:
-                                    description: readOnly Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretRef:
-                                    description: secretRef references to the secret
-                                      for ScaleIO user and other sensitive information.
-                                      If this is not provided, Login operation will
-                                      fail.
+                                    description: |-
+                                      secretRef references to the secret for ScaleIO user and other
+                                      sensitive information. If this is not provided, Login operation will fail.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   sslEnabled:
                                     description: sslEnabled Flag enable/disable SSL
                                       communication with Gateway, default false
                                     type: boolean
                                   storageMode:
-                                    description: storageMode indicates whether the
-                                      storage for a volume should be ThickProvisioned
-                                      or ThinProvisioned. Default is ThinProvisioned.
+                                    description: |-
+                                      storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                      Default is ThinProvisioned.
                                     type: string
                                   storagePool:
                                     description: storagePool is the ScaleIO Storage
@@ -1958,9 +1903,9 @@ spec:
                                       system as configured in ScaleIO.
                                     type: string
                                   volumeName:
-                                    description: volumeName is the name of a volume
-                                      already created in the ScaleIO system that is
-                                      associated with this volume source.
+                                    description: |-
+                                      volumeName is the name of a volume already created in the ScaleIO system
+                                      that is associated with this volume source.
                                     type: string
                                 required:
                                 - gateway
@@ -1968,35 +1913,30 @@ spec:
                                 - system
                                 type: object
                               secret:
-                                description: 'secret represents a secret that should
-                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                 properties:
                                   defaultMode:
-                                    description: 'defaultMode is Optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description: items If unspecified, each key-value
-                                      pair in the Data field of the referenced Secret
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description: Maps a string key to a path within
                                         a volume.
@@ -2005,25 +1945,21 @@ spec:
                                           description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -2035,8 +1971,9 @@ spec:
                                       Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'secretName is the name of the secret
-                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     type: string
                                 type: object
                               storageos:
@@ -2044,45 +1981,42 @@ spec:
                                   attached and mounted on Kubernetes nodes.
                                 properties:
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified.
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   readOnly:
-                                    description: readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretRef:
-                                    description: secretRef specifies the secret to
-                                      use for obtaining the StorageOS API credentials.  If
-                                      not specified, default values will be attempted.
+                                    description: |-
+                                      secretRef specifies the secret to use for obtaining the StorageOS API
+                                      credentials.  If not specified, default values will be attempted.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeName:
-                                    description: volumeName is the human-readable
-                                      name of the StorageOS volume.  Volume names
-                                      are only unique within a namespace.
+                                    description: |-
+                                      volumeName is the human-readable name of the StorageOS volume.  Volume
+                                      names are only unique within a namespace.
                                     type: string
                                   volumeNamespace:
-                                    description: volumeNamespace specifies the scope
-                                      of the volume within StorageOS.  If no namespace
-                                      is specified then the Pod's namespace will be
-                                      used.  This allows the Kubernetes name scoping
-                                      to be mirrored within StorageOS for tighter
-                                      integration. Set VolumeName to any name to override
-                                      the default behaviour. Set to "default" if you
-                                      are not using namespaces within StorageOS. Namespaces
-                                      that do not pre-exist within StorageOS will
-                                      be created.
+                                    description: |-
+                                      volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                      namespace is specified then the Pod's namespace will be used.  This allows the
+                                      Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                      Set VolumeName to any name to override the default behaviour.
+                                      Set to "default" if you are not using namespaces within StorageOS.
+                                      Namespaces that do not pre-exist within StorageOS will be created.
                                     type: string
                                 type: object
                               vsphereVolume:
@@ -2090,10 +2024,10 @@ spec:
                                   attached and mounted on kubelets host machine
                                 properties:
                                   fsType:
-                                    description: fsType is filesystem type to mount.
-                                      Must be a filesystem type supported by the host
-                                      operating system. Ex. "ext4", "xfs", "ntfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   storagePolicyID:
                                     description: storagePolicyID is the storage Policy
@@ -2137,8 +2071,9 @@ spec:
                 description: Conditions represents the current state of the Request
                   Service.
                 items:
-                  description: Condition represents the current state of the Request
-                    Service. A condition might not show up if it is not happening.
+                  description: |-
+                    Condition represents the current state of the Request Service.
+                    A condition might not show up if it is not happening.
                   properties:
                     lastTransitionTime:
                       description: Last time the condition transitioned from one status
@@ -2210,5 +2145,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/operator.ibm.com_operandrequests.yaml
+++ b/bundle/manifests/operator.ibm.com_operandrequests.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: operand-deployment-lifecycle-manager
@@ -34,17 +34,24 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OperandRequest is the Schema for the operandrequests API.
+        description: OperandRequest is the Schema for the operandrequests API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -74,13 +81,12 @@ spec:
                             type: string
                           bindings:
                             additionalProperties:
-                              description: Bindable is a Kubernetes resources to be
-                                shared from one namespace to another. List of supported
-                                resources are Secrets, Configmaps, Services, and Routes.
-                                Secrets and Configmaps will be copied such that a
-                                new Secret/Configmap with exactly the same data will
-                                be created in the target namespace. Services and Routes
-                                data will be copied into a configmap in the target
+                              description: |-
+                                Bindable is a Kubernetes resources to be shared from one namespace to another.
+                                List of supported resources are Secrets, Configmaps, Services, and Routes.
+                                Secrets and Configmaps will be copied such that a new Secret/Configmap with
+                                exactly the same data will be created in the target namespace.
+                                Services and Routes data will be copied into a configmap in the target
                                 namespace.
                               properties:
                                 configmap:
@@ -89,15 +95,15 @@ spec:
                                     share to the namespace of the OperandRequest.
                                   type: string
                                 route:
-                                  description: Route data will be shared by copying
-                                    it into a configmap which is then created in the
-                                    target namespace
+                                  description: |-
+                                    Route data will be shared by copying it into a configmap which is then
+                                    created in the target namespace
                                   properties:
                                     data:
                                       additionalProperties:
                                         type: string
-                                      description: Data is a key-value pair where
-                                        the value is a YAML path to a value in the
+                                      description: |-
+                                        Data is a key-value pair where the value is a YAML path to a value in the
                                         OpenShift Route, e.g. .spec.host or .spec.tls.termination
                                       type: object
                                     name:
@@ -111,15 +117,15 @@ spec:
                                     of the OperandRequest.
                                   type: string
                                 service:
-                                  description: Service data will be shared by copying
-                                    it into a configmap which is then created in the
-                                    target namespace
+                                  description: |-
+                                    Service data will be shared by copying it into a configmap which is then
+                                    created in the target namespace
                                   properties:
                                     data:
                                       additionalProperties:
                                         type: string
-                                      description: Data is a key-value pair where
-                                        the value is a YAML path to a value in the
+                                      description: |-
+                                        Data is a key-value pair where the value is a YAML path to a value in the
                                         Kubernetes Service, e.g. .spec.ports[0]port
                                       type: object
                                     name:
@@ -132,22 +138,22 @@ spec:
                               of secret and/or configmap.
                             type: object
                           instanceName:
-                            description: InstanceName is used when users want to deploy
-                              multiple custom resources. It is the name of the custom
-                              resource.
+                            description: |-
+                              InstanceName is used when users want to deploy multiple custom resources.
+                              It is the name of the custom resource.
                             type: string
                           kind:
-                            description: Kind is used when users want to deploy multiple
-                              custom resources. Kind identifies the kind of the custom
-                              resource.
+                            description: |-
+                              Kind is used when users want to deploy multiple custom resources.
+                              Kind identifies the kind of the custom resource.
                             type: string
                           name:
                             description: Name of the operand to be deployed.
                             type: string
                           spec:
-                            description: Spec is used when users want to deploy multiple
-                              custom resources. It is the configuration map of custom
-                              resource.
+                            description: |-
+                              Spec is used when users want to deploy multiple custom resources.
+                              It is the configuration map of custom resource.
                             nullable: true
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -160,9 +166,9 @@ spec:
                         reside.
                       type: string
                     registryNamespace:
-                      description: Specifies the namespace in which the OperandRegistry
-                        reside. The default is the current namespace in which the
-                        request is defined.
+                      description: |-
+                        Specifies the namespace in which the OperandRegistry reside.
+                        The default is the current namespace in which the request is defined.
                       type: string
                   required:
                   - operands
@@ -180,8 +186,9 @@ spec:
                 description: Conditions represents the current state of the Request
                   Service.
                 items:
-                  description: Condition represents the current state of the Request
-                    Service. A condition might not show up if it is not happening.
+                  description: |-
+                    Condition represents the current state of the Request Service.
+                    A condition might not show up if it is not happening.
                   properties:
                     lastTransitionTime:
                       description: Last time the condition transitioned from one status
@@ -315,5 +322,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/manifests/operator.ibm.com_operatorconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operatorconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.14.0
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: operand-deployment-lifecycle-manager
@@ -24,14 +24,19 @@ spec:
         description: OperatorConfig is the Schema for the operatorconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -57,22 +62,20 @@ spec:
                             the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a
-                                  no-op). A null preferred scheduling term matches
-                                  no objects (i.e. is also a no-op).
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated
@@ -82,32 +85,26 @@ spec:
                                         description: A list of node selector requirements
                                           by node's labels.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -120,32 +117,26 @@ spec:
                                         description: A list of node selector requirements
                                           by node's fields.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -155,6 +146,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     description: Weight associated with matching the
                                       corresponding nodeSelectorTerm, in the range
@@ -167,53 +159,46 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to an
-                                update), the system may or may not try to eventually
-                                evict the pod from its node.
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms.
                                     The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them
-                                      are ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements
                                           by node's labels.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -226,32 +211,26 @@ spec:
                                         description: A list of node selector requirements
                                           by node's fields.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -261,10 +240,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                               - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           description: Describes pod affinity scheduling rules (e.g.
@@ -272,18 +253,16 @@ spec:
                             other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the
-                                corresponding podAffinityTerm; the node(s) with the
-                                highest sum are the most preferred.
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
                               items:
                                 description: The weights of all of the matched WeightedPodAffinityTerm
                                   fields are added per-node to find the most preferred
@@ -302,29 +281,24 @@ spec:
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -337,52 +311,44 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces.
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -395,43 +361,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace".
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                     - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range
-                                      1-100.
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -440,24 +400,22 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a
-                                pod label update), the system may or may not try to
-                                eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all
-                                terms must be satisfied.
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or
-                                  not co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any
-                                  node on which a pod of the set of pods is running
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources,
@@ -468,28 +426,24 @@ spec:
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -502,50 +456,44 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces
-                                      field. null selector and null or empty namespaces
-                                      list means "this pod's namespace". An empty
-                                      selector ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -558,34 +506,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces
-                                      list and null namespaceSelector means "this
-                                      pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                 - topologyKey
@@ -598,18 +541,16 @@ spec:
                             as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node
-                                that violates one or more of the expressions. The
-                                node that is most preferred is the one with the greatest
-                                sum of weights, i.e. for each node that meets all
-                                of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions,
-                                etc.), compute a sum by iterating through the elements
-                                of this field and adding "weight" to the sum if the
-                                node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
                               items:
                                 description: The weights of all of the matched WeightedPodAffinityTerm
                                   fields are added per-node to find the most preferred
@@ -628,29 +569,24 @@ spec:
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -663,52 +599,44 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces.
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -721,43 +649,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace".
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                     - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range
-                                      1-100.
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -766,24 +688,22 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a
-                                pod label update), the system may or may not try to
-                                eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all
-                                terms must be satisfied.
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or
-                                  not co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any
-                                  node on which a pod of the set of pods is running
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources,
@@ -794,28 +714,24 @@ spec:
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -828,50 +744,44 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces
-                                      field. null selector and null or empty namespaces
-                                      list means "this pod's namespace". An empty
-                                      selector ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -884,34 +794,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces
-                                      list and null namespaceSelector means "this
-                                      pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                 - topologyKey
@@ -923,30 +828,32 @@ spec:
                       description: Name is the operator name as requested in the OperandRequest.
                       type: string
                     replicas:
-                      description: Number of desired pods. This is a pointer to distinguish
-                        between explicit zero and not specified. Defaults to 1.
+                      description: |-
+                        Number of desired pods. This is a pointer to distinguish between explicit
+                        zero and not specified. Defaults to 1.
                       format: int32
                       type: integer
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraints describes how a group
-                        of pods ought to spread across topology domains. Scheduler
-                        will schedule pods in a way which abides by the constraints.
+                      description: |-
+                        TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                        domains. Scheduler will schedule pods in a way which abides by the constraints.
                         All topologySpreadConstraints are ANDed.
                       items:
                         description: TopologySpreadConstraint specifies how to spread
                           matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
-                              Pods that match this label selector are counted to determine
-                              the number of pods in their corresponding topology domain.
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -954,17 +861,16 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -976,93 +882,93 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods
-                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                              it is the maximum permitted difference between the number
-                              of matching pods in the target topology and the global
-                              minimum. The global minimum is the minimum number of
-                              matching pods in an eligible domain or zero if the number
-                              of eligible domains is less than MinDomains. For example,
-                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
-                              the same labelSelector spread as 2/2/1: In this case,
-                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
-                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
-                              can only be scheduled to zone3 to become 2/2/2; scheduling
-                              it onto zone1(zone2) would make the ActualSkew(3-1)
-                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
-                              2, incoming pod can be scheduled onto any zone. When
-                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
-                              higher precedence to topologies that satisfy it. It''s
-                              a required field. Default value is 1 and 0 is not allowed.'
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of
-                              eligible domains. When the number of eligible domains
-                              with matching topology keys is less than minDomains,
-                              Pod Topology Spread treats \"global minimum\" as 0,
-                              and then the calculation of Skew is performed. And when
-                              the number of eligible domains with matching topology
-                              keys equals or greater than minDomains, this value has
-                              no effect on scheduling. As a result, when the number
-                              of eligible domains is less than minDomains, scheduler
-                              won't schedule more than maxSkew Pods to those domains.
-                              If value is nil, the constraint behaves as if MinDomains
-                              is equal to 1. Valid values are integers greater than
-                              0. When value is not nil, WhenUnsatisfiable must be
-                              DoNotSchedule. \n For example, in a 3-zone cluster,
-                              MaxSkew is set to 2, MinDomains is set to 5 and pods
-                              with the same labelSelector spread as 2/2/2: | zone1
-                              | zone2 | zone3 | |  P P  |  P P  |  P P  | The number
-                              of domains is less than 5(MinDomains), so \"global minimum\"
-                              is treated as 0. In this situation, new pod with the
-                              same labelSelector cannot be scheduled, because computed
-                              skew will be 3(3 - 0) if new Pod is scheduled to any
-                              of the three zones, it will violate MaxSkew. \n This
-                              is an alpha field and requires enabling MinDomainsInPodTopologySpread
-                              feature gate."
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+
+
+                              This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate.
                             format: int32
                             type: integer
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes
-                              that have a label with this key and identical values
-                              are considered to be in the same topology. We consider
-                              each <key, value> as a "bucket", and try to put balanced
-                              number of pods into each bucket. We define a domain
-                              as a particular instance of a topology. Also, we define
-                              an eligible domain as a domain whose nodes match the
-                              node selector. e.g. If TopologyKey is "kubernetes.io/hostname",
-                              each Node is a domain of that topology. And, if TopologyKey
-                              is "topology.kubernetes.io/zone", each zone is a domain
-                              of that topology. It's a required field.
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes match the node selector.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal
-                              with a pod if it doesn''t satisfy the spread constraint.
-                              - DoNotSchedule (default) tells the scheduler not to
-                              schedule it. - ScheduleAnyway tells the scheduler to
-                              schedule the pod in any location,   but giving higher
-                              precedence to topologies that would help reduce the   skew.
-                              A constraint is considered "Unsatisfiable" for an incoming
-                              pod if and only if every possible node assignment for
-                              that pod would violate "MaxSkew" on some topology. For
-                              example, in a 3-zone cluster, MaxSkew is set to 1, and
-                              pods with the same labelSelector spread as 3/1/1: |
-                              zone1 | zone2 | zone3 | | P P P |   P   |   P   | If
-                              WhenUnsatisfiable is set to DoNotSchedule, incoming
-                              pod can only be scheduled to zone2(zone3) to become
-                              3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                              MaxSkew(1). In other words, the cluster can still be
-                              imbalanced, but scheduler won''t make it *more* imbalanced.
-                              It''s a required field.'
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
                             type: string
                         required:
                         - maxSkew
@@ -1094,5 +1000,5 @@ status:
   acceptedNames:
     kind: ""
     plural: ""
-  conditions: []
-  storedVersions: []
+  conditions: null
+  storedVersions: null

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: ibm-odlm
   operators.operatorframework.io.bundle.channels.v1: v4.3
   operators.operatorframework.io.bundle.channel.default.v1: v4.3
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.29.0
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.32.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
   # Annotations for testing.

--- a/config/crd/bases/operator.ibm.com_operandbindinfos.yaml
+++ b/config/crd/bases/operator.ibm.com_operandbindinfos.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: operandbindinfos.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -33,16 +31,24 @@ spec:
     schema:
       openAPIV3Schema:
         description: OperandBindInfo is the Schema for the operandbindinfoes API.
+          Documentation For additional details regarding install parameters check
+          https://ibm.biz/icpfs39install. License By installing this product you accept
+          the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -51,12 +57,13 @@ spec:
             properties:
               bindings:
                 additionalProperties:
-                  description: Bindable is a Kubernetes resources to be shared from
-                    one namespace to another. List of supported resources are Secrets,
-                    Configmaps, Services, and Routes. Secrets and Configmaps will
-                    be copied such that a new Secret/Configmap with exactly the same
-                    data will be created in the target namespace. Services and Routes
-                    data will be copied into a configmap in the target namespace.
+                  description: |-
+                    Bindable is a Kubernetes resources to be shared from one namespace to another.
+                    List of supported resources are Secrets, Configmaps, Services, and Routes.
+                    Secrets and Configmaps will be copied such that a new Secret/Configmap with
+                    exactly the same data will be created in the target namespace.
+                    Services and Routes data will be copied into a configmap in the target
+                    namespace.
                   properties:
                     configmap:
                       description: The configmap identifies an existing configmap
@@ -64,15 +71,16 @@ spec:
                         of the OperandRequest.
                       type: string
                     route:
-                      description: Route data will be shared by copying it into a
-                        configmap which is then created in the target namespace
+                      description: |-
+                        Route data will be shared by copying it into a configmap which is then
+                        created in the target namespace
                       properties:
                         data:
                           additionalProperties:
                             type: string
-                          description: Data is a key-value pair where the value is
-                            a YAML path to a value in the OpenShift Route, e.g. .spec.host
-                            or .spec.tls.termination
+                          description: |-
+                            Data is a key-value pair where the value is a YAML path to a value in the
+                            OpenShift Route, e.g. .spec.host or .spec.tls.termination
                           type: object
                         name:
                           description: Name is the name of the OpenShift Route resource
@@ -83,15 +91,16 @@ spec:
                         exists, the ODLM will share to the namespace of the OperandRequest.
                       type: string
                     service:
-                      description: Service data will be shared by copying it into
-                        a configmap which is then created in the target namespace
+                      description: |-
+                        Service data will be shared by copying it into a configmap which is then
+                        created in the target namespace
                       properties:
                         data:
                           additionalProperties:
                             type: string
-                          description: Data is a key-value pair where the value is
-                            a YAML path to a value in the Kubernetes Service, e.g.
-                            .spec.ports[0]port
+                          description: |-
+                            Data is a key-value pair where the value is a YAML path to a value in the
+                            Kubernetes Service, e.g. .spec.ports[0]port
                           type: object
                         name:
                           description: Name is the name of the Kubernetes Service
@@ -105,7 +114,8 @@ spec:
               description:
                 type: string
               operand:
-                description: The deployed service identifies itself with its operand.
+                description: |-
+                  The deployed service identifies itself with its operand.
                   This must match the name in the OperandRegistry in the current namespace.
                 type: string
               registry:
@@ -113,9 +123,9 @@ spec:
                   CR from which this operand deployment is being requested.
                 type: string
               registryNamespace:
-                description: Specifies the namespace in which the OperandRegistry
-                  reside. The default is the current namespace in which the request
-                  is defined.
+                description: |-
+                  Specifies the namespace in which the OperandRegistry reside.
+                  The default is the current namespace in which the request is defined.
                 type: string
             required:
             - operand
@@ -140,9 +150,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: operandconfigs.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -32,17 +30,24 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OperandConfig is the Schema for the operandconfigs API.
+        description: OperandConfig is the Schema for the operandconfigs API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -108,14 +113,16 @@ spec:
                                   description: API version of the referent.
                                   type: string
                                 blockOwnerDeletion:
-                                  description: If true, AND if the owner has the "foregroundDeletion"
-                                    finalizer, then the owner cannot be deleted from
-                                    the key-value store until this reference is removed.
+                                  description: |-
+                                    If true, AND if the owner has the "foregroundDeletion" finalizer, then
+                                    the owner cannot be deleted from the key-value store until this
+                                    reference is removed.
                                     Defaults to false.
                                   type: boolean
                                 controller:
-                                  description: If true, this reference points to the
-                                    managing controller. Default is false.
+                                  description: |-
+                                    If true, this reference points to the managing controller.
+                                    Default is false.
                                   type: boolean
                                 kind:
                                   description: Kind of the referent.
@@ -177,9 +184,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: operandregistries.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -33,16 +31,24 @@ spec:
     schema:
       openAPIV3Schema:
         description: OperandRegistry is the Schema for the operandregistries API.
+          Documentation For additional details regarding install parameters check
+          https://ibm.biz/icpfs39install. License By installing this product you accept
+          the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -61,27 +67,28 @@ spec:
                       description: Description of a common service.
                       type: string
                     installMode:
-                      description: 'The install mode of an operator, either namespace
-                        or cluster. Valid values are: - "namespace" (default): operator
-                        is deployed in namespace of OperandRegistry; - "cluster":
-                        operator is deployed in "openshift-operators" namespace; -
-                        "no-op": operator is not supported to be fresh deployed;'
+                      description: |-
+                        The install mode of an operator, either namespace or cluster.
+                        Valid values are:
+                        - "namespace" (default): operator is deployed in namespace of OperandRegistry;
+                        - "cluster": operator is deployed in "openshift-operators" namespace;
+                        - "no-op": operator is not supported to be fresh deployed;
                       type: string
                     installPlanApproval:
-                      description: 'Approval mode for emitted InstallPlans. Valid
-                        values are: - "Automatic" (default): operator will be installed
-                        automatically; - "Manual": operator installation will be pending
-                        until users approve it;'
+                      description: |-
+                        Approval mode for emitted InstallPlans.
+                        Valid values are:
+                        - "Automatic" (default): operator will be installed automatically;
+                        - "Manual": operator installation will be pending until users approve it;
                       type: string
                     name:
                       description: A unique name for the operator whose operand may
                         be deployed.
                       type: string
                     namespace:
-                      description: The namespace in which operator should be deployed
-                        when InstallMode is empty or set to "namespace". If the namespace
-                        is not set, the operator namespace is the same as OperandRegistry
-                        Namespace
+                      description: |-
+                        The namespace in which operator should be deployed when InstallMode is empty or set to "namespace".
+                        If the namespace is not set, the operator namespace is the same as OperandRegistry Namespace
                       type: string
                     operatorConfig:
                       description: OperatorConfig is the name of the OperatorConfig
@@ -90,10 +97,11 @@ spec:
                       description: Name of the package that defines the applications.
                       type: string
                     scope:
-                      description: 'A scope indicator, either public or private. Valid
-                        values are: - "private" (default): deployment only request
-                        from the containing names; - "public": deployment can be requested
-                        from other namespaces;'
+                      description: |-
+                        A scope indicator, either public or private.
+                        Valid values are:
+                        - "private" (default): deployment only request from the containing names;
+                        - "public": deployment can be requested from other namespaces;
                       enum:
                       - public
                       - private
@@ -114,8 +122,9 @@ spec:
                         configuration.
                       properties:
                         env:
-                          description: Env is a list of environment variables to set
-                            in the container. Cannot be updated.
+                          description: |-
+                            Env is a list of environment variables to set in the container.
+                            Cannot be updated.
                           items:
                             description: EnvVar represents an environment variable
                               present in a Container.
@@ -125,17 +134,16 @@ spec:
                                   be a C_IDENTIFIER.
                                 type: string
                               value:
-                                description: 'Variable references $(VAR_NAME) are
-                                  expanded using the previously defined environment
-                                  variables in the container and any service environment
-                                  variables. If a variable cannot be resolved, the
-                                  reference in the input string will be unchanged.
-                                  Double $$ are reduced to a single $, which allows
-                                  for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)"
-                                  will produce the string literal "$(VAR_NAME)". Escaped
-                                  references will never be expanded, regardless of
-                                  whether the variable exists or not. Defaults to
-                                  "".'
+                                description: |-
+                                  Variable references $(VAR_NAME) are expanded
+                                  using the previously defined environment variables in the container and
+                                  any service environment variables. If a variable cannot be resolved,
+                                  the reference in the input string will be unchanged. Double $$ are reduced
+                                  to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                  "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                  Escaped references will never be expanded, regardless of whether the variable
+                                  exists or not.
+                                  Defaults to "".
                                 type: string
                               valueFrom:
                                 description: Source for the environment variable's
@@ -148,10 +156,10 @@ spec:
                                         description: The key to select.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the ConfigMap
@@ -160,12 +168,11 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   fieldRef:
-                                    description: 'Selects a field of the pod: supports
-                                      metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                      `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                      spec.serviceAccountName, status.hostIP, status.podIP,
-                                      status.podIPs.'
+                                    description: |-
+                                      Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                      spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                     properties:
                                       apiVersion:
                                         description: Version of the schema the FieldPath
@@ -178,12 +185,11 @@ spec:
                                     required:
                                     - fieldPath
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   resourceFieldRef:
-                                    description: 'Selects a resource of the container:
-                                      only resources limits and requests (limits.cpu,
-                                      limits.memory, limits.ephemeral-storage, requests.cpu,
-                                      requests.memory and requests.ephemeral-storage)
-                                      are currently supported.'
+                                    description: |-
+                                      Selects a resource of the container: only resources limits and requests
+                                      (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                     properties:
                                       containerName:
                                         description: 'Container name: required for
@@ -203,6 +209,7 @@ spec:
                                     required:
                                     - resource
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   secretKeyRef:
                                     description: Selects a key of a secret in the
                                       pod's namespace
@@ -212,10 +219,10 @@ spec:
                                           from.  Must be a valid secret key.
                                         type: string
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                       optional:
                                         description: Specify whether the Secret or
@@ -224,19 +231,20 @@ spec:
                                     required:
                                     - key
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 type: object
                             required:
                             - name
                             type: object
                           type: array
                         envFrom:
-                          description: EnvFrom is a list of sources to populate environment
-                            variables in the container. The keys defined within a
-                            source must be a C_IDENTIFIER. All invalid keys will be
-                            reported as an event when the container is starting. When
-                            a key exists in multiple sources, the value associated
-                            with the last source will take precedence. Values defined
-                            by an Env with a duplicate key will take precedence. Immutable.
+                          description: |-
+                            EnvFrom is a list of sources to populate environment variables in the container.
+                            The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                            will be reported as an event when the container is starting. When a key exists in multiple
+                            sources, the value associated with the last source will take precedence.
+                            Values defined by an Env with a duplicate key will take precedence.
+                            Immutable.
                           items:
                             description: EnvFromSource represents the source of a
                               set of ConfigMaps
@@ -245,16 +253,17 @@ spec:
                                 description: The ConfigMap to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: Specify whether the ConfigMap must
                                       be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               prefix:
                                 description: An optional identifier to prepend to
                                   each key in the ConfigMap. Must be a C_IDENTIFIER.
@@ -263,29 +272,32 @@ spec:
                                 description: The Secret to select from
                                 properties:
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: Specify whether the Secret must be
                                       defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                             type: object
                           type: array
                         nodeSelector:
                           additionalProperties:
                             type: string
-                          description: 'NodeSelector is a selector which must be true
-                            for the pod to fit on a node. Selector which must match
-                            a node''s labels for the pod to be scheduled on that node.
-                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/'
+                          description: |-
+                            NodeSelector is a selector which must be true for the pod to fit on a node.
+                            Selector which must match a node's labels for the pod to be scheduled on that node.
+                            More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
                           type: object
                         resources:
-                          description: 'Resources represents compute resources required
-                            by this container. Immutable. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                          description: |-
+                            Resources represents compute resources required by this container.
+                            Immutable.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
                           properties:
                             limits:
                               additionalProperties:
@@ -294,8 +306,9 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Limits describes the maximum amount of compute resources allowed.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               type: object
                             requests:
                               additionalProperties:
@@ -304,25 +317,26 @@ spec:
                                 - type: string
                                 pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                 x-kubernetes-int-or-string: true
-                              description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                              description: |-
+                                Requests describes the minimum amount of compute resources required.
+                                If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                otherwise to an implementation-defined value.
+                                More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                               type: object
                           type: object
                         selector:
-                          description: Selector is the label selector for pods to
-                            be configured. Existing ReplicaSets whose pods are selected
-                            by this will be the ones affected by this deployment.
+                          description: |-
+                            Selector is the label selector for pods to be configured.
+                            Existing ReplicaSets whose pods are
+                            selected by this will be the ones affected by this deployment.
                             It must match the pod template's labels.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
                                 requirements. The requirements are ANDed.
                               items:
-                                description: A label selector requirement is a selector
-                                  that contains values, a key, and an operator that
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
                                   relates the key and values.
                                 properties:
                                   key:
@@ -330,17 +344,16 @@ spec:
                                       applies to.
                                     type: string
                                   operator:
-                                    description: operator represents a key's relationship
-                                      to a set of values. Valid operators are In,
-                                      NotIn, Exists and DoesNotExist.
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
                                     type: string
                                   values:
-                                    description: values is an array of string values.
-                                      If the operator is In or NotIn, the values array
-                                      must be non-empty. If the operator is Exists
-                                      or DoesNotExist, the values array must be empty.
-                                      This array is replaced during a strategic merge
-                                      patch.
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
                                     items:
                                       type: string
                                     type: array
@@ -352,53 +365,49 @@ spec:
                             matchLabels:
                               additionalProperties:
                                 type: string
-                              description: matchLabels is a map of {key,value} pairs.
-                                A single {key,value} in the matchLabels map is equivalent
-                                to an element of matchExpressions, whose key field
-                                is "key", the operator is "In", and the values array
-                                contains only "value". The requirements are ANDed.
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
                               type: object
                           type: object
+                          x-kubernetes-map-type: atomic
                         tolerations:
                           description: Tolerations are the pod's tolerations.
                           items:
-                            description: The pod this Toleration is attached to tolerates
-                              any taint that matches the triple <key,value,effect>
-                              using the matching operator <operator>.
+                            description: |-
+                              The pod this Toleration is attached to tolerates any taint that matches
+                              the triple <key,value,effect> using the matching operator <operator>.
                             properties:
                               effect:
-                                description: Effect indicates the taint effect to
-                                  match. Empty means match all taint effects. When
-                                  specified, allowed values are NoSchedule, PreferNoSchedule
-                                  and NoExecute.
+                                description: |-
+                                  Effect indicates the taint effect to match. Empty means match all taint effects.
+                                  When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                                 type: string
                               key:
-                                description: Key is the taint key that the toleration
-                                  applies to. Empty means match all taint keys. If
-                                  the key is empty, operator must be Exists; this
-                                  combination means to match all values and all keys.
+                                description: |-
+                                  Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                                  If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                                 type: string
                               operator:
-                                description: Operator represents a key's relationship
-                                  to the value. Valid operators are Exists and Equal.
-                                  Defaults to Equal. Exists is equivalent to wildcard
-                                  for value, so that a pod can tolerate all taints
-                                  of a particular category.
+                                description: |-
+                                  Operator represents a key's relationship to the value.
+                                  Valid operators are Exists and Equal. Defaults to Equal.
+                                  Exists is equivalent to wildcard for value, so that a pod can
+                                  tolerate all taints of a particular category.
                                 type: string
                               tolerationSeconds:
-                                description: TolerationSeconds represents the period
-                                  of time the toleration (which must be of effect
-                                  NoExecute, otherwise this field is ignored) tolerates
-                                  the taint. By default, it is not set, which means
-                                  tolerate the taint forever (do not evict). Zero
-                                  and negative values will be treated as 0 (evict
-                                  immediately) by the system.
+                                description: |-
+                                  TolerationSeconds represents the period of time the toleration (which must be
+                                  of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                                  it is not set, which means tolerate the taint forever (do not evict). Zero and
+                                  negative values will be treated as 0 (evict immediately) by the system.
                                 format: int64
                                 type: integer
                               value:
-                                description: Value is the taint value the toleration
-                                  matches to. If the operator is Exists, the value
-                                  should be empty, otherwise just a regular string.
+                                description: |-
+                                  Value is the taint value the toleration matches to.
+                                  If the operator is Exists, the value should be empty, otherwise just a regular string.
                                 type: string
                             type: object
                           type: array
@@ -409,34 +418,36 @@ spec:
                               within a container.
                             properties:
                               mountPath:
-                                description: Path within the container at which the
-                                  volume should be mounted.  Must not contain ':'.
+                                description: |-
+                                  Path within the container at which the volume should be mounted.  Must
+                                  not contain ':'.
                                 type: string
                               mountPropagation:
-                                description: mountPropagation determines how mounts
-                                  are propagated from the host to container and the
-                                  other way around. When not set, MountPropagationNone
-                                  is used. This field is beta in 1.10.
+                                description: |-
+                                  mountPropagation determines how mounts are propagated from the host
+                                  to container and the other way around.
+                                  When not set, MountPropagationNone is used.
+                                  This field is beta in 1.10.
                                 type: string
                               name:
                                 description: This must match the Name of a Volume.
                                 type: string
                               readOnly:
-                                description: Mounted read-only if true, read-write
-                                  otherwise (false or unspecified). Defaults to false.
+                                description: |-
+                                  Mounted read-only if true, read-write otherwise (false or unspecified).
+                                  Defaults to false.
                                 type: boolean
                               subPath:
-                                description: Path within the volume from which the
-                                  container's volume should be mounted. Defaults to
-                                  "" (volume's root).
+                                description: |-
+                                  Path within the volume from which the container's volume should be mounted.
+                                  Defaults to "" (volume's root).
                                 type: string
                               subPathExpr:
-                                description: Expanded path within the volume from
-                                  which the container's volume should be mounted.
-                                  Behaves similarly to SubPath but environment variable
-                                  references $(VAR_NAME) are expanded using the container's
-                                  environment. Defaults to "" (volume's root). SubPathExpr
-                                  and SubPath are mutually exclusive.
+                                description: |-
+                                  Expanded path within the volume from which the container's volume should be mounted.
+                                  Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                  Defaults to "" (volume's root).
+                                  SubPathExpr and SubPath are mutually exclusive.
                                 type: string
                             required:
                             - mountPath
@@ -450,40 +461,36 @@ spec:
                               that may be accessed by any container in the pod.
                             properties:
                               awsElasticBlockStore:
-                                description: 'awsElasticBlockStore represents an AWS
-                                  Disk resource that is attached to a kubelet''s host
-                                  machine and then exposed to the pod. More info:
-                                  https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                description: |-
+                                  awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type of
-                                      the volume that you want to mount. Tip: Ensure
-                                      that the filesystem type is supported by the
-                                      host operating system. Examples: "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
-                                    description: 'partition is the partition in the
-                                      volume that you want to mount. If omitted, the
-                                      default is to mount by volume name. Examples:
-                                      For volume /dev/sda1, you specify the partition
-                                      as "1". Similarly, the volume partition for
-                                      /dev/sda is "0" (or you can leave the property
-                                      empty).'
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                                     format: int32
                                     type: integer
                                   readOnly:
-                                    description: 'readOnly value true will force the
-                                      readOnly setting in VolumeMounts. More info:
-                                      https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      readOnly value true will force the readOnly setting in VolumeMounts.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     type: boolean
                                   volumeID:
-                                    description: 'volumeID is unique ID of the persistent
-                                      disk resource in AWS (Amazon EBS volume). More
-                                      info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                    description: |-
+                                      volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                                     type: string
                                 required:
                                 - volumeID
@@ -505,10 +512,10 @@ spec:
                                       the blob storage
                                     type: string
                                   fsType:
-                                    description: fsType is Filesystem type to mount.
-                                      Must be a filesystem type supported by the host
-                                      operating system. Ex. "ext4", "xfs", "ntfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fsType is Filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   kind:
                                     description: 'kind expected values are Shared:
@@ -518,9 +525,9 @@ spec:
                                       set). defaults to shared'
                                     type: string
                                   readOnly:
-                                    description: readOnly Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                 required:
                                 - diskName
@@ -531,9 +538,9 @@ spec:
                                   mount on the host and bind mount to the pod.
                                 properties:
                                   readOnly:
-                                    description: readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretName:
                                     description: secretName is the  name of secret
@@ -552,8 +559,9 @@ spec:
                                   the host that shares a pod's lifetime
                                 properties:
                                   monitors:
-                                    description: 'monitors is Required: Monitors is
-                                      a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      monitors is Required: Monitors is a collection of Ceph monitors
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     items:
                                       type: string
                                     type: array
@@ -563,67 +571,72 @@ spec:
                                       is /'
                                     type: string
                                   readOnly:
-                                    description: 'readOnly is Optional: Defaults to
-                                      false (read/write). ReadOnly here will force
-                                      the ReadOnly setting in VolumeMounts. More info:
-                                      https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     type: boolean
                                   secretFile:
-                                    description: 'secretFile is Optional: SecretFile
-                                      is the path to key ring for User, default is
-                                      /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     type: string
                                   secretRef:
-                                    description: 'secretRef is Optional: SecretRef
-                                      is reference to the authentication secret for
-                                      User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
-                                    description: 'user is optional: User is the rados
-                                      user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                    description: |-
+                                      user is optional: User is the rados user name, default is admin
+                                      More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                                     type: string
                                 required:
                                 - monitors
                                 type: object
                               cinder:
-                                description: 'cinder represents a cinder volume attached
-                                  and mounted on kubelets host machine. More info:
-                                  https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                description: |-
+                                  cinder represents a cinder volume attached and mounted on kubelets host machine.
+                                  More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Examples: "ext4",
-                                      "xfs", "ntfs". Implicitly inferred to be "ext4"
-                                      if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     type: string
                                   readOnly:
-                                    description: 'readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     type: boolean
                                   secretRef:
-                                    description: 'secretRef is optional: points to
-                                      a secret object containing parameters used to
-                                      connect to OpenStack.'
+                                    description: |-
+                                      secretRef is optional: points to a secret object containing parameters used to connect
+                                      to OpenStack.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeID:
-                                    description: 'volumeID used to identify the volume
-                                      in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                    description: |-
+                                      volumeID used to identify the volume in cinder.
+                                      More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                                     type: string
                                 required:
                                 - volumeID
@@ -633,31 +646,25 @@ spec:
                                   should populate this volume
                                 properties:
                                   defaultMode:
-                                    description: 'defaultMode is optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description: items if unspecified, each key-value
-                                      pair in the Data field of the referenced ConfigMap
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the ConfigMap, the volume
-                                      setup will error unless it is marked optional.
-                                      Paths must be relative and may not contain the
-                                      '..' path or start with '..'.
+                                    description: |-
+                                      items if unspecified, each key-value pair in the Data field of the referenced
+                                      ConfigMap will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the ConfigMap,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description: Maps a string key to a path within
                                         a volume.
@@ -666,25 +673,21 @@ spec:
                                           description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -692,61 +695,60 @@ spec:
                                       type: object
                                     type: array
                                   name:
-                                    description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
                                     type: string
                                   optional:
                                     description: optional specify whether the ConfigMap
                                       or its keys must be defined
                                     type: boolean
                                 type: object
+                                x-kubernetes-map-type: atomic
                               csi:
                                 description: csi (Container Storage Interface) represents
                                   ephemeral storage that is handled by certain external
                                   CSI drivers (Beta feature).
                                 properties:
                                   driver:
-                                    description: driver is the name of the CSI driver
-                                      that handles this volume. Consult with your
-                                      admin for the correct name as registered in
-                                      the cluster.
+                                    description: |-
+                                      driver is the name of the CSI driver that handles this volume.
+                                      Consult with your admin for the correct name as registered in the cluster.
                                     type: string
                                   fsType:
-                                    description: fsType to mount. Ex. "ext4", "xfs",
-                                      "ntfs". If not provided, the empty value is
-                                      passed to the associated CSI driver which will
-                                      determine the default filesystem to apply.
+                                    description: |-
+                                      fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                                      If not provided, the empty value is passed to the associated CSI driver
+                                      which will determine the default filesystem to apply.
                                     type: string
                                   nodePublishSecretRef:
-                                    description: nodePublishSecretRef is a reference
-                                      to the secret object containing sensitive information
-                                      to pass to the CSI driver to complete the CSI
+                                    description: |-
+                                      nodePublishSecretRef is a reference to the secret object containing
+                                      sensitive information to pass to the CSI driver to complete the CSI
                                       NodePublishVolume and NodeUnpublishVolume calls.
-                                      This field is optional, and  may be empty if
-                                      no secret is required. If the secret object
-                                      contains more than one secret, all secret references
-                                      are passed.
+                                      This field is optional, and  may be empty if no secret is required. If the
+                                      secret object contains more than one secret, all secret references are passed.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   readOnly:
-                                    description: readOnly specifies a read-only configuration
-                                      for the volume. Defaults to false (read/write).
+                                    description: |-
+                                      readOnly specifies a read-only configuration for the volume.
+                                      Defaults to false (read/write).
                                     type: boolean
                                   volumeAttributes:
                                     additionalProperties:
                                       type: string
-                                    description: volumeAttributes stores driver-specific
-                                      properties that are passed to the CSI driver.
-                                      Consult your driver's documentation for supported
-                                      values.
+                                    description: |-
+                                      volumeAttributes stores driver-specific properties that are passed to the CSI
+                                      driver. Consult your driver's documentation for supported values.
                                     type: object
                                 required:
                                 - driver
@@ -756,18 +758,15 @@ spec:
                                   the pod that should populate this volume
                                 properties:
                                   defaultMode:
-                                    description: 'Optional: mode bits to use on created
-                                      files by default. Must be a Optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
+                                    description: |-
+                                      Optional: mode bits to use on created files by default. Must be a
+                                      Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
@@ -795,18 +794,15 @@ spec:
                                           required:
                                           - fieldPath
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         mode:
-                                          description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                          description: |-
+                                            Optional: mode bits used to set permissions on this file, must be an octal value
+                                            between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
@@ -818,10 +814,9 @@ spec:
                                             with ''..'''
                                           type: string
                                         resourceFieldRef:
-                                          description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
+                                          description: |-
+                                            Selects a resource of the container: only resources limits and requests
+                                            (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                           properties:
                                             containerName:
                                               description: 'Container name: required
@@ -843,127 +838,131 @@ spec:
                                           required:
                                           - resource
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                       required:
                                       - path
                                       type: object
                                     type: array
                                 type: object
                               emptyDir:
-                                description: 'emptyDir represents a temporary directory
-                                  that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                description: |-
+                                  emptyDir represents a temporary directory that shares a pod's lifetime.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                 properties:
                                   medium:
-                                    description: 'medium represents what type of storage
-                                      medium should back this directory. The default
-                                      is "" which means to use the node''s default
-                                      medium. Must be an empty string (default) or
-                                      Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                    description: |-
+                                      medium represents what type of storage medium should back this directory.
+                                      The default is "" which means to use the node's default medium.
+                                      Must be an empty string (default) or Memory.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                                     type: string
                                   sizeLimit:
                                     anyOf:
                                     - type: integer
                                     - type: string
-                                    description: 'sizeLimit is the total amount of
-                                      local storage required for this EmptyDir volume.
-                                      The size limit is also applicable for memory
-                                      medium. The maximum usage on memory medium EmptyDir
-                                      would be the minimum value between the SizeLimit
-                                      specified here and the sum of memory limits
-                                      of all containers in a pod. The default is nil
-                                      which means that the limit is undefined. More
-                                      info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                    description: |-
+                                      sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                                      The size limit is also applicable for memory medium.
+                                      The maximum usage on memory medium EmptyDir would be the minimum value between
+                                      the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                                      The default is nil which means that the limit is undefined.
+                                      More info: http://kubernetes.io/docs/user-guide/volumes#emptydir
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                 type: object
                               ephemeral:
-                                description: "ephemeral represents a volume that is
-                                  handled by a cluster storage driver. The volume's
-                                  lifecycle is tied to the pod that defines it - it
-                                  will be created before the pod starts, and deleted
-                                  when the pod is removed. \n Use this if: a) the
-                                  volume is only needed while the pod runs, b) features
-                                  of normal volumes like restoring from snapshot or
-                                  capacity    tracking are needed, c) the storage
-                                  driver is specified through a storage class, and
-                                  d) the storage driver supports dynamic volume provisioning
-                                  through    a PersistentVolumeClaim (see EphemeralVolumeSource
-                                  for more    information on the connection between
-                                  this volume type    and PersistentVolumeClaim).
-                                  \n Use PersistentVolumeClaim or one of the vendor-specific
-                                  APIs for volumes that persist for longer than the
-                                  lifecycle of an individual pod. \n Use CSI for light-weight
-                                  local ephemeral volumes if the CSI driver is meant
-                                  to be used that way - see the documentation of the
-                                  driver for more information. \n A pod can use both
-                                  types of ephemeral volumes and persistent volumes
-                                  at the same time."
+                                description: |-
+                                  ephemeral represents a volume that is handled by a cluster storage driver.
+                                  The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                                  and deleted when the pod is removed.
+
+
+                                  Use this if:
+                                  a) the volume is only needed while the pod runs,
+                                  b) features of normal volumes like restoring from snapshot or capacity
+                                     tracking are needed,
+                                  c) the storage driver is specified through a storage class, and
+                                  d) the storage driver supports dynamic volume provisioning through
+                                     a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                     information on the connection between this volume type
+                                     and PersistentVolumeClaim).
+
+
+                                  Use PersistentVolumeClaim or one of the vendor-specific
+                                  APIs for volumes that persist for longer than the lifecycle
+                                  of an individual pod.
+
+
+                                  Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                                  be used that way - see the documentation of the driver for
+                                  more information.
+
+
+                                  A pod can use both types of ephemeral volumes and
+                                  persistent volumes at the same time.
                                 properties:
                                   volumeClaimTemplate:
-                                    description: "Will be used to create a stand-alone
-                                      PVC to provision the volume. The pod in which
-                                      this EphemeralVolumeSource is embedded will
-                                      be the owner of the PVC, i.e. the PVC will be
-                                      deleted together with the pod.  The name of
-                                      the PVC will be `<pod name>-<volume name>` where
-                                      `<volume name>` is the name from the `PodSpec.Volumes`
-                                      array entry. Pod validation will reject the
-                                      pod if the concatenated name is not valid for
-                                      a PVC (for example, too long). \n An existing
-                                      PVC with that name that is not owned by the
-                                      pod will *not* be used for the pod to avoid
-                                      using an unrelated volume by mistake. Starting
-                                      the pod is then blocked until the unrelated
-                                      PVC is removed. If such a pre-created PVC is
-                                      meant to be used by the pod, the PVC has to
-                                      updated with an owner reference to the pod once
-                                      the pod exists. Normally this should not be
-                                      necessary, but it may be useful when manually
-                                      reconstructing a broken cluster. \n This field
-                                      is read-only and no changes will be made by
-                                      Kubernetes to the PVC after it has been created.
-                                      \n Required, must not be nil."
+                                    description: |-
+                                      Will be used to create a stand-alone PVC to provision the volume.
+                                      The pod in which this EphemeralVolumeSource is embedded will be the
+                                      owner of the PVC, i.e. the PVC will be deleted together with the
+                                      pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                                      `<volume name>` is the name from the `PodSpec.Volumes` array
+                                      entry. Pod validation will reject the pod if the concatenated name
+                                      is not valid for a PVC (for example, too long).
+
+
+                                      An existing PVC with that name that is not owned by the pod
+                                      will *not* be used for the pod to avoid using an unrelated
+                                      volume by mistake. Starting the pod is then blocked until
+                                      the unrelated PVC is removed. If such a pre-created PVC is
+                                      meant to be used by the pod, the PVC has to updated with an
+                                      owner reference to the pod once the pod exists. Normally
+                                      this should not be necessary, but it may be useful when
+                                      manually reconstructing a broken cluster.
+
+
+                                      This field is read-only and no changes will be made by Kubernetes
+                                      to the PVC after it has been created.
+
+
+                                      Required, must not be nil.
                                     properties:
                                       metadata:
-                                        description: May contain labels and annotations
-                                          that will be copied into the PVC when creating
-                                          it. No other fields are allowed and will
-                                          be rejected during validation.
+                                        description: |-
+                                          May contain labels and annotations that will be copied into the PVC
+                                          when creating it. No other fields are allowed and will be rejected during
+                                          validation.
                                         type: object
                                       spec:
-                                        description: The specification for the PersistentVolumeClaim.
-                                          The entire content is copied unchanged into
-                                          the PVC that gets created from this template.
-                                          The same fields as in a PersistentVolumeClaim
+                                        description: |-
+                                          The specification for the PersistentVolumeClaim. The entire content is
+                                          copied unchanged into the PVC that gets created from this
+                                          template. The same fields as in a PersistentVolumeClaim
                                           are also valid here.
                                         properties:
                                           accessModes:
-                                            description: 'accessModes contains the
-                                              desired access modes the volume should
-                                              have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                            description: |-
+                                              accessModes contains the desired access modes the volume should have.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                             items:
                                               type: string
                                             type: array
                                           dataSource:
-                                            description: 'dataSource field can be
-                                              used to specify either: * An existing
-                                              VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                            description: |-
+                                              dataSource field can be used to specify either:
+                                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
                                               * An existing PVC (PersistentVolumeClaim)
-                                              If the provisioner or an external controller
-                                              can support the specified data source,
-                                              it will create a new volume based on
-                                              the contents of the specified data source.
-                                              If the AnyVolumeDataSource feature gate
-                                              is enabled, this field will always have
-                                              the same contents as the DataSourceRef
-                                              field.'
+                                              If the provisioner or an external controller can support the specified data source,
+                                              it will create a new volume based on the contents of the specified data source.
+                                              If the AnyVolumeDataSource feature gate is enabled, this field will always have
+                                              the same contents as the DataSourceRef field.
                                             properties:
                                               apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
                                                 type: string
                                               kind:
                                                 description: Kind is the type of resource
@@ -977,44 +976,32 @@ spec:
                                             - kind
                                             - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           dataSourceRef:
-                                            description: 'dataSourceRef specifies
-                                              the object from which to populate the
-                                              volume with data, if a non-empty volume
-                                              is desired. This may be any local object
-                                              from a non-empty API group (non core
-                                              object) or a PersistentVolumeClaim object.
-                                              When this field is specified, volume
-                                              binding will only succeed if the type
-                                              of the specified object matches some
-                                              installed volume populator or dynamic
-                                              provisioner. This field will replace
-                                              the functionality of the DataSource
-                                              field and as such if both fields are
-                                              non-empty, they must have the same value.
-                                              For backwards compatibility, both fields
-                                              (DataSource and DataSourceRef) will
-                                              be set to the same value automatically
-                                              if one of them is empty and the other
-                                              is non-empty. There are two important
-                                              differences between DataSource and DataSourceRef:
-                                              * While DataSource only allows two specific
-                                              types of objects, DataSourceRef   allows
-                                              any non-core object, as well as PersistentVolumeClaim
-                                              objects. * While DataSource ignores
-                                              disallowed values (dropping them), DataSourceRef   preserves
-                                              all values, and generates an error if
-                                              a disallowed value is   specified. (Beta)
-                                              Using this field requires the AnyVolumeDataSource
-                                              feature gate to be enabled.'
+                                            description: |-
+                                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                              volume is desired. This may be any local object from a non-empty API group (non
+                                              core object) or a PersistentVolumeClaim object.
+                                              When this field is specified, volume binding will only succeed if the type of
+                                              the specified object matches some installed volume populator or dynamic
+                                              provisioner.
+                                              This field will replace the functionality of the DataSource field and as such
+                                              if both fields are non-empty, they must have the same value. For backwards
+                                              compatibility, both fields (DataSource and DataSourceRef) will be set to the same
+                                              value automatically if one of them is empty and the other is non-empty.
+                                              There are two important differences between DataSource and DataSourceRef:
+                                              * While DataSource only allows two specific types of objects, DataSourceRef
+                                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                                              * While DataSource ignores disallowed values (dropping them), DataSourceRef
+                                                preserves all values, and generates an error if a disallowed value is
+                                                specified.
+                                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
                                             properties:
                                               apiGroup:
-                                                description: APIGroup is the group
-                                                  for the resource being referenced.
-                                                  If APIGroup is not specified, the
-                                                  specified Kind must be in the core
-                                                  API group. For any other third-party
-                                                  types, APIGroup is required.
+                                                description: |-
+                                                  APIGroup is the group for the resource being referenced.
+                                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                                  For any other third-party types, APIGroup is required.
                                                 type: string
                                               kind:
                                                 description: Kind is the type of resource
@@ -1028,16 +1015,14 @@ spec:
                                             - kind
                                             - name
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           resources:
-                                            description: 'resources represents the
-                                              minimum resources the volume should
-                                              have. If RecoverVolumeExpansionFailure
-                                              feature is enabled users are allowed
-                                              to specify resource requirements that
-                                              are lower than previous value but must
-                                              still be higher than capacity recorded
-                                              in the status field of the claim. More
-                                              info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                            description: |-
+                                              resources represents the minimum resources the volume should have.
+                                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                              that are lower than previous value but must still be higher than capacity recorded in the
+                                              status field of the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                             properties:
                                               limits:
                                                 additionalProperties:
@@ -1046,9 +1031,9 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: 'Limits describes the
-                                                  maximum amount of compute resources
-                                                  allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                description: |-
+                                                  Limits describes the maximum amount of compute resources allowed.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                               requests:
                                                 additionalProperties:
@@ -1057,13 +1042,11 @@ spec:
                                                   - type: string
                                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                                   x-kubernetes-int-or-string: true
-                                                description: 'Requests describes the
-                                                  minimum amount of compute resources
-                                                  required. If Requests is omitted
-                                                  for a container, it defaults to
-                                                  Limits if that is explicitly specified,
-                                                  otherwise to an implementation-defined
-                                                  value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                                description: |-
+                                                  Requests describes the minimum amount of compute resources required.
+                                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                                  otherwise to an implementation-defined value.
+                                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                                 type: object
                                             type: object
                                           selector:
@@ -1075,10 +1058,9 @@ spec:
                                                   list of label selector requirements.
                                                   The requirements are ANDed.
                                                 items:
-                                                  description: A label selector requirement
-                                                    is a selector that contains values,
-                                                    a key, and an operator that relates
-                                                    the key and values.
+                                                  description: |-
+                                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                                    relates the key and values.
                                                   properties:
                                                     key:
                                                       description: key is the label
@@ -1086,21 +1068,15 @@ spec:
                                                         to.
                                                       type: string
                                                     operator:
-                                                      description: operator represents
-                                                        a key's relationship to a
-                                                        set of values. Valid operators
-                                                        are In, NotIn, Exists and
-                                                        DoesNotExist.
+                                                      description: |-
+                                                        operator represents a key's relationship to a set of values.
+                                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                                       type: string
                                                     values:
-                                                      description: values is an array
-                                                        of string values. If the operator
-                                                        is In or NotIn, the values
-                                                        array must be non-empty. If
-                                                        the operator is Exists or
-                                                        DoesNotExist, the values array
-                                                        must be empty. This array
-                                                        is replaced during a strategic
+                                                      description: |-
+                                                        values is an array of string values. If the operator is In or NotIn,
+                                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                        the values array must be empty. This array is replaced during a strategic
                                                         merge patch.
                                                       items:
                                                         type: string
@@ -1113,26 +1089,22 @@ spec:
                                               matchLabels:
                                                 additionalProperties:
                                                   type: string
-                                                description: matchLabels is a map
-                                                  of {key,value} pairs. A single {key,value}
-                                                  in the matchLabels map is equivalent
-                                                  to an element of matchExpressions,
-                                                  whose key field is "key", the operator
-                                                  is "In", and the values array contains
-                                                  only "value". The requirements are
-                                                  ANDed.
+                                                description: |-
+                                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                                 type: object
                                             type: object
+                                            x-kubernetes-map-type: atomic
                                           storageClassName:
-                                            description: 'storageClassName is the
-                                              name of the StorageClass required by
-                                              the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                            description: |-
+                                              storageClassName is the name of the StorageClass required by the claim.
+                                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                             type: string
                                           volumeMode:
-                                            description: volumeMode defines what type
-                                              of volume is required by the claim.
-                                              Value of Filesystem is implied when
-                                              not included in claim spec.
+                                            description: |-
+                                              volumeMode defines what type of volume is required by the claim.
+                                              Value of Filesystem is implied when not included in claim spec.
                                             type: string
                                           volumeName:
                                             description: volumeName is the binding
@@ -1150,21 +1122,20 @@ spec:
                                   then exposed to the pod.
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. TODO: how do we prevent errors
-                                      in the filesystem from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   lun:
                                     description: 'lun is Optional: FC target lun number'
                                     format: int32
                                     type: integer
                                   readOnly:
-                                    description: 'readOnly is Optional: Defaults to
-                                      false (read/write). ReadOnly here will force
-                                      the ReadOnly setting in VolumeMounts.'
+                                    description: |-
+                                      readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   targetWWNs:
                                     description: 'targetWWNs is Optional: FC target
@@ -1173,29 +1144,27 @@ spec:
                                       type: string
                                     type: array
                                   wwids:
-                                    description: 'wwids Optional: FC volume world
-                                      wide identifiers (wwids) Either wwids or combination
-                                      of targetWWNs and lun must be set, but not both
-                                      simultaneously.'
+                                    description: |-
+                                      wwids Optional: FC volume world wide identifiers (wwids)
+                                      Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                                     items:
                                       type: string
                                     type: array
                                 type: object
                               flexVolume:
-                                description: flexVolume represents a generic volume
-                                  resource that is provisioned/attached using an exec
-                                  based plugin.
+                                description: |-
+                                  flexVolume represents a generic volume resource that is
+                                  provisioned/attached using an exec based plugin.
                                 properties:
                                   driver:
                                     description: driver is the name of the driver
                                       to use for this volume.
                                     type: string
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". The default filesystem depends on FlexVolume
-                                      script.
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                                     type: string
                                   options:
                                     additionalProperties:
@@ -1204,26 +1173,26 @@ spec:
                                       holds extra command options if any.'
                                     type: object
                                   readOnly:
-                                    description: 'readOnly is Optional: defaults to
-                                      false (read/write). ReadOnly here will force
-                                      the ReadOnly setting in VolumeMounts.'
+                                    description: |-
+                                      readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretRef:
-                                    description: 'secretRef is Optional: secretRef
-                                      is reference to the secret object containing
-                                      sensitive information to pass to the plugin
-                                      scripts. This may be empty if no secret object
-                                      is specified. If the secret object contains
-                                      more than one secret, all secrets are passed
-                                      to the plugin scripts.'
+                                    description: |-
+                                      secretRef is Optional: secretRef is reference to the secret object containing
+                                      sensitive information to pass to the plugin scripts. This may be
+                                      empty if no secret object is specified. If the secret object
+                                      contains more than one secret, all secrets are passed to the plugin
+                                      scripts.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                 required:
                                 - driver
                                 type: object
@@ -1233,9 +1202,9 @@ spec:
                                   Flocker control service being running
                                 properties:
                                   datasetName:
-                                    description: datasetName is Name of the dataset
-                                      stored as metadata -> name on the dataset for
-                                      Flocker should be considered as deprecated
+                                    description: |-
+                                      datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                                      should be considered as deprecated
                                     type: string
                                   datasetUUID:
                                     description: datasetUUID is the UUID of the dataset.
@@ -1243,57 +1212,54 @@ spec:
                                     type: string
                                 type: object
                               gcePersistentDisk:
-                                description: 'gcePersistentDisk represents a GCE Disk
-                                  resource that is attached to a kubelet''s host machine
-                                  and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                description: |-
+                                  gcePersistentDisk represents a GCE Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                 properties:
                                   fsType:
-                                    description: 'fsType is filesystem type of the
-                                      volume that you want to mount. Tip: Ensure that
-                                      the filesystem type is supported by the host
-                                      operating system. Examples: "ext4", "xfs", "ntfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fsType is filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                       More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   partition:
-                                    description: 'partition is the partition in the
-                                      volume that you want to mount. If omitted, the
-                                      default is to mount by volume name. Examples:
-                                      For volume /dev/sda1, you specify the partition
-                                      as "1". Similarly, the volume partition for
-                                      /dev/sda is "0" (or you can leave the property
-                                      empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      partition is the partition in the volume that you want to mount.
+                                      If omitted, the default is to mount by volume name.
+                                      Examples: For volume /dev/sda1, you specify the partition as "1".
+                                      Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     format: int32
                                     type: integer
                                   pdName:
-                                    description: 'pdName is unique name of the PD
-                                      resource in GCE. Used to identify the disk in
-                                      GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                                     type: boolean
                                 required:
                                 - pdName
                                 type: object
                               gitRepo:
-                                description: 'gitRepo represents a git repository
-                                  at a particular revision. DEPRECATED: GitRepo is
-                                  deprecated. To provision a container with a git
-                                  repo, mount an EmptyDir into an InitContainer that
-                                  clones the repo using git, then mount the EmptyDir
-                                  into the Pod''s container.'
+                                description: |-
+                                  gitRepo represents a git repository at a particular revision.
+                                  DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                                  EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                                  into the Pod's container.
                                 properties:
                                   directory:
-                                    description: directory is the target directory
-                                      name. Must not contain or start with '..'.  If
-                                      '.' is supplied, the volume directory will be
-                                      the git repository.  Otherwise, if specified,
-                                      the volume will contain the git repository in
+                                    description: |-
+                                      directory is the target directory name.
+                                      Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                                      git repository.  Otherwise, if specified, the volume will contain the git repository in
                                       the subdirectory with the given name.
                                     type: string
                                   repository:
@@ -1307,54 +1273,61 @@ spec:
                                 - repository
                                 type: object
                               glusterfs:
-                                description: 'glusterfs represents a Glusterfs mount
-                                  on the host that shares a pod''s lifetime. More
-                                  info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                                description: |-
+                                  glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                                  More info: https://examples.k8s.io/volumes/glusterfs/README.md
                                 properties:
                                   endpoints:
-                                    description: 'endpoints is the endpoint name that
-                                      details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    description: |-
+                                      endpoints is the endpoint name that details Glusterfs topology.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                     type: string
                                   path:
-                                    description: 'path is the Glusterfs volume path.
-                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    description: |-
+                                      path is the Glusterfs volume path.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the Glusterfs
-                                      volume to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                    description: |-
+                                      readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                                     type: boolean
                                 required:
                                 - endpoints
                                 - path
                                 type: object
                               hostPath:
-                                description: 'hostPath represents a pre-existing file
-                                  or directory on the host machine that is directly
-                                  exposed to the container. This is generally used
-                                  for system agents or other privileged things that
-                                  are allowed to see the host machine. Most containers
-                                  will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                                  --- TODO(jonesdl) We need to restrict who can use
-                                  host directory mounts and who can/can not mount
-                                  host directories as read/write.'
+                                description: |-
+                                  hostPath represents a pre-existing file or directory on the host
+                                  machine that is directly exposed to the container. This is generally
+                                  used for system agents or other privileged things that are allowed
+                                  to see the host machine. Most containers will NOT need this.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                                  ---
+                                  TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                                  mount host directories as read/write.
                                 properties:
                                   path:
-                                    description: 'path of the directory on the host.
-                                      If the path is a symlink, it will follow the
-                                      link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      path of the directory on the host.
+                                      If the path is a symlink, it will follow the link to the real path.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                   type:
-                                    description: 'type for HostPath Volume Defaults
-                                      to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                    description: |-
+                                      type for HostPath Volume
+                                      Defaults to ""
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                                     type: string
                                 required:
                                 - path
                                 type: object
                               iscsi:
-                                description: 'iscsi represents an ISCSI Disk resource
-                                  that is attached to a kubelet''s host machine and
-                                  then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                                description: |-
+                                  iscsi represents an ISCSI Disk resource that is attached to a
+                                  kubelet's host machine and then exposed to the pod.
+                                  More info: https://examples.k8s.io/volumes/iscsi/README.md
                                 properties:
                                   chapAuthDiscovery:
                                     description: chapAuthDiscovery defines whether
@@ -1365,63 +1338,60 @@ spec:
                                       iSCSI Session CHAP authentication
                                     type: boolean
                                   fsType:
-                                    description: 'fsType is the filesystem type of
-                                      the volume that you want to mount. Tip: Ensure
-                                      that the filesystem type is supported by the
-                                      host operating system. Examples: "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   initiatorName:
-                                    description: initiatorName is the custom iSCSI
-                                      Initiator Name. If initiatorName is specified
-                                      with iscsiInterface simultaneously, new iSCSI
-                                      interface <target portal>:<volume name> will
-                                      be created for the connection.
+                                    description: |-
+                                      initiatorName is the custom iSCSI Initiator Name.
+                                      If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                                      <target portal>:<volume name> will be created for the connection.
                                     type: string
                                   iqn:
                                     description: iqn is the target iSCSI Qualified
                                       Name.
                                     type: string
                                   iscsiInterface:
-                                    description: iscsiInterface is the interface Name
-                                      that uses an iSCSI transport. Defaults to 'default'
-                                      (tcp).
+                                    description: |-
+                                      iscsiInterface is the interface Name that uses an iSCSI transport.
+                                      Defaults to 'default' (tcp).
                                     type: string
                                   lun:
                                     description: lun represents iSCSI Target Lun number.
                                     format: int32
                                     type: integer
                                   portals:
-                                    description: portals is the iSCSI Target Portal
-                                      List. The portal is either an IP or ip_addr:port
-                                      if the port is other than default (typically
-                                      TCP ports 860 and 3260).
+                                    description: |-
+                                      portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
                                     items:
                                       type: string
                                     type: array
                                   readOnly:
-                                    description: readOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
                                     type: boolean
                                   secretRef:
                                     description: secretRef is the CHAP Secret for
                                       iSCSI target and initiator authentication
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   targetPortal:
-                                    description: targetPortal is iSCSI Target Portal.
-                                      The Portal is either an IP or ip_addr:port if
-                                      the port is other than default (typically TCP
-                                      ports 860 and 3260).
+                                    description: |-
+                                      targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                                      is other than default (typically TCP ports 860 and 3260).
                                     type: string
                                 required:
                                 - iqn
@@ -1429,43 +1399,51 @@ spec:
                                 - targetPortal
                                 type: object
                               name:
-                                description: 'name of the volume. Must be a DNS_LABEL
-                                  and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                description: |-
+                                  name of the volume.
+                                  Must be a DNS_LABEL and unique within the pod.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                                 type: string
                               nfs:
-                                description: 'nfs represents an NFS mount on the host
-                                  that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                description: |-
+                                  nfs represents an NFS mount on the host that shares a pod's lifetime
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                 properties:
                                   path:
-                                    description: 'path that is exported by the NFS
-                                      server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      path that is exported by the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the NFS
-                                      export to be mounted with read-only permissions.
-                                      Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      readOnly here will force the NFS export to be mounted with read-only permissions.
+                                      Defaults to false.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     type: boolean
                                   server:
-                                    description: 'server is the hostname or IP address
-                                      of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                    description: |-
+                                      server is the hostname or IP address of the NFS server.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                                     type: string
                                 required:
                                 - path
                                 - server
                                 type: object
                               persistentVolumeClaim:
-                                description: 'persistentVolumeClaimVolumeSource represents
-                                  a reference to a PersistentVolumeClaim in the same
-                                  namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                description: |-
+                                  persistentVolumeClaimVolumeSource represents a reference to a
+                                  PersistentVolumeClaim in the same namespace.
+                                  More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                 properties:
                                   claimName:
-                                    description: 'claimName is the name of a PersistentVolumeClaim
-                                      in the same namespace as the pod using this
-                                      volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                    description: |-
+                                      claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                                     type: string
                                   readOnly:
-                                    description: readOnly Will force the ReadOnly
-                                      setting in VolumeMounts. Default false.
+                                    description: |-
+                                      readOnly Will force the ReadOnly setting in VolumeMounts.
+                                      Default false.
                                     type: boolean
                                 required:
                                 - claimName
@@ -1476,11 +1454,10 @@ spec:
                                   host machine
                                 properties:
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified.
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   pdID:
                                     description: pdID is the ID that identifies Photon
@@ -1494,15 +1471,15 @@ spec:
                                   volume attached and mounted on kubelets host machine
                                 properties:
                                   fsType:
-                                    description: fSType represents the filesystem
-                                      type to mount Must be a filesystem type supported
-                                      by the host operating system. Ex. "ext4", "xfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fSType represents the filesystem type to mount
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   readOnly:
-                                    description: readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   volumeID:
                                     description: volumeID uniquely identifies a Portworx
@@ -1516,16 +1493,13 @@ spec:
                                   secrets, configmaps, and downward API
                                 properties:
                                   defaultMode:
-                                    description: defaultMode are the mode bits used
-                                      to set permissions on created files by default.
-                                      Must be an octal value between 0000 and 0777
-                                      or a decimal value between 0 and 511. YAML accepts
-                                      both octal and decimal values, JSON requires
-                                      decimal values for mode bits. Directories within
-                                      the path are not affected by this setting. This
-                                      might be in conflict with other options that
-                                      affect the file mode, like fsGroup, and the
-                                      result can be other mode bits set.
+                                    description: |-
+                                      defaultMode are the mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   sources:
@@ -1539,20 +1513,14 @@ spec:
                                             the configMap data to project
                                           properties:
                                             items:
-                                              description: items if unspecified, each
-                                                key-value pair in the Data field of
-                                                the referenced ConfigMap will be projected
-                                                into the volume as a file whose name
-                                                is the key and content is the value.
-                                                If specified, the listed keys will
-                                                be projected into the specified paths,
-                                                and unlisted keys will not be present.
-                                                If a key is specified which is not
-                                                present in the ConfigMap, the volume
-                                                setup will error unless it is marked
-                                                optional. Paths must be relative and
-                                                may not contain the '..' path or start
-                                                with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                ConfigMap will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the ConfigMap,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description: Maps a string key to
                                                   a path within a volume.
@@ -1562,30 +1530,21 @@ spec:
                                                       project.
                                                     type: string
                                                   mode:
-                                                    description: 'mode is Optional:
-                                                      mode bits used to set permissions
-                                                      on this file. Must be an octal
-                                                      value between 0000 and 0777
-                                                      or a decimal value between 0
-                                                      and 511. YAML accepts both octal
-                                                      and decimal values, JSON requires
-                                                      decimal values for mode bits.
-                                                      If not specified, the volume
-                                                      defaultMode will be used. This
-                                                      might be in conflict with other
-                                                      options that affect the file
-                                                      mode, like fsGroup, and the
-                                                      result can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description: path is the relative
-                                                      path of the file to map the
-                                                      key to. May not be an absolute
-                                                      path. May not contain the path
-                                                      element '..'. May not start
-                                                      with the string '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                 - key
@@ -1593,10 +1552,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: optional specify whether
@@ -1604,6 +1563,7 @@ spec:
                                                 defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         downwardAPI:
                                           description: downwardAPI information about
                                             the downwardAPI data to project
@@ -1636,21 +1596,15 @@ spec:
                                                     required:
                                                     - fieldPath
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                   mode:
-                                                    description: 'Optional: mode bits
-                                                      used to set permissions on this
-                                                      file, must be an octal value
-                                                      between 0000 and 0777 or a decimal
-                                                      value between 0 and 511. YAML
-                                                      accepts both octal and decimal
-                                                      values, JSON requires decimal
-                                                      values for mode bits. If not
-                                                      specified, the volume defaultMode
-                                                      will be used. This might be
-                                                      in conflict with other options
-                                                      that affect the file mode, like
-                                                      fsGroup, and the result can
-                                                      be other mode bits set.'
+                                                    description: |-
+                                                      Optional: mode bits used to set permissions on this file, must be an octal value
+                                                      between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
@@ -1663,12 +1617,9 @@ spec:
                                                       not start with ''..'''
                                                     type: string
                                                   resourceFieldRef:
-                                                    description: 'Selects a resource
-                                                      of the container: only resources
-                                                      limits and requests (limits.cpu,
-                                                      limits.memory, requests.cpu
-                                                      and requests.memory) are currently
-                                                      supported.'
+                                                    description: |-
+                                                      Selects a resource of the container: only resources limits and requests
+                                                      (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                                     properties:
                                                       containerName:
                                                         description: 'Container name:
@@ -1691,6 +1642,7 @@ spec:
                                                     required:
                                                     - resource
                                                     type: object
+                                                    x-kubernetes-map-type: atomic
                                                 required:
                                                 - path
                                                 type: object
@@ -1701,20 +1653,14 @@ spec:
                                             secret data to project
                                           properties:
                                             items:
-                                              description: items if unspecified, each
-                                                key-value pair in the Data field of
-                                                the referenced Secret will be projected
-                                                into the volume as a file whose name
-                                                is the key and content is the value.
-                                                If specified, the listed keys will
-                                                be projected into the specified paths,
-                                                and unlisted keys will not be present.
-                                                If a key is specified which is not
-                                                present in the Secret, the volume
-                                                setup will error unless it is marked
-                                                optional. Paths must be relative and
-                                                may not contain the '..' path or start
-                                                with '..'.
+                                              description: |-
+                                                items if unspecified, each key-value pair in the Data field of the referenced
+                                                Secret will be projected into the volume as a file whose name is the
+                                                key and content is the value. If specified, the listed keys will be
+                                                projected into the specified paths, and unlisted keys will not be
+                                                present. If a key is specified which is not present in the Secret,
+                                                the volume setup will error unless it is marked optional. Paths must be
+                                                relative and may not contain the '..' path or start with '..'.
                                               items:
                                                 description: Maps a string key to
                                                   a path within a volume.
@@ -1724,30 +1670,21 @@ spec:
                                                       project.
                                                     type: string
                                                   mode:
-                                                    description: 'mode is Optional:
-                                                      mode bits used to set permissions
-                                                      on this file. Must be an octal
-                                                      value between 0000 and 0777
-                                                      or a decimal value between 0
-                                                      and 511. YAML accepts both octal
-                                                      and decimal values, JSON requires
-                                                      decimal values for mode bits.
-                                                      If not specified, the volume
-                                                      defaultMode will be used. This
-                                                      might be in conflict with other
-                                                      options that affect the file
-                                                      mode, like fsGroup, and the
-                                                      result can be other mode bits
-                                                      set.'
+                                                    description: |-
+                                                      mode is Optional: mode bits used to set permissions on this file.
+                                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                                      YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                                      If not specified, the volume defaultMode will be used.
+                                                      This might be in conflict with other options that affect the file
+                                                      mode, like fsGroup, and the result can be other mode bits set.
                                                     format: int32
                                                     type: integer
                                                   path:
-                                                    description: path is the relative
-                                                      path of the file to map the
-                                                      key to. May not be an absolute
-                                                      path. May not contain the path
-                                                      element '..'. May not start
-                                                      with the string '..'.
+                                                    description: |-
+                                                      path is the relative path of the file to map the key to.
+                                                      May not be an absolute path.
+                                                      May not contain the path element '..'.
+                                                      May not start with the string '..'.
                                                     type: string
                                                 required:
                                                 - key
@@ -1755,10 +1692,10 @@ spec:
                                                 type: object
                                               type: array
                                             name:
-                                              description: 'Name of the referent.
+                                              description: |-
+                                                Name of the referent.
                                                 More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                                TODO: Add other useful fields. apiVersion,
-                                                kind, uid?'
+                                                TODO: Add other useful fields. apiVersion, kind, uid?
                                               type: string
                                             optional:
                                               description: optional field specify
@@ -1766,38 +1703,33 @@ spec:
                                                 be defined
                                               type: boolean
                                           type: object
+                                          x-kubernetes-map-type: atomic
                                         serviceAccountToken:
                                           description: serviceAccountToken is information
                                             about the serviceAccountToken data to
                                             project
                                           properties:
                                             audience:
-                                              description: audience is the intended
-                                                audience of the token. A recipient
-                                                of a token must identify itself with
-                                                an identifier specified in the audience
-                                                of the token, and otherwise should
-                                                reject the token. The audience defaults
-                                                to the identifier of the apiserver.
+                                              description: |-
+                                                audience is the intended audience of the token. A recipient of a token
+                                                must identify itself with an identifier specified in the audience of the
+                                                token, and otherwise should reject the token. The audience defaults to the
+                                                identifier of the apiserver.
                                               type: string
                                             expirationSeconds:
-                                              description: expirationSeconds is the
-                                                requested duration of validity of
-                                                the service account token. As the
-                                                token approaches expiration, the kubelet
-                                                volume plugin will proactively rotate
-                                                the service account token. The kubelet
-                                                will start trying to rotate the token
-                                                if the token is older than 80 percent
-                                                of its time to live or if the token
-                                                is older than 24 hours.Defaults to
-                                                1 hour and must be at least 10 minutes.
+                                              description: |-
+                                                expirationSeconds is the requested duration of validity of the service
+                                                account token. As the token approaches expiration, the kubelet volume
+                                                plugin will proactively rotate the service account token. The kubelet will
+                                                start trying to rotate the token if the token is older than 80 percent of
+                                                its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                                and must be at least 10 minutes.
                                               format: int64
                                               type: integer
                                             path:
-                                              description: path is the path relative
-                                                to the mount point of the file to
-                                                project the token into.
+                                              description: |-
+                                                path is the path relative to the mount point of the file to project the
+                                                token into.
                                               type: string
                                           required:
                                           - path
@@ -1810,29 +1742,30 @@ spec:
                                   the host that shares a pod's lifetime
                                 properties:
                                   group:
-                                    description: group to map volume access to Default
-                                      is no group
+                                    description: |-
+                                      group to map volume access to
+                                      Default is no group
                                     type: string
                                   readOnly:
-                                    description: readOnly here will force the Quobyte
-                                      volume to be mounted with read-only permissions.
+                                    description: |-
+                                      readOnly here will force the Quobyte volume to be mounted with read-only permissions.
                                       Defaults to false.
                                     type: boolean
                                   registry:
-                                    description: registry represents a single or multiple
-                                      Quobyte Registry services specified as a string
-                                      as host:port pair (multiple entries are separated
-                                      with commas) which acts as the central registry
-                                      for volumes
+                                    description: |-
+                                      registry represents a single or multiple Quobyte Registry services
+                                      specified as a string as host:port pair (multiple entries are separated with commas)
+                                      which acts as the central registry for volumes
                                     type: string
                                   tenant:
-                                    description: tenant owning the given Quobyte volume
-                                      in the Backend Used with dynamically provisioned
-                                      Quobyte volumes, value is set by the plugin
+                                    description: |-
+                                      tenant owning the given Quobyte volume in the Backend
+                                      Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                                     type: string
                                   user:
-                                    description: user to map volume access to Defaults
-                                      to serivceaccount user
+                                    description: |-
+                                      user to map volume access to
+                                      Defaults to serivceaccount user
                                     type: string
                                   volume:
                                     description: volume is a string that references
@@ -1843,59 +1776,68 @@ spec:
                                 - volume
                                 type: object
                               rbd:
-                                description: 'rbd represents a Rados Block Device
-                                  mount on the host that shares a pod''s lifetime.
-                                  More info: https://examples.k8s.io/volumes/rbd/README.md'
+                                description: |-
+                                  rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                                  More info: https://examples.k8s.io/volumes/rbd/README.md
                                 properties:
                                   fsType:
-                                    description: 'fsType is the filesystem type of
-                                      the volume that you want to mount. Tip: Ensure
-                                      that the filesystem type is supported by the
-                                      host operating system. Examples: "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                                      TODO: how do we prevent errors in the filesystem
-                                      from compromising the machine'
+                                    description: |-
+                                      fsType is the filesystem type of the volume that you want to mount.
+                                      Tip: Ensure that the filesystem type is supported by the host operating system.
+                                      Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                                      TODO: how do we prevent errors in the filesystem from compromising the machine
                                     type: string
                                   image:
-                                    description: 'image is the rados image name. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      image is the rados image name.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   keyring:
-                                    description: 'keyring is the path to key ring
-                                      for RBDUser. Default is /etc/ceph/keyring. More
-                                      info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      keyring is the path to key ring for RBDUser.
+                                      Default is /etc/ceph/keyring.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   monitors:
-                                    description: 'monitors is a collection of Ceph
-                                      monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      monitors is a collection of Ceph monitors.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     items:
                                       type: string
                                     type: array
                                   pool:
-                                    description: 'pool is the rados pool name. Default
-                                      is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      pool is the rados pool name.
+                                      Default is rbd.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                   readOnly:
-                                    description: 'readOnly here will force the ReadOnly
-                                      setting in VolumeMounts. Defaults to false.
-                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      readOnly here will force the ReadOnly setting in VolumeMounts.
+                                      Defaults to false.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: boolean
                                   secretRef:
-                                    description: 'secretRef is name of the authentication
-                                      secret for RBDUser. If provided overrides keyring.
-                                      Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      secretRef is name of the authentication secret for RBDUser. If provided
+                                      overrides keyring.
+                                      Default is nil.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   user:
-                                    description: 'user is the rados user name. Default
-                                      is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                    description: |-
+                                      user is the rados user name.
+                                      Default is admin.
+                                      More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                                     type: string
                                 required:
                                 - image
@@ -1906,10 +1848,11 @@ spec:
                                   volume attached and mounted on Kubernetes nodes.
                                 properties:
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Default is "xfs".
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs".
+                                      Default is "xfs".
                                     type: string
                                   gateway:
                                     description: gateway is the host address of the
@@ -1921,31 +1864,31 @@ spec:
                                       storage.
                                     type: string
                                   readOnly:
-                                    description: readOnly Defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly Defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretRef:
-                                    description: secretRef references to the secret
-                                      for ScaleIO user and other sensitive information.
-                                      If this is not provided, Login operation will
-                                      fail.
+                                    description: |-
+                                      secretRef references to the secret for ScaleIO user and other
+                                      sensitive information. If this is not provided, Login operation will fail.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   sslEnabled:
                                     description: sslEnabled Flag enable/disable SSL
                                       communication with Gateway, default false
                                     type: boolean
                                   storageMode:
-                                    description: storageMode indicates whether the
-                                      storage for a volume should be ThickProvisioned
-                                      or ThinProvisioned. Default is ThinProvisioned.
+                                    description: |-
+                                      storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
+                                      Default is ThinProvisioned.
                                     type: string
                                   storagePool:
                                     description: storagePool is the ScaleIO Storage
@@ -1956,9 +1899,9 @@ spec:
                                       system as configured in ScaleIO.
                                     type: string
                                   volumeName:
-                                    description: volumeName is the name of a volume
-                                      already created in the ScaleIO system that is
-                                      associated with this volume source.
+                                    description: |-
+                                      volumeName is the name of a volume already created in the ScaleIO system
+                                      that is associated with this volume source.
                                     type: string
                                 required:
                                 - gateway
@@ -1966,35 +1909,30 @@ spec:
                                 - system
                                 type: object
                               secret:
-                                description: 'secret represents a secret that should
-                                  populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                description: |-
+                                  secret represents a secret that should populate this volume.
+                                  More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                 properties:
                                   defaultMode:
-                                    description: 'defaultMode is Optional: mode bits
-                                      used to set permissions on created files by
-                                      default. Must be an octal value between 0000
-                                      and 0777 or a decimal value between 0 and 511.
-                                      YAML accepts both octal and decimal values,
-                                      JSON requires decimal values for mode bits.
-                                      Defaults to 0644. Directories within the path
-                                      are not affected by this setting. This might
-                                      be in conflict with other options that affect
-                                      the file mode, like fsGroup, and the result
-                                      can be other mode bits set.'
+                                    description: |-
+                                      defaultMode is Optional: mode bits used to set permissions on created files by default.
+                                      Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                      YAML accepts both octal and decimal values, JSON requires decimal values
+                                      for mode bits. Defaults to 0644.
+                                      Directories within the path are not affected by this setting.
+                                      This might be in conflict with other options that affect the file
+                                      mode, like fsGroup, and the result can be other mode bits set.
                                     format: int32
                                     type: integer
                                   items:
-                                    description: items If unspecified, each key-value
-                                      pair in the Data field of the referenced Secret
-                                      will be projected into the volume as a file
-                                      whose name is the key and content is the value.
-                                      If specified, the listed keys will be projected
-                                      into the specified paths, and unlisted keys
-                                      will not be present. If a key is specified which
-                                      is not present in the Secret, the volume setup
-                                      will error unless it is marked optional. Paths
-                                      must be relative and may not contain the '..'
-                                      path or start with '..'.
+                                    description: |-
+                                      items If unspecified, each key-value pair in the Data field of the referenced
+                                      Secret will be projected into the volume as a file whose name is the
+                                      key and content is the value. If specified, the listed keys will be
+                                      projected into the specified paths, and unlisted keys will not be
+                                      present. If a key is specified which is not present in the Secret,
+                                      the volume setup will error unless it is marked optional. Paths must be
+                                      relative and may not contain the '..' path or start with '..'.
                                     items:
                                       description: Maps a string key to a path within
                                         a volume.
@@ -2003,25 +1941,21 @@ spec:
                                           description: key is the key to project.
                                           type: string
                                         mode:
-                                          description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                          description: |-
+                                            mode is Optional: mode bits used to set permissions on this file.
+                                            Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                            YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                            If not specified, the volume defaultMode will be used.
+                                            This might be in conflict with other options that affect the file
+                                            mode, like fsGroup, and the result can be other mode bits set.
                                           format: int32
                                           type: integer
                                         path:
-                                          description: path is the relative path of
-                                            the file to map the key to. May not be
-                                            an absolute path. May not contain the
-                                            path element '..'. May not start with
-                                            the string '..'.
+                                          description: |-
+                                            path is the relative path of the file to map the key to.
+                                            May not be an absolute path.
+                                            May not contain the path element '..'.
+                                            May not start with the string '..'.
                                           type: string
                                       required:
                                       - key
@@ -2033,8 +1967,9 @@ spec:
                                       Secret or its keys must be defined
                                     type: boolean
                                   secretName:
-                                    description: 'secretName is the name of the secret
-                                      in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                    description: |-
+                                      secretName is the name of the secret in the pod's namespace to use.
+                                      More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                                     type: string
                                 type: object
                               storageos:
@@ -2042,45 +1977,42 @@ spec:
                                   attached and mounted on Kubernetes nodes.
                                 properties:
                                   fsType:
-                                    description: fsType is the filesystem type to
-                                      mount. Must be a filesystem type supported by
-                                      the host operating system. Ex. "ext4", "xfs",
-                                      "ntfs". Implicitly inferred to be "ext4" if
-                                      unspecified.
+                                    description: |-
+                                      fsType is the filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   readOnly:
-                                    description: readOnly defaults to false (read/write).
-                                      ReadOnly here will force the ReadOnly setting
-                                      in VolumeMounts.
+                                    description: |-
+                                      readOnly defaults to false (read/write). ReadOnly here will force
+                                      the ReadOnly setting in VolumeMounts.
                                     type: boolean
                                   secretRef:
-                                    description: secretRef specifies the secret to
-                                      use for obtaining the StorageOS API credentials.  If
-                                      not specified, default values will be attempted.
+                                    description: |-
+                                      secretRef specifies the secret to use for obtaining the StorageOS API
+                                      credentials.  If not specified, default values will be attempted.
                                     properties:
                                       name:
-                                        description: 'Name of the referent. More info:
-                                          https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                          TODO: Add other useful fields. apiVersion,
-                                          kind, uid?'
+                                        description: |-
+                                          Name of the referent.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                          TODO: Add other useful fields. apiVersion, kind, uid?
                                         type: string
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   volumeName:
-                                    description: volumeName is the human-readable
-                                      name of the StorageOS volume.  Volume names
-                                      are only unique within a namespace.
+                                    description: |-
+                                      volumeName is the human-readable name of the StorageOS volume.  Volume
+                                      names are only unique within a namespace.
                                     type: string
                                   volumeNamespace:
-                                    description: volumeNamespace specifies the scope
-                                      of the volume within StorageOS.  If no namespace
-                                      is specified then the Pod's namespace will be
-                                      used.  This allows the Kubernetes name scoping
-                                      to be mirrored within StorageOS for tighter
-                                      integration. Set VolumeName to any name to override
-                                      the default behaviour. Set to "default" if you
-                                      are not using namespaces within StorageOS. Namespaces
-                                      that do not pre-exist within StorageOS will
-                                      be created.
+                                    description: |-
+                                      volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                                      namespace is specified then the Pod's namespace will be used.  This allows the
+                                      Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                                      Set VolumeName to any name to override the default behaviour.
+                                      Set to "default" if you are not using namespaces within StorageOS.
+                                      Namespaces that do not pre-exist within StorageOS will be created.
                                     type: string
                                 type: object
                               vsphereVolume:
@@ -2088,10 +2020,10 @@ spec:
                                   attached and mounted on kubelets host machine
                                 properties:
                                   fsType:
-                                    description: fsType is filesystem type to mount.
-                                      Must be a filesystem type supported by the host
-                                      operating system. Ex. "ext4", "xfs", "ntfs".
-                                      Implicitly inferred to be "ext4" if unspecified.
+                                    description: |-
+                                      fsType is filesystem type to mount.
+                                      Must be a filesystem type supported by the host operating system.
+                                      Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                                     type: string
                                   storagePolicyID:
                                     description: storagePolicyID is the storage Policy
@@ -2135,8 +2067,9 @@ spec:
                 description: Conditions represents the current state of the Request
                   Service.
                 items:
-                  description: Condition represents the current state of the Request
-                    Service. A condition might not show up if it is not happening.
+                  description: |-
+                    Condition represents the current state of the Request Service.
+                    A condition might not show up if it is not happening.
                   properties:
                     lastTransitionTime:
                       description: Last time the condition transitioned from one status
@@ -2204,9 +2137,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/operator.ibm.com_operandrequests.yaml
+++ b/config/crd/bases/operator.ibm.com_operandrequests.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: operandrequests.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -32,17 +30,24 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OperandRequest is the Schema for the operandrequests API.
+        description: OperandRequest is the Schema for the operandrequests API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -72,13 +77,12 @@ spec:
                             type: string
                           bindings:
                             additionalProperties:
-                              description: Bindable is a Kubernetes resources to be
-                                shared from one namespace to another. List of supported
-                                resources are Secrets, Configmaps, Services, and Routes.
-                                Secrets and Configmaps will be copied such that a
-                                new Secret/Configmap with exactly the same data will
-                                be created in the target namespace. Services and Routes
-                                data will be copied into a configmap in the target
+                              description: |-
+                                Bindable is a Kubernetes resources to be shared from one namespace to another.
+                                List of supported resources are Secrets, Configmaps, Services, and Routes.
+                                Secrets and Configmaps will be copied such that a new Secret/Configmap with
+                                exactly the same data will be created in the target namespace.
+                                Services and Routes data will be copied into a configmap in the target
                                 namespace.
                               properties:
                                 configmap:
@@ -87,15 +91,15 @@ spec:
                                     share to the namespace of the OperandRequest.
                                   type: string
                                 route:
-                                  description: Route data will be shared by copying
-                                    it into a configmap which is then created in the
-                                    target namespace
+                                  description: |-
+                                    Route data will be shared by copying it into a configmap which is then
+                                    created in the target namespace
                                   properties:
                                     data:
                                       additionalProperties:
                                         type: string
-                                      description: Data is a key-value pair where
-                                        the value is a YAML path to a value in the
+                                      description: |-
+                                        Data is a key-value pair where the value is a YAML path to a value in the
                                         OpenShift Route, e.g. .spec.host or .spec.tls.termination
                                       type: object
                                     name:
@@ -109,15 +113,15 @@ spec:
                                     of the OperandRequest.
                                   type: string
                                 service:
-                                  description: Service data will be shared by copying
-                                    it into a configmap which is then created in the
-                                    target namespace
+                                  description: |-
+                                    Service data will be shared by copying it into a configmap which is then
+                                    created in the target namespace
                                   properties:
                                     data:
                                       additionalProperties:
                                         type: string
-                                      description: Data is a key-value pair where
-                                        the value is a YAML path to a value in the
+                                      description: |-
+                                        Data is a key-value pair where the value is a YAML path to a value in the
                                         Kubernetes Service, e.g. .spec.ports[0]port
                                       type: object
                                     name:
@@ -130,22 +134,22 @@ spec:
                               of secret and/or configmap.
                             type: object
                           instanceName:
-                            description: InstanceName is used when users want to deploy
-                              multiple custom resources. It is the name of the custom
-                              resource.
+                            description: |-
+                              InstanceName is used when users want to deploy multiple custom resources.
+                              It is the name of the custom resource.
                             type: string
                           kind:
-                            description: Kind is used when users want to deploy multiple
-                              custom resources. Kind identifies the kind of the custom
-                              resource.
+                            description: |-
+                              Kind is used when users want to deploy multiple custom resources.
+                              Kind identifies the kind of the custom resource.
                             type: string
                           name:
                             description: Name of the operand to be deployed.
                             type: string
                           spec:
-                            description: Spec is used when users want to deploy multiple
-                              custom resources. It is the configuration map of custom
-                              resource.
+                            description: |-
+                              Spec is used when users want to deploy multiple custom resources.
+                              It is the configuration map of custom resource.
                             nullable: true
                             type: object
                             x-kubernetes-preserve-unknown-fields: true
@@ -158,9 +162,9 @@ spec:
                         reside.
                       type: string
                     registryNamespace:
-                      description: Specifies the namespace in which the OperandRegistry
-                        reside. The default is the current namespace in which the
-                        request is defined.
+                      description: |-
+                        Specifies the namespace in which the OperandRegistry reside.
+                        The default is the current namespace in which the request is defined.
                       type: string
                   required:
                   - operands
@@ -178,8 +182,9 @@ spec:
                 description: Conditions represents the current state of the Request
                   Service.
                 items:
-                  description: Condition represents the current state of the Request
-                    Service. A condition might not show up if it is not happening.
+                  description: |-
+                    Condition represents the current state of the Request Service.
+                    A condition might not show up if it is not happening.
                   properties:
                     lastTransitionTime:
                       description: Last time the condition transitioned from one status
@@ -309,9 +314,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/crd/bases/operator.ibm.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operatorconfigs.yaml
@@ -1,11 +1,9 @@
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: operatorconfigs.operator.ibm.com
 spec:
   group: operator.ibm.com
@@ -22,14 +20,19 @@ spec:
         description: OperatorConfig is the Schema for the operatorconfigs API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -55,22 +58,20 @@ spec:
                             the pod.
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node matches the corresponding matchExpressions;
-                                the node(s) with the highest sum are the most preferred.
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
                               items:
-                                description: An empty preferred scheduling term matches
-                                  all objects with implicit weight 0 (i.e. it's a
-                                  no-op). A null preferred scheduling term matches
-                                  no objects (i.e. is also a no-op).
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                                 properties:
                                   preference:
                                     description: A node selector term, associated
@@ -80,32 +81,26 @@ spec:
                                         description: A list of node selector requirements
                                           by node's labels.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -118,32 +113,26 @@ spec:
                                         description: A list of node selector requirements
                                           by node's fields.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -153,6 +142,7 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   weight:
                                     description: Weight associated with matching the
                                       corresponding nodeSelectorTerm, in the range
@@ -165,53 +155,46 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to an
-                                update), the system may or may not try to eventually
-                                evict the pod from its node.
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
                               properties:
                                 nodeSelectorTerms:
                                   description: Required. A list of node selector terms.
                                     The terms are ORed.
                                   items:
-                                    description: A null or empty node selector term
-                                      matches no objects. The requirements of them
-                                      are ANDed. The TopologySelectorTerm type implements
-                                      a subset of the NodeSelectorTerm.
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                     properties:
                                       matchExpressions:
                                         description: A list of node selector requirements
                                           by node's labels.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -224,32 +207,26 @@ spec:
                                         description: A list of node selector requirements
                                           by node's fields.
                                         items:
-                                          description: A node selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
                                           properties:
                                             key:
                                               description: The label key that the
                                                 selector applies to.
                                               type: string
                                             operator:
-                                              description: Represents a key's relationship
-                                                to a set of values. Valid operators
-                                                are In, NotIn, Exists, DoesNotExist.
-                                                Gt, and Lt.
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                               type: string
                                             values:
-                                              description: An array of string values.
-                                                If the operator is In or NotIn, the
-                                                values array must be non-empty. If
-                                                the operator is Exists or DoesNotExist,
-                                                the values array must be empty. If
-                                                the operator is Gt or Lt, the values
-                                                array must have a single element,
-                                                which will be interpreted as an integer.
-                                                This array is replaced during a strategic
-                                                merge patch.
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
                                               items:
                                                 type: string
                                               type: array
@@ -259,10 +236,12 @@ spec:
                                           type: object
                                         type: array
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   type: array
                               required:
                               - nodeSelectorTerms
                               type: object
+                              x-kubernetes-map-type: atomic
                           type: object
                         podAffinity:
                           description: Describes pod affinity scheduling rules (e.g.
@@ -270,18 +249,16 @@ spec:
                             other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the affinity expressions specified
-                                by this field, but it may choose a node that violates
-                                one or more of the expressions. The node that is most
-                                preferred is the one with the greatest sum of weights,
-                                i.e. for each node that meets all of the scheduling
-                                requirements (resource request, requiredDuringScheduling
-                                affinity expressions, etc.), compute a sum by iterating
-                                through the elements of this field and adding "weight"
-                                to the sum if the node has pods which matches the
-                                corresponding podAffinityTerm; the node(s) with the
-                                highest sum are the most preferred.
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
                               items:
                                 description: The weights of all of the matched WeightedPodAffinityTerm
                                   fields are added per-node to find the most preferred
@@ -300,29 +277,24 @@ spec:
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -335,52 +307,44 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces.
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -393,43 +357,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace".
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                     - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range
-                                      1-100.
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -438,24 +396,22 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a
-                                pod label update), the system may or may not try to
-                                eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all
-                                terms must be satisfied.
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or
-                                  not co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any
-                                  node on which a pod of the set of pods is running
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources,
@@ -466,28 +422,24 @@ spec:
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -500,50 +452,44 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces
-                                      field. null selector and null or empty namespaces
-                                      list means "this pod's namespace". An empty
-                                      selector ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -556,34 +502,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces
-                                      list and null namespaceSelector means "this
-                                      pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                 - topologyKey
@@ -596,18 +537,16 @@ spec:
                             as some other pod(s)).
                           properties:
                             preferredDuringSchedulingIgnoredDuringExecution:
-                              description: The scheduler will prefer to schedule pods
-                                to nodes that satisfy the anti-affinity expressions
-                                specified by this field, but it may choose a node
-                                that violates one or more of the expressions. The
-                                node that is most preferred is the one with the greatest
-                                sum of weights, i.e. for each node that meets all
-                                of the scheduling requirements (resource request,
-                                requiredDuringScheduling anti-affinity expressions,
-                                etc.), compute a sum by iterating through the elements
-                                of this field and adding "weight" to the sum if the
-                                node has pods which matches the corresponding podAffinityTerm;
-                                the node(s) with the highest sum are the most preferred.
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
                               items:
                                 description: The weights of all of the matched WeightedPodAffinityTerm
                                   fields are added per-node to find the most preferred
@@ -626,29 +565,24 @@ spec:
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -661,52 +595,44 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaceSelector:
-                                        description: A label query over the set of
-                                          namespaces that the term applies to. The
-                                          term is applied to the union of the namespaces
-                                          selected by this field and the ones listed
-                                          in the namespaces field. null selector and
-                                          null or empty namespaces list means "this
-                                          pod's namespace". An empty selector ({})
-                                          matches all namespaces.
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
                                         properties:
                                           matchExpressions:
                                             description: matchExpressions is a list
                                               of label selector requirements. The
                                               requirements are ANDed.
                                             items:
-                                              description: A label selector requirement
-                                                is a selector that contains values,
-                                                a key, and an operator that relates
-                                                the key and values.
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
                                               properties:
                                                 key:
                                                   description: key is the label key
                                                     that the selector applies to.
                                                   type: string
                                                 operator:
-                                                  description: operator represents
-                                                    a key's relationship to a set
-                                                    of values. Valid operators are
-                                                    In, NotIn, Exists and DoesNotExist.
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                                   type: string
                                                 values:
-                                                  description: values is an array
-                                                    of string values. If the operator
-                                                    is In or NotIn, the values array
-                                                    must be non-empty. If the operator
-                                                    is Exists or DoesNotExist, the
-                                                    values array must be empty. This
-                                                    array is replaced during a strategic
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
                                                     merge patch.
                                                   items:
                                                     type: string
@@ -719,43 +645,37 @@ spec:
                                           matchLabels:
                                             additionalProperties:
                                               type: string
-                                            description: matchLabels is a map of {key,value}
-                                              pairs. A single {key,value} in the matchLabels
-                                              map is equivalent to an element of matchExpressions,
-                                              whose key field is "key", the operator
-                                              is "In", and the values array contains
-                                              only "value". The requirements are ANDed.
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                                             type: object
                                         type: object
+                                        x-kubernetes-map-type: atomic
                                       namespaces:
-                                        description: namespaces specifies a static
-                                          list of namespace names that the term applies
-                                          to. The term is applied to the union of
-                                          the namespaces listed in this field and
-                                          the ones selected by namespaceSelector.
-                                          null or empty namespaces list and null namespaceSelector
-                                          means "this pod's namespace".
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                         items:
                                           type: string
                                         type: array
                                       topologyKey:
-                                        description: This pod should be co-located
-                                          (affinity) or not co-located (anti-affinity)
-                                          with the pods matching the labelSelector
-                                          in the specified namespaces, where co-located
-                                          is defined as running on a node whose value
-                                          of the label with key topologyKey matches
-                                          that of any node on which any of the selected
-                                          pods is running. Empty topologyKey is not
-                                          allowed.
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
                                         type: string
                                     required:
                                     - topologyKey
                                     type: object
                                   weight:
-                                    description: weight associated with matching the
-                                      corresponding podAffinityTerm, in the range
-                                      1-100.
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
                                     format: int32
                                     type: integer
                                 required:
@@ -764,24 +684,22 @@ spec:
                                 type: object
                               type: array
                             requiredDuringSchedulingIgnoredDuringExecution:
-                              description: If the anti-affinity requirements specified
-                                by this field are not met at scheduling time, the
-                                pod will not be scheduled onto the node. If the anti-affinity
-                                requirements specified by this field cease to be met
-                                at some point during pod execution (e.g. due to a
-                                pod label update), the system may or may not try to
-                                eventually evict the pod from its node. When there
-                                are multiple elements, the lists of nodes corresponding
-                                to each podAffinityTerm are intersected, i.e. all
-                                terms must be satisfied.
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
                               items:
-                                description: Defines a set of pods (namely those matching
-                                  the labelSelector relative to the given namespace(s))
-                                  that this pod should be co-located (affinity) or
-                                  not co-located (anti-affinity) with, where co-located
-                                  is defined as running on a node whose value of the
-                                  label with key <topologyKey> matches that of any
-                                  node on which a pod of the set of pods is running
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
                                 properties:
                                   labelSelector:
                                     description: A label query over a set of resources,
@@ -792,28 +710,24 @@ spec:
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -826,50 +740,44 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces
-                                      field. null selector and null or empty namespaces
-                                      list means "this pod's namespace". An empty
-                                      selector ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of
                                           label selector requirements. The requirements
                                           are ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a
-                                            key, and an operator that relates the
-                                            key and values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -882,34 +790,29 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only
-                                          "value". The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
+                                    x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to.
-                                      The term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces
-                                      list and null namespaceSelector means "this
-                                      pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified
-                                      namespaces, where co-located is defined as running
-                                      on a node whose value of the label with key
-                                      topologyKey matches that of any node on which
-                                      any of the selected pods is running. Empty topologyKey
-                                      is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                 - topologyKey
@@ -921,30 +824,32 @@ spec:
                       description: Name is the operator name as requested in the OperandRequest.
                       type: string
                     replicas:
-                      description: Number of desired pods. This is a pointer to distinguish
-                        between explicit zero and not specified. Defaults to 1.
+                      description: |-
+                        Number of desired pods. This is a pointer to distinguish between explicit
+                        zero and not specified. Defaults to 1.
                       format: int32
                       type: integer
                     topologySpreadConstraints:
-                      description: TopologySpreadConstraints describes how a group
-                        of pods ought to spread across topology domains. Scheduler
-                        will schedule pods in a way which abides by the constraints.
+                      description: |-
+                        TopologySpreadConstraints describes how a group of pods ought to spread across topology
+                        domains. Scheduler will schedule pods in a way which abides by the constraints.
                         All topologySpreadConstraints are ANDed.
                       items:
                         description: TopologySpreadConstraint specifies how to spread
                           matching pods among the given topology.
                         properties:
                           labelSelector:
-                            description: LabelSelector is used to find matching pods.
-                              Pods that match this label selector are counted to determine
-                              the number of pods in their corresponding topology domain.
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -952,17 +857,16 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values
-                                        array must be non-empty. If the operator is
-                                        Exists or DoesNotExist, the values array must
-                                        be empty. This array is replaced during a
-                                        strategic merge patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -974,93 +878,93 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
+                            x-kubernetes-map-type: atomic
                           maxSkew:
-                            description: 'MaxSkew describes the degree to which pods
-                              may be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                              it is the maximum permitted difference between the number
-                              of matching pods in the target topology and the global
-                              minimum. The global minimum is the minimum number of
-                              matching pods in an eligible domain or zero if the number
-                              of eligible domains is less than MinDomains. For example,
-                              in a 3-zone cluster, MaxSkew is set to 1, and pods with
-                              the same labelSelector spread as 2/2/1: In this case,
-                              the global minimum is 1. | zone1 | zone2 | zone3 | |  P
-                              P  |  P P  |   P   | - if MaxSkew is 1, incoming pod
-                              can only be scheduled to zone3 to become 2/2/2; scheduling
-                              it onto zone1(zone2) would make the ActualSkew(3-1)
-                              on zone1(zone2) violate MaxSkew(1). - if MaxSkew is
-                              2, incoming pod can be scheduled onto any zone. When
-                              `whenUnsatisfiable=ScheduleAnyway`, it is used to give
-                              higher precedence to topologies that satisfy it. It''s
-                              a required field. Default value is 1 and 0 is not allowed.'
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
                             format: int32
                             type: integer
                           minDomains:
-                            description: "MinDomains indicates a minimum number of
-                              eligible domains. When the number of eligible domains
-                              with matching topology keys is less than minDomains,
-                              Pod Topology Spread treats \"global minimum\" as 0,
-                              and then the calculation of Skew is performed. And when
-                              the number of eligible domains with matching topology
-                              keys equals or greater than minDomains, this value has
-                              no effect on scheduling. As a result, when the number
-                              of eligible domains is less than minDomains, scheduler
-                              won't schedule more than maxSkew Pods to those domains.
-                              If value is nil, the constraint behaves as if MinDomains
-                              is equal to 1. Valid values are integers greater than
-                              0. When value is not nil, WhenUnsatisfiable must be
-                              DoNotSchedule. \n For example, in a 3-zone cluster,
-                              MaxSkew is set to 2, MinDomains is set to 5 and pods
-                              with the same labelSelector spread as 2/2/2: | zone1
-                              | zone2 | zone3 | |  P P  |  P P  |  P P  | The number
-                              of domains is less than 5(MinDomains), so \"global minimum\"
-                              is treated as 0. In this situation, new pod with the
-                              same labelSelector cannot be scheduled, because computed
-                              skew will be 3(3 - 0) if new Pod is scheduled to any
-                              of the three zones, it will violate MaxSkew. \n This
-                              is an alpha field and requires enabling MinDomainsInPodTopologySpread
-                              feature gate."
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+
+
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+
+
+                              This is an alpha field and requires enabling MinDomainsInPodTopologySpread feature gate.
                             format: int32
                             type: integer
                           topologyKey:
-                            description: TopologyKey is the key of node labels. Nodes
-                              that have a label with this key and identical values
-                              are considered to be in the same topology. We consider
-                              each <key, value> as a "bucket", and try to put balanced
-                              number of pods into each bucket. We define a domain
-                              as a particular instance of a topology. Also, we define
-                              an eligible domain as a domain whose nodes match the
-                              node selector. e.g. If TopologyKey is "kubernetes.io/hostname",
-                              each Node is a domain of that topology. And, if TopologyKey
-                              is "topology.kubernetes.io/zone", each zone is a domain
-                              of that topology. It's a required field.
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes match the node selector.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
                             type: string
                           whenUnsatisfiable:
-                            description: 'WhenUnsatisfiable indicates how to deal
-                              with a pod if it doesn''t satisfy the spread constraint.
-                              - DoNotSchedule (default) tells the scheduler not to
-                              schedule it. - ScheduleAnyway tells the scheduler to
-                              schedule the pod in any location,   but giving higher
-                              precedence to topologies that would help reduce the   skew.
-                              A constraint is considered "Unsatisfiable" for an incoming
-                              pod if and only if every possible node assignment for
-                              that pod would violate "MaxSkew" on some topology. For
-                              example, in a 3-zone cluster, MaxSkew is set to 1, and
-                              pods with the same labelSelector spread as 3/1/1: |
-                              zone1 | zone2 | zone3 | | P P P |   P   |   P   | If
-                              WhenUnsatisfiable is set to DoNotSchedule, incoming
-                              pod can only be scheduled to zone2(zone3) to become
-                              3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
-                              MaxSkew(1). In other words, the cluster can still be
-                              imbalanced, but scheduler won''t make it *more* imbalanced.
-                              It''s a required field.'
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
                             type: string
                         required:
                         - maxSkew
@@ -1088,9 +992,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -28,7 +28,9 @@ spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-    - description: OperandBindInfo is the Schema for the operandbindinfoes API.
+    - description: OperandBindInfo is the Schema for the operandbindinfoes API. Documentation
+        For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+        License By installing this product you accept the license terms https://ibm.biz/icpfs39license
       displayName: OperandBindInfo
       kind: OperandBindInfo
       name: operandbindinfos.operator.ibm.com
@@ -39,7 +41,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperandConfig is the Schema for the operandconfigs API.
+    - description: OperandConfig is the Schema for the operandconfigs API. Documentation
+        For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+        License By installing this product you accept the license terms https://ibm.biz/icpfs39license
       displayName: OperandConfig
       kind: OperandConfig
       name: operandconfigs.operator.ibm.com
@@ -54,7 +58,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperandRegistry is the Schema for the operandregistries API.
+    - description: OperandRegistry is the Schema for the operandregistries API. Documentation
+        For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+        License By installing this product you accept the license terms https://ibm.biz/icpfs39license
       displayName: OperandRegistry
       kind: OperandRegistry
       name: operandregistries.operator.ibm.com
@@ -74,7 +80,9 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperandRequest is the Schema for the operandrequests API.
+    - description: OperandRequest is the Schema for the operandrequests API. Documentation
+        For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+        License By installing this product you accept the license terms https://ibm.biz/icpfs39license
       displayName: OperandRequest
       kind: OperandRequest
       name: operandrequests.operator.ibm.com

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -102,6 +102,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
+    - description: OperatorConfig is the Schema for the operatorconfigs API
+      displayName: Operator Config
+      kind: OperatorConfig
+      name: operatorconfigs.operator.ibm.com
+      version: v1alpha1
   description: |-
     # Introduction
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,29 +1,45 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: operand-deployment-lifecycle-manager
 rules:
 - apiGroups:
+  - operator.ibm.com
+  resources:
+  - auditloggings
+  - certmanagers
+  verbs:
+  - delete
+  - get
+- apiGroups:
   - operators.coreos.com
   resources:
   - catalogsources
   verbs:
   - get
-- apiGroups:
-  - operator.ibm.com
-  resources:
-  - certmanagers
-  - auditloggings
-  verbs:
-  - get
-  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  creationTimestamp: null
   name: operand-deployment-lifecycle-manager
+  namespace: placeholder
 rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - namespaces
+  - secrets
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - '*'
   resources:
@@ -36,7 +52,12 @@ rules:
   - patch
   - update
   - watch
-- verbs:
+- apiGroups:
+  - k8s.keycloak.org
+  resources:
+  - keycloakrealmimports
+  - keycloaks
+  verbs:
   - create
   - delete
   - get
@@ -44,25 +65,55 @@ rules:
   - patch
   - update
   - watch
-  apiGroups:
+- apiGroups:
   - operator.ibm.com
   resources:
   - operandconfigs
-  - operandconfigs/status
   - operandconfigs/finalizers
+  - operandconfigs/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
   - operandregistries
-  - operandregistries/status
   - operandregistries/finalizers
+  - operandregistries/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
   - operandrequests
-  - operandrequests/status
   - operandrequests/finalizers
-  - operandbindinfos
-  - operandbindinfos/status
-  - operandbindinfos/finalizers
+  - operandrequests/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
   - operatorconfigs
-  - operatorconfigs/status
   - operatorconfigs/finalizers
-- verbs:
+  - operatorconfigs/status
+  verbs:
   - create
   - delete
   - get
@@ -70,39 +121,12 @@ rules:
   - patch
   - update
   - watch
-  apiGroups:
-  - ''
-  resources:
-  - configmaps
-  - secrets
-  - services
-  - namespaces
-- verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-- verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-  apiGroups:
+- apiGroups:
   - operators.coreos.com
   resources:
-  - operatorgroups
-  - installplans
-- verbs:
+  - clusterserviceversions
+  - subscriptions
+  verbs:
   - create
   - delete
   - get
@@ -110,15 +134,36 @@ rules:
   - patch
   - update
   - watch
-  apiGroups:
-  - k8s.keycloak.org
+- apiGroups:
+  - operators.coreos.com
   resources:
-  - keycloaks
+  - installplans
+  - operatorgroups
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - packages.operators.coreos.com
   resources:
   - packagemanifests
   verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -31,6 +31,9 @@ const (
 	//OpreqLabel is the label used to label the subscription/CR managed by ODLM
 	OpreqLabel string = "operator.ibm.com/opreq-control"
 
+	//InternalOpreqLabel is the label used label the OperandRequest internally created by ODLM
+	OperandOnlyLabel string = "operator.ibm.com/operand-only"
+
 	//ODLMReferenceLabel is the label used to label the resources used for ODLM operand value reference
 	ODLMReferenceLabel string = "operator.ibm.com/referenced-by-odlm-resource"
 

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -70,6 +70,8 @@ var (
 	isRouteAPI         = false
 )
 
+// +kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandbindinfos;operandbindinfos/status;operandbindinfos/finalizers,verbs=get;list;watch;create;update;patch;delete
+
 // Reconcile reads that state of the cluster for a OperandBindInfo object and makes changes based on the state read
 // and what is in the OperandBindInfo.Spec
 // Note:

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -54,6 +54,8 @@ type Reconciler struct {
 	*deploy.ODLMOperator
 }
 
+//+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandconfigs;operandconfigs/status;operandconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
+
 // Reconcile reads that state of the cluster for a OperandConfig object and makes changes based on the state read
 // and what is in the OperandConfig.Spec
 // Note:

--- a/controllers/operandregistry/operandregistry_controller.go
+++ b/controllers/operandregistry/operandregistry_controller.go
@@ -43,6 +43,8 @@ type Reconciler struct {
 	*deploy.ODLMOperator
 }
 
+// +kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandregistries;operandregistries/status;operandregistries/finalizers,verbs=get;list;watch;create;update;patch;delete
+
 // Reconcile reads that state of the cluster for a OperandRegistry object and makes changes based on the state read
 // and what is in the OperandRegistry.Spec
 // Note:

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -61,6 +61,18 @@ type clusterObjects struct {
 	subscription  *olmv1alpha1.Subscription
 }
 
+//+kubebuilder:rbac:groups=operator.ibm.com,resources=certmanagers;auditloggings,verbs=get;delete
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=get
+
+//+kubebuilder:rbac:groups=*,namespace="placeholder",resources=*,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandrequests;operandrequests/status;operandrequests/finalizers,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",namespace="placeholder",resources=configmaps;secrets;services;namespaces,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=route.openshift.io,namespace="placeholder",resources=routes,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=operators.coreos.com,namespace="placeholder",resources=operatorgroups;installplans,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=k8s.keycloak.org,namespace="placeholder",resources=keycloaks;keycloakrealmimports,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=packages.operators.coreos.com,namespace="placeholder",resources=packagemanifests,verbs=get;list;patch;update;watch
+//+kubebuilder:rbac:groups=operators.coreos.com,namespace="placeholder",resources=clusterserviceversions;subscriptions,verbs=create;delete;get;list;patch;update;watch
+
 // Reconcile reads that state of the cluster for a OperandRequest object and makes changes based on the state read
 // and what is in the OperandRequest.Spec
 // Note:

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1073,8 +1073,7 @@ func (r *Reconciler) updateK8sResource(ctx context.Context, existingK8sRes unstr
 			// Deep copy the existing k8s resource
 			originalK8sRes, err := deepcopy.Anything(existingK8sRes.Object)
 			if err != nil {
-				klog.Error(err)
-				return false, err
+				return false, errors.Wrapf(err, "failed to deep copy k8s resource -- Kind: %s, NamespacedName: %s/%s", kind, namespace, name)
 			}
 
 			// Update the existing k8s resource with the merged CR

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -406,45 +406,23 @@ func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandN
 		return nil
 	}
 
-	// remove request info including channel and operator namespace in annotation of subscription
-	reqName := requestInstance.ObjectMeta.Name
-	reqNs := requestInstance.ObjectMeta.Namespace
-	delete(sub.Annotations, reqNs+"."+reqName+"."+op.Name+"/request")
-	delete(sub.Annotations, reqNs+"."+reqName+"."+op.Name+"/operatorNamespace")
-
-	uninstallOperatorOnly := false
-	var nsAnnoSlice []string
-	namespaceReg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/operatorNamespace`)
-	for anno, ns := range sub.Annotations {
-		if namespaceReg.MatchString(anno) {
-			nsAnnoSlice = append(nsAnnoSlice, ns)
+	uninstallOperator, uninstallOperand := checkSubAnnotationsForUninstall(requestInstance.ObjectMeta.Name, requestInstance.ObjectMeta.Namespace, op.Name, sub)
+	if !uninstallOperand && !uninstallOperator {
+		if err = r.updateSubscription(ctx, requestInstance, sub); err != nil {
+			requestInstance.SetMemberStatus(op.Name, operatorv1alpha1.OperatorFailed, "", &r.Mutex)
+			return err
 		}
-	}
-	if len(nsAnnoSlice) != 0 {
-		// No OperandRequest is requesting operator in existing subscription's namespace, uninstall Operator only
-		if !util.Contains(nsAnnoSlice, sub.Namespace) {
-			uninstallOperatorOnly = true
-		} else {
-			// remove the associated request from annotation of subscription
-			if err = r.updateSubscription(ctx, requestInstance, sub); err != nil {
-				requestInstance.SetMemberStatus(op.Name, operatorv1alpha1.OperatorFailed, "", &r.Mutex)
-				return err
-			}
-			requestInstance.SetMemberStatus(op.Name, operatorv1alpha1.OperatorUpdating, "", &r.Mutex)
+		requestInstance.SetMemberStatus(op.Name, operatorv1alpha1.OperatorUpdating, "", &r.Mutex)
 
-			klog.V(1).Infof("Did not delete Subscription %s/%s which is requested by other OperandRequests", sub.Namespace, sub.Name)
-			return nil
-		}
+		klog.V(1).Infof("No deletion, subscription %s/%s and its operands are still requested by other OperandRequests", sub.Namespace, sub.Name)
+		return nil
 	}
 
-	csv, err := r.GetClusterServiceVersion(ctx, sub)
-	// If can't get CSV, requeue the request
-	if err != nil {
+	if csv, err := r.GetClusterServiceVersion(ctx, sub); err != nil {
+		// If can't get CSV, requeue the request
 		return err
-	}
-
-	if csv != nil {
-		if !uninstallOperatorOnly {
+	} else if csv != nil {
+		if uninstallOperand {
 			klog.V(2).Infof("Deleting all the Custom Resources for CSV, Namespace: %s, Name: %s", csv.Namespace, csv.Name)
 			if err := r.deleteAllCustomResource(ctx, csv, requestInstance, configInstance, operandName, configInstance.Namespace); err != nil {
 				return err
@@ -454,34 +432,41 @@ func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandN
 				return err
 			}
 		}
-		if r.checkUninstallLabel(sub) {
-			klog.V(1).Infof("Operator %s has label operator.ibm.com/opreq-do-not-uninstall. Skip the uninstall", op.Name)
-			return nil
-		}
+		if uninstallOperator {
+			if r.checkUninstallLabel(sub) {
+				klog.V(1).Infof("Operator %s has label operator.ibm.com/opreq-do-not-uninstall. Skip the uninstall", op.Name)
+				return nil
+			}
 
-		klog.V(3).Info("Set Deleting Condition in the operandRequest")
-		requestInstance.SetDeletingCondition(csv.Name, operatorv1alpha1.ResourceTypeCsv, corev1.ConditionTrue, &r.Mutex)
+			klog.V(3).Info("Set Deleting Condition in the operandRequest")
+			requestInstance.SetDeletingCondition(csv.Name, operatorv1alpha1.ResourceTypeCsv, corev1.ConditionTrue, &r.Mutex)
 
-		klog.V(1).Infof("Deleting the ClusterServiceVersion, Namespace: %s, Name: %s", csv.Namespace, csv.Name)
-		if err := r.Delete(ctx, csv); err != nil {
-			requestInstance.SetDeletingCondition(csv.Name, operatorv1alpha1.ResourceTypeCsv, corev1.ConditionFalse, &r.Mutex)
-			return errors.Wrap(err, "failed to delete the ClusterServiceVersion")
-		}
-	}
-
-	klog.V(2).Infof("Deleting the Subscription, Namespace: %s, Name: %s", namespace, op.Name)
-	requestInstance.SetDeletingCondition(op.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionTrue, &r.Mutex)
-
-	if err := r.Delete(ctx, sub); err != nil {
-		if apierrors.IsNotFound(err) {
-			klog.Warningf("Subscription %s was not found in namespace %s", op.Name, namespace)
-		} else {
-			requestInstance.SetDeletingCondition(op.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionFalse, &r.Mutex)
-			return errors.Wrap(err, "failed to delete subscription")
+			klog.V(1).Infof("Deleting the ClusterServiceVersion, Namespace: %s, Name: %s", csv.Namespace, csv.Name)
+			if err := r.Delete(ctx, csv); err != nil {
+				requestInstance.SetDeletingCondition(csv.Name, operatorv1alpha1.ResourceTypeCsv, corev1.ConditionFalse, &r.Mutex)
+				return errors.Wrap(err, "failed to delete the ClusterServiceVersion")
+			}
 		}
 	}
 
-	klog.V(1).Infof("Subscription %s/%s is deleted", namespace, op.Name)
+	if uninstallOperator {
+		klog.V(2).Infof("Deleting the Subscription, Namespace: %s, Name: %s", namespace, op.Name)
+		requestInstance.SetDeletingCondition(op.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionTrue, &r.Mutex)
+
+		if err := r.Delete(ctx, sub); err != nil {
+			if apierrors.IsNotFound(err) {
+				klog.Warningf("Subscription %s was not found in namespace %s", op.Name, namespace)
+			} else {
+				requestInstance.SetDeletingCondition(op.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionFalse, &r.Mutex)
+				return errors.Wrap(err, "failed to delete subscription")
+			}
+		}
+
+		klog.V(1).Infof("Subscription %s/%s is deleted", namespace, op.Name)
+	} else {
+		klog.V(1).Infof("Subscription %s/%s is not deleted due to the annotation from OperandRequest", namespace, op.Name)
+	}
+
 	return nil
 }
 
@@ -652,4 +637,59 @@ func compareSub(sub *olmv1alpha1.Subscription, originalSub *olmv1alpha1.Subscrip
 func CheckSingletonServices(operator string) bool {
 	singletonServices := []string{"ibm-cert-manager-operator", "ibm-licensing-operator"}
 	return util.Contains(singletonServices, operator)
+}
+
+// checkSubAnnotationsForUninstall checks the annotations of a Subscription object
+// to determine whether the operator and operand should be uninstalled.
+// It takes the name of the OperandRequest, the namespace of the OperandRequest,
+// the name of the operator, and a pointer to the Subscription object as input.
+// It returns two boolean values: uninstallOperator and uninstallOperand.
+// If uninstallOperator is true, it means the operator should be uninstalled.
+// If uninstallOperand is true, it means the operand should be uninstalled.
+func checkSubAnnotationsForUninstall(reqName, reqNs, opName string, sub *olmv1alpha1.Subscription) (bool, bool) {
+	uninstallOperator := true
+	uninstallOperand := true
+
+	var curChannel string
+	if sub.GetAnnotations() != nil {
+		curChannel = sub.Annotations[reqNs+"."+reqName+"."+opName+"/request"]
+	}
+
+	delete(sub.Annotations, reqNs+"."+reqName+"."+opName+"/request")
+	delete(sub.Annotations, reqNs+"."+reqName+"."+opName+"/operatorNamespace")
+
+	var opreqNsSlice []string
+	var operatorNameSlice []string
+	var channelSlice []string
+	namespaceReg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/operatorNamespace`)
+	channelReg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/request`)
+
+	for key, value := range sub.Annotations {
+		if namespaceReg.MatchString(key) {
+			opreqNsSlice = append(opreqNsSlice, value)
+		}
+
+		if channelReg.MatchString(key) {
+			channelSlice = append(channelSlice, value)
+			// Extract the operator name from the key
+			keyParts := strings.Split(key, "/")
+			annoPrefix := strings.Split(keyParts[0], ".")
+			operatorNameSlice = append(operatorNameSlice, annoPrefix[len(annoPrefix)-1])
+		}
+	}
+
+	// If one of remaining <prefix>/operatorNamespace annotations' values is the same as subscription's namespace,
+	// the operator should NOT be uninstalled.
+	if util.Contains(opreqNsSlice, sub.Namespace) {
+		uninstallOperator = false
+	}
+
+	// If the removed/uninstalled <prefix>/request annotation's value is NOT the same as all other <prefix>/request annotation's values.
+	// or the operator namespace in one of remaining annotation is the same as the operator name in removed/uninstalled <prefix>/request
+	// the operand should NOT be uninstalled.
+	if util.Differs(channelSlice, curChannel) || util.Contains(operatorNameSlice, opName) {
+		uninstallOperand = false
+	}
+
+	return uninstallOperator, uninstallOperand
 }

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -464,6 +464,11 @@ func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandN
 
 		klog.V(1).Infof("Subscription %s/%s is deleted", namespace, op.Name)
 	} else {
+		if err = r.updateSubscription(ctx, requestInstance, sub); err != nil {
+			requestInstance.SetMemberStatus(op.Name, operatorv1alpha1.OperatorFailed, "", &r.Mutex)
+			return err
+		}
+		requestInstance.SetMemberStatus(op.Name, operatorv1alpha1.OperatorUpdating, "", &r.Mutex)
 		klog.V(1).Infof("Subscription %s/%s is not deleted due to the annotation from OperandRequest", namespace, op.Name)
 	}
 

--- a/controllers/operandrequest/reconcile_operator_test.go
+++ b/controllers/operandrequest/reconcile_operator_test.go
@@ -1,3 +1,19 @@
+//
+// Copyright 2022 IBM Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package operandrequest
 
 import (

--- a/controllers/operandrequest/reconcile_operator_test.go
+++ b/controllers/operandrequest/reconcile_operator_test.go
@@ -1,0 +1,224 @@
+package operandrequest
+
+import (
+	"testing"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
+)
+
+func TestGenerateClusterObjects(t *testing.T) {
+	r := &Reconciler{}
+
+	o := &operatorv1alpha1.Operator{
+		Namespace:           "test-namespace",
+		TargetNamespaces:    []string{"target-namespace"},
+		InstallMode:         "namespace",
+		Channel:             "test-channel",
+		PackageName:         "test-package",
+		SourceName:          "test-source",
+		SourceNamespace:     "test-source-namespace",
+		InstallPlanApproval: "Automatic",
+		StartingCSV:         "test-csv",
+		SubscriptionConfig: &olmv1alpha1.SubscriptionConfig{
+			Env: []corev1.EnvVar{
+				{
+					Name:  "key",
+					Value: "value",
+				},
+			},
+		},
+	}
+
+	registryKey := types.NamespacedName{
+		Namespace: "test-registry-namespace",
+		Name:      "test-registry-name",
+	}
+	requestKey := types.NamespacedName{
+		Namespace: "test-namespace",
+		Name:      "test-opreq",
+	}
+
+	co := r.generateClusterObjects(o, registryKey, requestKey)
+
+	assert.NotNil(t, co.namespace)
+	assert.Equal(t, "Namespace", co.namespace.Kind)
+	assert.Equal(t, "v1", co.namespace.APIVersion)
+	assert.Equal(t, "test-namespace", co.namespace.Name)
+	assert.Equal(t, map[string]string{"operator.ibm.com/opreq-control": "true"}, co.namespace.Labels)
+
+	assert.NotNil(t, co.operatorGroup)
+	assert.Equal(t, "OperatorGroup", co.operatorGroup.Kind)
+	assert.Equal(t, "test-namespace", co.operatorGroup.Namespace)
+	assert.Equal(t, []string{"target-namespace"}, co.operatorGroup.Spec.TargetNamespaces)
+
+	assert.NotNil(t, co.subscription)
+	assert.Equal(t, "Subscription", co.subscription.Kind)
+	assert.Equal(t, "test-namespace", co.subscription.Namespace)
+	assert.Equal(t, "test-channel", co.subscription.Spec.Channel)
+	assert.Equal(t, "test-package", co.subscription.Spec.Package)
+	assert.Equal(t, "test-source", co.subscription.Spec.CatalogSource)
+	assert.Equal(t, "test-source-namespace", co.subscription.Spec.CatalogSourceNamespace)
+	assert.Equal(t, olmv1alpha1.Approval("Automatic"), co.subscription.Spec.InstallPlanApproval)
+	assert.Equal(t, "test-csv", co.subscription.Spec.StartingCSV)
+	assert.NotNil(t, co.subscription.Spec.Config)
+	assert.Equal(t, "value", co.subscription.Spec.Config.Env[0].Value)
+}
+
+func TestCheckSubAnnotationsForUninstall(t *testing.T) {
+	reqNameA := "common-service"
+	reqNsA := "ibm-common-services"
+	opNameA := "ibm-iam"
+	opChannelA := "v3"
+
+	reqNameB := "other-request"
+	reqNsB := "other-namespace"
+	opNameB := "ibm-im"
+	opChannelB := "v4.0"
+
+	reqNameC := "common-service"
+	reqNsC := "ibm-common-services"
+	opNameC := "common-service-postgresql"
+	opChannelC := "stable-v1"
+
+	reqNameD := "common-service"
+	reqNsD := "ibm-common-services"
+	opNameD := "edb-keycloak"
+	opChannelD := "stable-v1"
+
+	// The annotation key has prefix: <requestNamespace>.<requestName>.<operatorName>/*
+
+	// When following conditions are met, the operator should be uninstalled:
+	// If all remaining <prefix>/operatorNamespace annotations' values are not the same as subscription's namespace, the operator should be uninstalled.
+
+	// When following conditions are met, the operand should be uninstalled:
+	// 1. The removed/uninstalled <prefix>/request annotation's value is the same as all other <prefix>/request annotation's values.
+	// 2. Operator name in removed/uninstalled <prefix>/request is different from all other <prefix>/request annotation's values.
+
+	// Test case 1: uninstallOperator is true, uninstallOperand is true
+	// The operator and operand should be uninstalled because only the remaining OperandRequest B is internal-opreq: true.
+	sub := &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: reqNsA,
+			Annotations: map[string]string{
+				reqNsA + "." + reqNameA + "." + opNameA + "/request":           opChannelA,
+				reqNsA + "." + reqNameA + "." + opNameA + "/operatorNamespace": reqNsA,
+			},
+		},
+	}
+
+	uninstallOperator, uninstallOperand := checkSubAnnotationsForUninstall(reqNameA, reqNsA, opNameA, sub)
+
+	assert.True(t, uninstallOperator)
+	assert.True(t, uninstallOperand)
+
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/request")
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/operatorNamespace")
+
+	// Test case 2: uninstallOperator is true, uninstallOperand is false
+	// The operator should be uninstalled because only the remaining Subscription B requesting operator is not in the same namespace as the Subscription.
+	sub = &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: reqNsA,
+			Annotations: map[string]string{
+				reqNsA + "." + reqNameA + "." + opNameA + "/request":           opChannelA,
+				reqNsA + "." + reqNameA + "." + opNameA + "/operatorNamespace": reqNsA,
+				reqNsB + "." + reqNameB + "." + opNameB + "/request":           opChannelB,
+				reqNsB + "." + reqNameB + "." + opNameB + "/operatorNamespace": reqNsB,
+			},
+		},
+	}
+
+	uninstallOperator, uninstallOperand = checkSubAnnotationsForUninstall(reqNameA, reqNsA, opNameA, sub)
+
+	assert.True(t, uninstallOperator)
+	assert.False(t, uninstallOperand)
+
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/request")
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/operatorNamespace")
+	assert.Contains(t, sub.Annotations, reqNsB+"."+reqNameB+"."+opNameB+"/request")
+	assert.Contains(t, sub.Annotations, reqNsB+"."+reqNameB+"."+opNameB+"/operatorNamespace")
+
+	// Test case 3: uninstallOperator is false, uninstallOperand is true
+	// The operator should not be uninstalled because the remaining Subscription B requesting operator is in the same namespace as the Subscription.
+	// The operand should be uninstalled because
+	// 1. the operator name in removed/uninstalled Subscription A is different from all other Subscription annotation's values,
+	// 2. but the removed/uninstalled <prefix>/request annotation's value is the same as all other <prefix>/request annotation's values.
+	sub = &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: reqNsC,
+			Annotations: map[string]string{
+				reqNsC + "." + reqNameC + "." + opNameC + "/request":           opChannelC,
+				reqNsC + "." + reqNameC + "." + opNameC + "/operatorNamespace": reqNsC,
+				reqNsD + "." + reqNameD + "." + opNameD + "/request":           opChannelD,
+				reqNsD + "." + reqNameD + "." + opNameD + "/operatorNamespace": reqNsD,
+			},
+		},
+	}
+
+	uninstallOperator, uninstallOperand = checkSubAnnotationsForUninstall(reqNameC, reqNsC, opNameC, sub)
+
+	assert.False(t, uninstallOperator)
+	assert.True(t, uninstallOperand)
+
+	assert.NotContains(t, sub.Annotations, reqNsC+"."+reqNameC+"."+opNameC+"/request")
+	assert.NotContains(t, sub.Annotations, reqNsC+"."+reqNameC+"."+opNameC+"/operatorNamespace")
+	assert.Contains(t, sub.Annotations, reqNsD+"."+reqNameD+"."+opNameD+"/request")
+	assert.Contains(t, sub.Annotations, reqNsD+"."+reqNameD+"."+opNameD+"/operatorNamespace")
+
+	// Test case 4: uninstallOperator is false, uninstallOperand is false
+	// The operator and operand should not be uninstalled because at least one different OperandRequest requesting same operator
+	// But the annotation of removed OperandRequest should be removed.
+	sub = &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: reqNsA,
+			Annotations: map[string]string{
+				reqNsA + "." + reqNameA + "." + opNameA + "/request":           opChannelA,
+				reqNsA + "." + reqNameA + "." + opNameA + "/operatorNamespace": reqNsA,
+				// The remaining OperandRequest B is requesting the same operator
+				reqNsB + "." + reqNameB + "." + opNameA + "/request":           opChannelA,
+				reqNsB + "." + reqNameB + "." + opNameA + "/operatorNamespace": reqNsA,
+			},
+		},
+	}
+
+	uninstallOperator, uninstallOperand = checkSubAnnotationsForUninstall(reqNameA, reqNsA, opNameA, sub)
+
+	assert.False(t, uninstallOperator)
+	assert.False(t, uninstallOperand)
+
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/request")
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/operatorNamespace")
+	assert.Contains(t, sub.Annotations, reqNsB+"."+reqNameB+"."+opNameA+"/request")
+	assert.Contains(t, sub.Annotations, reqNsB+"."+reqNameB+"."+opNameA+"/operatorNamespace")
+
+	// Test case 5: uninstallOperator is false, uninstallOperand is false
+	// The operator and operand should not be uninstalled because at OperandRequest request a different operator name and different channel, but the same operator namespace
+	// But the annotation of removed OperandRequest should be removed.
+	sub = &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: reqNsA,
+			Annotations: map[string]string{
+				reqNsA + "." + reqNameA + "." + opNameA + "/request":           opChannelA,
+				reqNsA + "." + reqNameA + "." + opNameA + "/operatorNamespace": reqNsA,
+				reqNsB + "." + reqNameB + "." + opNameB + "/request":           opChannelB,
+				reqNsB + "." + reqNameB + "." + opNameB + "/operatorNamespace": reqNsA,
+			},
+		},
+	}
+
+	uninstallOperator, uninstallOperand = checkSubAnnotationsForUninstall(reqNameA, reqNsA, opNameA, sub)
+
+	assert.False(t, uninstallOperator)
+	assert.False(t, uninstallOperand)
+
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/request")
+	assert.NotContains(t, sub.Annotations, reqNsA+"."+reqNameA+"."+opNameA+"/operatorNamespace")
+	assert.Contains(t, sub.Annotations, reqNsB+"."+reqNameB+"."+opNameB+"/request")
+	assert.Contains(t, sub.Annotations, reqNsB+"."+reqNameB+"."+opNameB+"/operatorNamespace")
+}

--- a/controllers/operatorconfig/operatorconfig_controller.go
+++ b/controllers/operatorconfig/operatorconfig_controller.go
@@ -42,9 +42,7 @@ type Reconciler struct {
 	*deploy.ODLMOperator
 }
 
-//+kubebuilder:rbac:groups=operator.ibm.com,resources=operatorconfigs,verbs=get;list;watch;create;update;patch;delete
-//+kubebuilder:rbac:groups=operator.ibm.com,resources=operatorconfigs/status,verbs=get;update;patch
-//+kubebuilder:rbac:groups=operator.ibm.com,resources=operatorconfigs/finalizers,verbs=update
+//+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operatorconfigs;operatorconfigs/status;operatorconfigs/finalizers,verbs=get;list;watch;create;update;patch;delete
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -235,6 +235,15 @@ func Contains(list []string, s string) bool {
 	return false
 }
 
+func Differs(list []string, s string) bool {
+	for _, v := range list {
+		if v != s {
+			return true
+		}
+	}
+	return false
+}
+
 func ObjectToNewUnstructured(obj interface{}) (*unstructured.Unstructured, error) {
 	content, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 	if err != nil {

--- a/controllers/util/util_test.go
+++ b/controllers/util/util_test.go
@@ -71,3 +71,43 @@ var _ = Describe("Get environmental variables", func() {
 		})
 	})
 })
+
+var _ = Describe("Contains", func() {
+	It("Should return true if the list contains the string", func() {
+		list := []string{"apple", "banana", "cherry"}
+		s := "banana"
+		Expect(Contains(list, s)).Should(BeTrue())
+	})
+
+	It("Should return false if the list does not contain the string", func() {
+		list := []string{"apple", "banana", "cherry"}
+		s := "orange"
+		Expect(Contains(list, s)).Should(BeFalse())
+	})
+
+	It("Should return false if the list is empty", func() {
+		list := []string{}
+		s := "apple"
+		Expect(Contains(list, s)).Should(BeFalse())
+	})
+})
+
+var _ = Describe("Differs", func() {
+	It("Should return true if the list contains a different string", func() {
+		list := []string{"apple", "banana", "cherry"}
+		s := "banana"
+		Expect(Differs(list, s)).Should(BeTrue())
+	})
+
+	It("Should return false if the list contains only the same string", func() {
+		list := []string{"apple", "apple", "apple"}
+		s := "apple"
+		Expect(Differs(list, s)).Should(BeFalse())
+	})
+
+	It("Should return false if the list is empty", func() {
+		list := []string{}
+		s := "apple"
+		Expect(Differs(list, s)).Should(BeFalse())
+	})
+})


### PR DESCRIPTION
uninstallation issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62243

### Context
There are several services depending on the same operator, but different operands.

For example, both IM service and Keycloak service depend on the same EDB operator. However, each of them has different EDB Cluster CR. As a result, we are using different entires in OperandRegistry/OperandConfig to distinguish EDB used by IM as `common-service-postgresql`, and EDB used by Keycloak as `edb-keycloak`

For simplicity, I will only use EDB Cluster CR as the operand created by ODLM.

- If we request `common-service-postgresql`, it will install EDB operator, and EDB Cluster CR `common-service-db`.
- If we request `edb-keycloak`, it will install EDB operator, and EDB Cluster CR `keycloak-edb-cluster`.

When we request both of them in the OperandRequest, they share the same EDB operator, but different EDB Cluster CRs.

During the uninstallation, following pattern should be fulfilled.
- EDB operator would be uninstalled only when there is no `common-service-postgresql` and `edb-keycloak` requested
- `common-service-db` Cluster CR should be removed as long as there is no `common-service-postgresql` in OperandRequest
- `keycloak-edb-cluster` Cluster CR should be removed as long as there is no `edb-keycloak` in OperandRequest

### How to test
- Install CS 4.6 daily build in one namespace
- Update ODLM CSV to replace image to `quay.io/opencloudio/odlm:9c23dfda`, and update ImagePullPolicy to `Always`
- Create an OperandRequest to request both `common-service-postgresql` and `edb-keycloak`
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
            - name: edb-keycloak
          registry: common-service
    ```
- Observe that there are `common-service-db-1` and `keycloak-edb-cluster-1` pods available, representing two EDB Cluster CR respectively.
- Observe that there is a `postgresql-operator-controller-manager` pod available, representing EDB operator
- Update OperandRequest, to remove `common-service-postgresql`
- Observe that there is NO `common-service-db-1` pod in the namespace.
- Observe that there is still `keycloak-edb-cluster-1` and `postgresql-operator-controller-manager` pod in the namespace.
- Delete the entire OperandRequest
- Observe that there is no more EDB related pod left in the namespace.