### PR TITLE
Set channel annotation for no-op equal to spec channel when spec channel is lower

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -220,8 +220,11 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 			requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opt.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
 			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, mu)
 
-			//set operator channel back to previous one if it is tombstone service
-			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
+			// check if sub.Spec.Channel and opt.Channel are valid semantic version
+			// set annotation channel back to previous one if sub.Spec.Channel is lower than opt.Channel
+			if semver.IsValid(sub.Spec.Channel) && semver.IsValid(opt.Channel) && semver.Compare(sub.Spec.Channel, opt.Channel) < 0 {
+				sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
+			}
 		} else {
 			requestInstance.SetNotFoundOperatorFromRegistryCondition(operand.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionFalse, mu)
 


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62726#issuecomment-77073414

### Context
Previously ODLM will **unconditionally** set the channel annotation for `no-op` operator the same as subscription spec. Here is [the reason why we are doing this initially, to avoid intermediate upgrade issue in Airgap ENV](https://github.com/IBM/operand-deployment-lifecycle-manager/pull/910)

But there is another case when there are OperandRequests requesting no-op `ibm-iam-operator` and new `ibm-im-operator`, ODLM sets channel annotation to `v4.5` for both OperandRequests.
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  annotations:
    daily-cd.example-service-2.ibm-im-operator/request: v4.5     # new ibm-im-operator with v4.5 channel in OperandRegistry
    daily-cd.example-service.ibm-iam-operator/request: v4.5     # no-op ibm-iam-operator match with .spec.channel
                                                                # although no-op channel is v3.23 in OperandRegistry
  name: ibm-iam-operator
spec:
  channel: v4.5                                             # new installation in isolate upgrade
  installPlanApproval: Automatic
  name: ibm-iam-operator
  source: opencloud-operators-daily-cd
  sourceNamespace: openshift-marketplace
```

However, this setting causes an uninstallation issue - When OperandRequest for `ibm-iam-operator` is removed, ODLM remove IAM's Authentication CR because ODLM mistakenly thinks `ibm-iam-operator` and `ibm-im-operator` are two different entities sharing the same channel `v4.5`, but having different Authentication CRs.
   - If channel annotation for `ibm-iam-operator` and `ibm-im-operator` is different, then ODLM will not uninstall Authentication CR.
   - But in facts, there is only one Authentication CR, and it should always be preserved because it is still requested by the remaining OperatorRequest with `ibm-im-operator`.

In order to avoid ODLM remove IAM's Authentication CR, the channel annotation for `ibm-iam-operator` should be different from `ibm-im-operator`

### Solution
ODLM only set the channel annotation for `no-op` operator the same `.spec.channel` when `.spec.channel` is semantically lower then `no-op` channel in OperandRegistry

#### Avoid intermediate upgrade
For example, no-op `ibm-iam-operator` has channel `v3.23` in OperandRegistry, which is greater than the `.spec.channel: v3`, we will get following subscription
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  annotations:
    daily-cd.example-service.ibm-iam-operator/request: v3      # no-op ibm-iam-operator match with .spec.channel
                                                            # to avoid intermediate upgrade
                                                            # although no-op channel in OperandRegistry is v3.23
  name: ibm-iam-operator
spec:
  channel: v3        # v3 channel before upgrading to CPFS 4.x
  installPlanApproval: Automatic
  name: ibm-iam-operator
  source: opencloud-operators-daily-cd
  sourceNamespace: openshift-marketplace
```

#### Avoid uninstallation issue
When channel annotation is different, uninstallation of `ibm-iam-operator` will not trigger Authentication CR deletion.
For example, no-op `ibm-iam-operator` has channel `v3.23` in OperandRegistry, which is lower than the `.spec.channel: v4.5`, we will get following subscription. 

```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: Subscription
metadata:
  annotations:
    daily-cd.example-service-2.ibm-im-operator/request: v4.5     # new ibm-im-operator with v4.5 channel in OperandRegistry
    daily-cd.example-service.ibm-iam-operator/request: v3.23     # no-op ibm-iam-operator match channel v3.23 in OperandRegistry
  name: ibm-iam-operator
spec:
  channel: v4.5                                             # new installation in isolate upgrade
  installPlanApproval: Automatic
  name: ibm-iam-operator
  source: opencloud-operators-daily-cd
  sourceNamespace: openshift-marketplace
```