### PR TITLE
Overwrite the array in deep merge logic

### DIFF
--- a/controllers/util/merge.go
+++ b/controllers/util/merge.go
@@ -80,10 +80,7 @@ func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interf
 				changedMapRef := changedMap.([]interface{})
 				for i := range defaultMapRef {
 					if _, ok := defaultMapRef[i].(map[string]interface{}); ok {
-						if len(changedMapRef) <= i {
-							finalMap[key] = append(finalMap[key].([]interface{}), defaultMapRef[i])
-						} else {
-
+						if len(changedMapRef) > i {
 							for newKey := range defaultMapRef[i].(map[string]interface{}) {
 								checkKeyBeforeMerging(newKey, defaultMapRef[i].(map[string]interface{})[newKey], changedMapRef[i].(map[string]interface{})[newKey], finalMap[key].([]interface{})[i].(map[string]interface{}))
 							}


### PR DESCRIPTION
Issue: 
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63136
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63126

### Context
We've implemented JSON deep merge into ODLM reconciliation to support the merging of array objects. However, this  leads to a side effect where ODLM lost control over individual items in the arrays, causing problems during upgrades. This resulted in a case where the `ibm-iam-operator` in `ibm-bts-request` couldn't be removed and blocked the upgrade process.
