### PR TITLE
Fix operand phase error for Elasticsearch in OperandRequest

### DIFF
--- a/api/v1alpha1/operandrequest_types.go
+++ b/api/v1alpha1/operandrequest_types.go
@@ -429,6 +429,15 @@ func (r *OperandRequest) RemoveServiceStatus(operatorName string, mu sync.Locker
 	}
 }
 
+func (r *OperandRequest) RemoveOperandPhase(name string, mu sync.Locker) {
+	mu.Lock()
+	defer mu.Unlock()
+	pos, m := getMemberStatus(&r.Status, name)
+	if m != nil {
+		r.Status.Members[pos].Phase = MemberPhase{}
+	}
+}
+
 func (r *OperandRequest) SetServiceStatus(ctx context.Context, service ServiceStatus, updater client.StatusClient, mu sync.Locker) error {
 	mu.Lock()
 	defer mu.Unlock()

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -83,6 +83,7 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 				continue
 			}
 
+			// Set no-op operator to Running status
 			if opdRegistry.InstallMode == operatorv1alpha1.InstallModeNoop {
 				requestInstance.SetNoSuitableRegistryCondition(registryKey.String(), opdRegistry.Name+" is in maintenance status", operatorv1alpha1.ResourceTypeOperandRegistry, corev1.ConditionTrue, &r.Mutex)
 				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorRunning, operatorv1alpha1.ServiceRunning, &r.Mutex)
@@ -164,7 +165,7 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 
 			if len(requestList) == 0 || !util.Contains(requestList, requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request") {
 				klog.Infof("Subscription %s in the namespace %s is NOT managed by %s/%s, Skip reconciling Operands", sub.Name, sub.Namespace, requestInstance.Namespace, requestInstance.Name)
-				requestInstance.SetMemberStatus(operand.Name, "", operatorv1alpha1.ServiceFailed, &r.Mutex)
+				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "", &r.Mutex)
 				continue
 			}
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63588#issuecomment-80838597

### Enhancement:

-  If the operator is not managed by ODLM, it will set the `operatorPhase` to `Failed` instead.
- Clean up the phase value of OperandRequest and of each operand member at the beginning of each opreq reconciliation.

### How to test
image: quay.io/yuchen_shen/odlm:operand_phase

- Before applying the fix image:
  - request `ibm-elasticsearch-operator`
  - remove label and annotation in elasticsearch subscription:
    ```
    operator.ibm.com/opreq-control: 'true'
    cs-condition.example-service.ibm-elasticsearch-operator/request: v1.1
    ```
  - obverse operand phase failed in OperandRequest, even there is no operand for elasticsearch 
     ```yaml
     members:
      - name: ibm-elasticsearch-operator
        phase:
          operandPhase: Failed
     phase: Failed
     ```
- Applying the fix image:
  - will see the error changes to operator failed (Assume the removed label and annotation are not added back at this time)
     ```yaml
     members:
      - name: ibm-elasticsearch-operator
        phase:
          operatorPhase: Failed
     phase: Failed
     ```
  - add above label back to the subscription ` operator.ibm.com/opreq-control: 'true'`
  - OperandRequest phase status is back to `Running` with 
     ```yaml
     members:
      - name: ibm-elasticsearch-operator
        phase:
          operatorPhase: Running
     phase: Running
     ```
   