### PR TITLE
Skip catalog discover when operator is not found in OperandRegistry

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -402,6 +402,10 @@ func (m *ODLMOperator) GetOperatorNamespace(installMode, namespace string) strin
 // GetOperandFromRegistry gets the Operand from the OperandRegistry
 func (m *ODLMOperator) GetOperandFromRegistry(ctx context.Context, reg *apiv1alpha1.OperandRegistry, operandName string) (*apiv1alpha1.Operator, error) {
 	opt := reg.GetOperator(operandName)
+	if opt == nil {
+		return nil, nil
+	}
+
 	// Get excluded CatalogSource from annotation
 	// excluded-catalogsource: catalogsource1, catalogsource2
 	var excludedCatalogSources []string


### PR DESCRIPTION
**What this PR does / why we need it**:
When operator is not found in OperandRegistry, `opt` is `nil` and there should be no catalog discovery for this `nil` object.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63690#issuecomment-81218953

### Test
See comment https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63690#issuecomment-81222501