### PR TITLE
Update OperatorConfig reconciliation and improve error handling

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -392,6 +392,11 @@ func (m *ODLMOperator) GetSubscription(ctx context.Context, name, operatorNs, se
 
 // GetClusterServiceVersion gets the ClusterServiceVersion from the subscription
 func (m *ODLMOperator) GetClusterServiceVersion(ctx context.Context, sub *olmv1alpha1.Subscription) (*olmv1alpha1.ClusterServiceVersion, error) {
+	// Check if subscription is nil
+	if sub == nil {
+		klog.Error("The subscription is nil")
+		return nil, fmt.Errorf("the subscription is nil")
+	}
 	// Check the ClusterServiceVersion status in the subscription
 	if sub.Status.InstalledCSV == "" {
 		klog.Warningf("The ClusterServiceVersion for Subscription %s is not ready. Will check it again", sub.Name)

--- a/controllers/operatorconfig/operatorconfig_controller.go
+++ b/controllers/operatorconfig/operatorconfig_controller.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	operatorv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/api/v1alpha1"
+	"github.com/IBM/operand-deployment-lifecycle-manager/controllers/constant"
 	deploy "github.com/IBM/operand-deployment-lifecycle-manager/controllers/operator"
 )
 
@@ -73,19 +74,25 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			operand := u
 			operator := registry.GetOperator(operand.Name)
 			if operator.OperatorConfig == "" {
-				break
+				continue
 			}
 
 			var sub *olmv1alpha1.Subscription
 			sub, err = r.GetSubscription(ctx, operator.Name, operator.Namespace, registry.Namespace, operator.PackageName)
 			if err != nil {
 				return ctrl.Result{}, err
+			} else if sub == nil {
+				klog.Infof("Subscription for Operator %s/%s not found", operator.Name, operator.PackageName)
+				return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 			}
 
 			var csv *olmv1alpha1.ClusterServiceVersion
 			csv, err = r.GetClusterServiceVersion(ctx, sub)
 			if err != nil {
 				return ctrl.Result{}, err
+			} else if csv == nil {
+				klog.Infof("ClusterServiceVersion for Operator %s/%s not found", operator.Name, operator.PackageName)
+				return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 			}
 
 			klog.Infof("Fetching OperatorConfig: %s", operator.OperatorConfig)
@@ -94,12 +101,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				Name:      operator.OperatorConfig,
 				Namespace: registry.Namespace,
 			}, config); err != nil {
-				return ctrl.Result{}, client.IgnoreNotFound(err)
+				if client.IgnoreNotFound(err) != nil {
+					return ctrl.Result{}, client.IgnoreNotFound(err)
+				} else {
+					klog.Infof("OperatorConfig %s/%s does not exist for oeprand %s in request %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
+					continue
+				}
 			}
 			serviceConfig := config.GetConfigForOperator(operator.Name)
 			if serviceConfig == nil {
 				klog.Infof("OperatorConfig: %s, does not have configuration for operator: %s", operator.OperatorConfig, operator.Name)
-				return ctrl.Result{}, nil
+				continue
 			}
 
 			copyToCast, err := deepcopy.Anything(csv)
@@ -108,13 +120,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 			csvToUpdate := copyToCast.(*olmv1alpha1.ClusterServiceVersion)
 			klog.Infof("Applying OperatorConfig: %s to Operator: %s via CSV: %s, %s", operator.OperatorConfig, operator.Name, csv.Name, csv.Namespace)
-			return r.configCsv(ctx, csvToUpdate, serviceConfig)
+			if err := r.configCsv(ctx, csvToUpdate, serviceConfig); err != nil {
+				klog.Errorf("Failed to apply OperatorConfig %s/%s to Operator: %s via CSV: %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, csv.Namespace, csv.Name)
+				return ctrl.Result{}, err
+			}
 		}
 	}
+	klog.Infof("Finished reconciling OperatorConfig for request: %s, %s", instance.Namespace, instance.Name)
 	return ctrl.Result{}, nil
 }
 
-func (r *Reconciler) configCsv(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, config *operatorv1alpha1.ServiceOperatorConfig) (ctrl.Result, error) {
+func (r *Reconciler) configCsv(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, config *operatorv1alpha1.ServiceOperatorConfig) error {
 	if config.Replicas != nil {
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Replicas = config.Replicas
 	}
@@ -125,9 +141,9 @@ func (r *Reconciler) configCsv(ctx context.Context, csv *olmv1alpha1.ClusterServ
 		csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[0].Spec.Template.Spec.TopologySpreadConstraints = config.TopologySpreadConstraints
 	}
 	if err := r.Client.Update(ctx, csv); err != nil {
-		return ctrl.Result{}, err
+		return err
 	}
-	return ctrl.Result{}, nil
+	return nil
 }
 
 func (r *Reconciler) requestsFromMapFunc(ctx context.Context) handler.MapFunc {

--- a/controllers/operatorconfig/operatorconfig_controller.go
+++ b/controllers/operatorconfig/operatorconfig_controller.go
@@ -102,9 +102,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				Namespace: registry.Namespace,
 			}, config); err != nil {
 				if client.IgnoreNotFound(err) != nil {
-					return ctrl.Result{}, client.IgnoreNotFound(err)
+					return ctrl.Result{}, err
 				} else {
-					klog.Infof("OperatorConfig %s/%s does not exist for oeprand %s in request %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
+					klog.Infof("OperatorConfig %s/%s does not exist for operand %s in request %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
 					continue
 				}
 			}
@@ -127,7 +127,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 	}
 	klog.Infof("Finished reconciling OperatorConfig for request: %s, %s", instance.Namespace, instance.Name)
-	return ctrl.Result{}, nil
+	return ctrl.Result{RequeueAfter: constant.DefaultSyncPeriod}, nil
 }
 
 func (r *Reconciler) configCsv(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, config *operatorv1alpha1.ServiceOperatorConfig) error {

--- a/controllers/operatorconfig/operatorconfig_controller.go
+++ b/controllers/operatorconfig/operatorconfig_controller.go
@@ -103,10 +103,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}, config); err != nil {
 				if client.IgnoreNotFound(err) != nil {
 					return ctrl.Result{}, err
-				} else {
-					klog.Infof("OperatorConfig %s/%s does not exist for operand %s in request %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
-					continue
 				}
+				klog.Infof("OperatorConfig %s/%s does not exist for operand %s in request %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
+				continue
 			}
 			serviceConfig := config.GetConfigForOperator(operator.Name)
 			if serviceConfig == nil {


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62886

- Fix ODLM crashing issue when the CSV for a subscription is not found.
    ```log
    I0405 19:45:19.234024 1 operatorconfig_controller.go:94] ClusterServiceVersion for Operator edb-keycloak/cloud-native-postgresql not found
    I0405 19:45:19.234185 1 operatorconfig_controller.go:65] Reconciling OperatorConfig for request: test-operator-config, example-service
    W0405 19:45:19.683699 1 operandconfig_controller.go:158] ClusterServiceVersion for the Subscription test-operator-config/edb-keycloak doesn't exist, retry...
    W0405 19:45:19.722368 1 operandconfig_controller.go:158] ClusterServiceVersion for the Subscription test-operator-config/edb-keycloak doesn't exist, retry...
    ```

- Use `continue` when the OperatorConfig CR is not found or specified for the first requested operand in OperandRequest
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: keycloak-operator      # first one has no OperatorConfig available
            - name: cloud-native-postgresql   # skip to reconcile OperatorConfig for second one
          registry: common-service
    ```
    - In the logs, the first one `keycloak-operator` is skipped since it does not have OperandConfig available
        ```log
          I0405 19:19:00.236624 1 operatorconfig_controller.go:65] Reconciling OperatorConfig for request: test-operator-config, example-service
          I0405 19:19:03.422097 1 operatorconfig_controller.go:98] Fetching OperatorConfig: cloud-native-postgresql-operator-config
          I0405 19:19:03.423291 1 operatorconfig_controller.go:122] Applying OperatorConfig: cloud-native-postgresql-operator-config to Operator: cloud-native-postgresql via CSV: cloud-native-postgresql.v1.18.10, test-operator-config
          I0405 19:19:03.452439 1 operatorconfig_controller.go:129] Finished reconciling OperatorConfig for request: test-operator-config, example-service
        ``` 

- Re-queue the request every three hours if reconciliation is completed successful in last round.