### PR TITLE
Improve UX experience for OperatorConfig

### DIFF
--- a/api/v1alpha1/operatorconfig_types.go
+++ b/api/v1alpha1/operatorconfig_types.go
@@ -67,6 +67,11 @@ type OperatorConfigStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+// +kubebuilder:resource:path=operatorconfigs,scope=Namespaced
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=.metadata.creationTimestamp
+// +kubebuilder:printcolumn:name="Phase",type=string,JSONPath=.status.phase,description="Current Phase"
+// +kubebuilder:printcolumn:name="Created At",type=string,JSONPath=.metadata.creationTimestamp
+// +operator-sdk:csv:customresourcedefinitions:displayName="OperatorConfig"
 
 // OperatorConfig is the Schema for the operatorconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
 type OperatorConfig struct {

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,7 +129,7 @@ metadata:
     categories: Developer Tools, Monitoring, Logging & Tracing, Security
     certified: "false"
     containerImage: icr.io/cpopen/odlm:latest
-    createdAt: "2024-04-02T02:16:34Z"
+    createdAt: "2024-04-04T03:40:45Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.3.0'
@@ -215,8 +215,8 @@ spec:
             x-descriptors:
               - urn:alm:descriptor:io.kubernetes.phase
         version: v1alpha1
-      - description: OperatorConfig is the Schema for the operatorconfigs API
-        displayName: Operator Config
+      - description: OperatorConfig is the Schema for the operatorconfigs API. Documentation For additional details regarding install parameters check https://ibm.biz/icpfs39install. License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+        displayName: OperatorConfig
         kind: OperatorConfig
         name: operatorconfigs.operator.ibm.com
         version: v1alpha1
@@ -708,6 +708,20 @@ spec:
               resources:
                 - keycloakrealmimports
                 - keycloaks
+              verbs:
+                - create
+                - delete
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - operator.ibm.com
+              resources:
+                - operandbindinfos
+                - operandbindinfos/finalizers
+                - operandbindinfos/status
               verbs:
                 - create
                 - delete

--- a/bundle/manifests/operator.ibm.com_operatorconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operatorconfigs.yaml
@@ -18,10 +18,23 @@ spec:
     singular: operatorconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Current Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Created At
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OperatorConfig is the Schema for the operatorconfigs API
+        description: OperatorConfig is the Schema for the operatorconfigs API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
             description: |-

--- a/config/crd/bases/operator.ibm.com_operatorconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operatorconfigs.yaml
@@ -14,10 +14,23 @@ spec:
     singular: operatorconfig
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    - description: Current Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Created At
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: OperatorConfig is the Schema for the operatorconfigs API
+        description: OperatorConfig is the Schema for the operatorconfigs API. Documentation
+          For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+          License By installing this product you accept the license terms https://ibm.biz/icpfs39license
         properties:
           apiVersion:
             description: |-

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -102,8 +102,10 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:io.kubernetes.phase
       version: v1alpha1
-    - description: OperatorConfig is the Schema for the operatorconfigs API
-      displayName: Operator Config
+    - description: OperatorConfig is the Schema for the operatorconfigs API. Documentation
+        For additional details regarding install parameters check https://ibm.biz/icpfs39install.
+        License By installing this product you accept the license terms https://ibm.biz/icpfs39license
+      displayName: OperatorConfig
       kind: OperatorConfig
       name: operatorconfigs.operator.ibm.com
       version: v1alpha1

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -68,6 +68,20 @@ rules:
 - apiGroups:
   - operator.ibm.com
   resources:
+  - operandbindinfos
+  - operandbindinfos/finalizers
+  - operandbindinfos/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
   - operandconfigs
   - operandconfigs/finalizers
   - operandconfigs/status


### PR DESCRIPTION
- Add OperandBindinfo permission explicitly back to RBAC
- Update the additional columns from CLI
    ```console
    > oc get operatorconfig -n test-operator-config
    
    NAME                                      AGE   PHASE   CREATED AT
    cloud-native-postgresql-operator-config   23h           2024-04-03T04:00:26Z
    ```
- Remove additional space on display name
  <img width="1617" alt="Screenshot 2024-04-03 at 11 51 30 PM" src="https://github.com/IBM/operand-deployment-lifecycle-manager/assets/29827416/25846c75-ccfa-4cb0-9cbb-5facb9283c52">

