### PR TITLE
Only discover catalog for an operator when it has been requested in OperandRequest

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -159,11 +159,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		return ctrl.Result{}, nil
 	}
 	// Get the operand namespace
-	operandOperator := registryInstance.GetOperator(bindInfoInstance.Spec.Operand)
-	if operandOperator == nil {
-		klog.Errorf("failed to find operator %s in the OperandRegistry %s", bindInfoInstance.Spec.Operand, registryInstance.Name)
+	operandOperator, err := r.GetOperandFromRegistry(ctx, registryInstance, bindInfoInstance.Spec.Operand)
+	if err != nil || operandOperator == nil {
+		klog.Errorf("failed to find operator %s in the OperandRegistry %s: %v", bindInfoInstance.Spec.Operand, registryInstance.Name, err)
 		r.Recorder.Eventf(bindInfoInstance, corev1.EventTypeWarning, "NotFound", "NotFound operator %s in the OperandRegistry %s", bindInfoInstance.Spec.Operand, registryInstance.Name)
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 	operandNamespace := registryInstance.Namespace
 

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -354,18 +354,27 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	ReferencePredicates := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			labels := e.Object.GetLabels()
-			for labelKey, labelValue := range labels {
-				if labelKey == constant.ODLMWatchedLabel {
-					return labelValue == "true"
+			// only return true when both conditions are met at the same time:
+			// 1. label contain key "constant.ODLMWatchedLabel" and value is true
+			// 2. label does not contain key "constant.OpbiTypeLabel" with value "copy"
+			if labels != nil {
+				if labelValue, ok := labels[constant.ODLMWatchedLabel]; ok && labelValue == "true" {
+					if labelValue, ok := labels[constant.OpbiTypeLabel]; ok && labelValue == "copy" {
+						return false
+					}
+					return true
 				}
 			}
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			labels := e.ObjectNew.GetLabels()
-			for labelKey, labelValue := range labels {
-				if labelKey == constant.ODLMWatchedLabel {
-					return labelValue == "true"
+			if labels != nil {
+				if labelValue, ok := labels[constant.ODLMWatchedLabel]; ok && labelValue == "true" {
+					if labelValue, ok := labels[constant.OpbiTypeLabel]; ok && labelValue == "copy" {
+						return false
+					}
+					return true
 				}
 			}
 			return false

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -137,7 +137,11 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 	// Check the requested Operand if exist in specific OperandRegistry
 	var opt *operatorv1alpha1.Operator
 	if registryInstance != nil {
-		opt = registryInstance.GetOperator(operand.Name)
+		var err error
+		opt, err = r.GetOperandFromRegistry(ctx, registryInstance, operand.Name)
+		if err != nil {
+			return err
+		}
 	}
 	if opt == nil {
 		if registryInstance != nil {
@@ -381,7 +385,8 @@ func (r *Reconciler) deleteSubscription(ctx context.Context, cr *operatorv1alpha
 }
 
 func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandName string, requestInstance *operatorv1alpha1.OperandRequest, registryInstance *operatorv1alpha1.OperandRegistry, configInstance *operatorv1alpha1.OperandConfig) error {
-	op := registryInstance.GetOperator(operandName)
+	// No error handling for un-installation step in case Catalog has been deleted
+	op, _ := r.GetOperandFromRegistry(ctx, registryInstance, operandName)
 	if op == nil {
 		klog.Warningf("Operand %s not found", operandName)
 		return nil

--- a/controllers/operatorconfig/operatorconfig_controller.go
+++ b/controllers/operatorconfig/operatorconfig_controller.go
@@ -72,8 +72,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 		for _, u := range reqBlock.Operands {
 			operand := u
-			operator := registry.GetOperator(operand.Name)
-			if operator == nil || operator.OperatorConfig == "" {
+			operator, err := r.GetOperandFromRegistry(ctx, registry, operand.Name)
+			if err != nil {
+				return ctrl.Result{}, err
+			} else if operator == nil || operator.OperatorConfig == "" {
 				continue
 			}
 

--- a/controllers/util/merge.go
+++ b/controllers/util/merge.go
@@ -18,8 +18,8 @@ package util
 
 import (
 	"encoding/json"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/klog"
 )
 
@@ -59,7 +59,7 @@ func MergeCR(defaultCR, changedCR []byte) map[string]interface{} {
 }
 
 func checkKeyBeforeMerging(key string, defaultMap interface{}, changedMap interface{}, finalMap map[string]interface{}) {
-	if !reflect.DeepEqual(defaultMap, changedMap) {
+	if !equality.Semantic.DeepEqual(defaultMap, changedMap) {
 		switch defaultMap := defaultMap.(type) {
 		case map[string]interface{}:
 			//Check that the changed map value doesn't contain this map at all and is nil


### PR DESCRIPTION
**What this PR does / why we need it**:

After comparing the logs in ODLM from CPFS 4.5 and 4.7 release, the main difference happened on `reconciling Operators for OperandRequest`. And the root cause is about [removing hardcode Catalog specified in the OperandRegistry](https://github.com/IBM/ibm-common-service-operator/pull/1802) for the adoption of Catalog separation.

### Context
After hardcode Catalog specified in OperandRegistry is removed, ODLM needs to do discovery for each operator in OperandRegistry, and find their available Catalog for installation. There are almost 50 operators in OperandRegistry, and it takes about 1 mins to find the Catalog for all of them.

### Solution
However, from the operational perspective, ODLM does not have to find the CatalogSource for each operator in OperandRegistry since not all of them are requested in OperandRequest.
We will need to refactor the code, to only find the Catalog for the operators that are requested in OperandRequest. So it will significantly reduce the time on `reconciling Operators for OperandRequest`


**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63499#issuecomment-80082231
