### PR TITLE
Update deepcopy library for any type deep copying

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -28,7 +28,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/mohae/deepcopy"
+	"github.com/barkimedes/go-deepcopy"
 	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/pkg/errors"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -1071,7 +1071,11 @@ func (r *Reconciler) updateK8sResource(ctx context.Context, existingK8sRes unstr
 			updatedExistingK8sRes := util.MergeCR(existingK8sResRaw, k8sResConfig.Raw)
 
 			// Deep copy the existing k8s resource
-			originalK8sRes := deepcopy.Copy(existingK8sRes.Object)
+			originalK8sRes, err := deepcopy.Anything(existingK8sRes.Object)
+			if err != nil {
+				klog.Error(err)
+				return false, err
+			}
 
 			// Update the existing k8s resource with the merged CR
 			existingK8sRes.Object = updatedExistingK8sRes

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.20
 require (
 	github.com/IBM/controller-filtered-cache v0.3.5
 	github.com/IBM/ibm-namespace-scope-operator v1.17.3
+	github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df
 	github.com/deckarep/golang-set v1.7.1
 	github.com/google/go-cmp v0.5.9
 	github.com/jaegertracing/jaeger-operator v1.36.0

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df h1:GSoSVRLoBaFpOOds6QyY1L8AX7uoY+Ln3BHc22W40X0=
+github.com/barkimedes/go-deepcopy v0.0.0-20220514131651-17c30cfc62df/go.mod h1:hiVxq5OP2bUGBRNS3Z/bt/reCLFNbdcST6gISi1fiOM=
 github.com/benbjohnson/clock v1.0.3/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
Changed the deep copy library  in the existing code. This ensures proper deep copying functionality for slice types.
Updates for PR: https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1019

Test image: quay.io/yuchen_shen/odlm:deep_merge