### PR TITLE
Raise an error when no catalog is found for an operator given a channel.

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -229,6 +229,9 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 			if semver.IsValid(sub.Spec.Channel) && semver.IsValid(opt.Channel) && semver.Compare(sub.Spec.Channel, opt.Channel) < 0 {
 				sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = sub.Spec.Channel
 			}
+		} else if opt.SourceNamespace == "" || opt.SourceName == "" {
+			klog.Errorf("Failed to find catalogsource for operator %s with channel %s", opt.Name, opt.Channel)
+			requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "", mu)
 		} else {
 			requestInstance.SetNotFoundOperatorFromRegistryCondition(operand.Name, operatorv1alpha1.ResourceTypeSub, corev1.ConditionFalse, mu)
 


### PR DESCRIPTION
**What this PR does / why we need it**:
In order to install an operator via subscription, following specifications in subscription are necessary
- packageName
- CatalogSource
- CatalogSourceNamespace

If any of above fields are missing for an operator that ODLM is trying to install, ODLM should raise error, and not continue with the installation. Specifically ODLM should not update the operator subscription with incorrect and incomplete information. e.g., no catalog found for a given channel.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63462

In CPFS 4.7, Zen Operator's channel `v6.0` does not exist in CPFS Catalog anymore. User will need to load additional Zen Catalog containing the channel `v6.0` for Zen operator installation or upgrade.

#### Here is the expected upgrade flow
1. Originally ODLM create Zen subscription with following specification in CPFS 4.6.x
    ```yaml
    spec:
      channel: v4.4
      installPlanApproval: Automatic
      name: ibm-zen-operator
      source: opencloud-operators
      sourceNamespace: openshift-marketplace
    ```

2. After updating CPFS catalog and upgrading CPFS to 4.7, the latest OperandRegistry will contain `v6.0` channel for Zen operator.
   - However, the existing Zen operator subscription should keep unchanged until user loads additional Zen catalog. 
   - Meanwhile, ODLM will raise error in OperandRequest with `Failed` status because missing channel `v6.0` for Zen operator.
      ```logs
      I0606 01:18:06.230548       1 operandrequest_controller.go:137] Reconciling OperandRequest: 4-5-install/example-service
      I0606 01:18:06.237976       1 reconcile_operator.go:50] Reconciling Operators for OperandRequest: 4-5-install/example-service
      E0606 01:18:06.264075       1 reconcile_operator.go:233] Failed to find catalogsource for operator ibm-platformui-operator with channel v6.0
      I0606 01:18:06.264367       1 reconcile_operator.go:131] Finished reconciling Operators for OperandRequest: 4-5-install/example-service
      I0606 01:18:06.264381       1 reconcile_operand.go:55] Reconciling Operands for OperandRequest: 4-5-install/example-service
      I0606 01:18:06.295569       1 reconcile_operand.go:168] Subscription ibm-platformui-operator in the namespace 4-5-install is NOT managed by 4-5-install/example-service, Skip reconciling Operands
      I0606 01:18:06.295802       1 reconcile_operand.go:213] Finished reconciling Operands for OperandRequest: 4-5-install/example-service
      ```
      ```yaml
      apiVersion: operator.ibm.com/v1alpha1
      kind: OperandRequest
      metadata:
        name: example-service
      spec:
        requests:
          - operands:
              - name: ibm-platformui-operator
            registry: common-service
      status:
        conditions:
          - lastTransitionTime: '2024-06-06T01:20:26Z'
            lastUpdateTime: '2024-06-06T01:20:26Z'
            message: operator ibm-platformui-operator is ready
            reason: operator is ready
            status: 'False'
            type: Ready
          ...
        members:
          - name: ibm-platformui-operator
            phase:
              operatorPhase: Failed
        phase: Failed
      ```

3. After user loads additional Zen Catalog containing `v6.0` channel, ODLM updates Zen operator subscription, and upgrades Zen operator
    ```yaml
    apiVersion: operators.coreos.com/v1alpha1
    kind: Subscription
    metadata:
      name: ibm-platformui-operator
    spec:
      channel: v6.0
      installPlanApproval: Automatic
      name: ibm-zen-operator
      source: ibm-zen-operator-catalog
      sourceNamespace: openshift-marketplace
    ```