### PR TITLE
Fix nil pointer issue when operator is not found in OperandRegistry

### DIFF
--- a/controllers/operatorconfig/operatorconfig_controller.go
+++ b/controllers/operatorconfig/operatorconfig_controller.go
@@ -62,7 +62,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	klog.Infof("Reconciling OperatorConfig for request: %s, %s", instance.Namespace, instance.Name)
+	klog.Infof("Reconciling OperatorConfig for OperandRequest: %s/%s", instance.Namespace, instance.Name)
 
 	for _, v := range instance.Spec.Requests {
 		reqBlock := v
@@ -73,7 +73,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		for _, u := range reqBlock.Operands {
 			operand := u
 			operator := registry.GetOperator(operand.Name)
-			if operator.OperatorConfig == "" {
+			if operator == nil || operator.OperatorConfig == "" {
 				continue
 			}
 
@@ -104,12 +104,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				if client.IgnoreNotFound(err) != nil {
 					return ctrl.Result{}, err
 				}
-				klog.Infof("OperatorConfig %s/%s does not exist for operand %s in request %s, %s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
+				klog.Infof("OperatorConfig %s/%s does not exist for operand %s in OperandRequest %s/%s", registry.Namespace, operator.OperatorConfig, operator.Name, instance.Namespace, instance.Name)
 				continue
 			}
 			serviceConfig := config.GetConfigForOperator(operator.Name)
 			if serviceConfig == nil {
-				klog.Infof("OperatorConfig: %s, does not have configuration for operator: %s", operator.OperatorConfig, operator.Name)
+				klog.Infof("OperatorConfig %s does not have configuration for operator: %s", operator.OperatorConfig, operator.Name)
 				continue
 			}
 
@@ -125,7 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 			}
 		}
 	}
-	klog.Infof("Finished reconciling OperatorConfig for request: %s, %s", instance.Namespace, instance.Name)
+	klog.Infof("Finished reconciling OperatorConfig for OperandRequest %s/%s", instance.Namespace, instance.Name)
 	return ctrl.Result{RequeueAfter: constant.DefaultSyncPeriod}, nil
 }
 


### PR DESCRIPTION
issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63295
Fix error when operator entry is not found in OperandRegistry
```
I0426 13:30:32.519386 1 reconcile_operator.go:50] Reconciling Operators for OperandRequest: navigator-ns/cp4i-navigator-pn-ibm-integration-platform-navigator
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0xd8 pc=0x15a74e9]
goroutine 1189 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:118 +0x1da
panic({0x17277e0?, 0x281ce30?})
/usr/local/go/src/runtime/panic.go:770 +0x132
github.com/IBM/operand-deployment-lifecycle-manager/controllers/operatorconfig.(*Reconciler).Reconcile(0xc00008c8e0, {0x1bbfcb0, 0xc00150b680}, {{{0xc000a18d26?, 0x0?}, {0xc000a18d30?, 0xc00150b680?}}})
/workspace/controllers/operatorconfig/operatorconfig_controller.go:76 +0x4e9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0x1bbfce8?, {0x1bbfcb0?, 0xc00150b680?}, {{{0xc000a18d26?, 0x1870260?}, {0xc000a18d30?, 0x41a098?}}})
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:121 +0xb7
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc0007fdc20, {0x1bbfce8, 0xc00036fb80}, {0x178bf60, 0xc0003bc2a0})
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:320 +0x2dd
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc0007fdc20, {0x1bbfce8, 0xc00036fb80})
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:273 +0x1c9
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2()
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:234 +0x79
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2 in goroutine 716
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:230 +0x50c
```