### PR TITLE
[4.7] Remove cluster permission from ODLM

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,7 +129,7 @@ metadata:
     categories: Developer Tools, Monitoring, Logging & Tracing, Security
     certified: "false"
     containerImage: icr.io/cpopen/odlm:latest
-    createdAt: "2024-03-13T21:38:26Z"
+    createdAt: "2024-04-26T16:25:05Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.3.0'
@@ -562,22 +562,14 @@ spec:
   install:
     spec:
       clusterPermissions:
-      - rules:
-        - apiGroups:
-          - operators.coreos.com
-          resources:
-          - catalogsources
-          verbs:
-          - get
-        - apiGroups:
-          - operator.ibm.com
-          resources:
-          - certmanagers
-          - auditloggings
-          verbs:
-          - get
-          - delete
-        serviceAccountName: operand-deployment-lifecycle-manager
+        - rules:
+            - apiGroups:
+                - operators.coreos.com
+              resources:
+                - catalogsources
+              verbs:
+                - get
+          serviceAccountName: operand-deployment-lifecycle-manager
       deployments:
         - label:
             app.kubernetes.io/instance: operand-deployment-lifecycle-manager

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,14 +9,6 @@ rules:
   - catalogsources
   verbs:
   - get
-- apiGroups:
-  - operator.ibm.com
-  resources:
-  - certmanagers
-  - auditloggings
-  verbs:
-  - get
-  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/62528
This is to revert the fix made in release 4.6: https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1023
Original issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/61103

We are going to remove `CertManager` CR and `AuditLogging` CR clusterpermission from ODLM