### PR TITLE
Find CSVs by label for an operator, to ensure deleting all the CSVs for a specific subscription

### DIFF
--- a/controllers/operandconfig/operandconfig_controller_test.go
+++ b/controllers/operandconfig/operandconfig_controller_test.go
@@ -121,7 +121,7 @@ var _ = Describe("OperandConfig controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Creating and Setting status of the ClusterServiceVersions")
-			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", operatorNamespaceName, testutil.JaegerExample)
+			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", "jaeger", operatorNamespaceName, testutil.JaegerExample)
 			Expect(k8sClient.Create(ctx, jaegerCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "jaeger-csv.v0.0.1", Namespace: operatorNamespaceName}, jaegerCSV)
@@ -129,7 +129,7 @@ var _ = Describe("OperandConfig controller", func() {
 				return k8sClient.Status().Update(ctx, jaegerCSV)
 			}, timeout, interval).Should(Succeed())
 
-			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", operatorNamespaceName, testutil.MongodbExample)
+			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", "mongodb-atlas-kubernetes", operatorNamespaceName, testutil.MongodbExample)
 			Expect(k8sClient.Create(ctx, mongodbCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "mongodb-atlas-kubernetes-csv.v0.0.1", Namespace: operatorNamespaceName}, mongodbCSV)

--- a/controllers/operandregistry/operandregistry_controller_test.go
+++ b/controllers/operandregistry/operandregistry_controller_test.go
@@ -120,7 +120,7 @@ var _ = Describe("OperandRegistry controller", func() {
 			}, timeout, interval).Should(Succeed())
 
 			By("Creating and Setting status of the ClusterServiceVersions")
-			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", operatorNamespaceName, testutil.JaegerExample)
+			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", "jaeger", operatorNamespaceName, testutil.JaegerExample)
 			Expect(k8sClient.Create(ctx, jaegerCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "jaeger-csv.v0.0.1", Namespace: operatorNamespaceName}, jaegerCSV)
@@ -128,7 +128,7 @@ var _ = Describe("OperandRegistry controller", func() {
 				return k8sClient.Status().Update(ctx, jaegerCSV)
 			}, timeout, interval).Should(Succeed())
 
-			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", operatorNamespaceName, testutil.MongodbExample)
+			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", "mongodb-atlas-kubernetes", operatorNamespaceName, testutil.MongodbExample)
 			Expect(k8sClient.Create(ctx, mongodbCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "mongodb-atlas-kubernetes-csv.v0.0.1", Namespace: operatorNamespaceName}, mongodbCSV)

--- a/controllers/operandrequest/operandrequest_controller_test.go
+++ b/controllers/operandrequest/operandrequest_controller_test.go
@@ -140,7 +140,7 @@ var _ = Describe("OperandRequest controller", func() {
 			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 
 			By("Creating and Setting status of the ClusterServiceVersions")
-			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", operatorNamespaceName, testutil.JaegerExample)
+			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", "jaeger", operatorNamespaceName, testutil.JaegerExample)
 			Expect(k8sClient.Create(ctx, jaegerCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "jaeger-csv.v0.0.1", Namespace: operatorNamespaceName}, jaegerCSV)
@@ -148,7 +148,7 @@ var _ = Describe("OperandRequest controller", func() {
 				return k8sClient.Status().Update(ctx, jaegerCSV)
 			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 
-			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", operatorNamespaceName, testutil.MongodbExample)
+			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", "mongodb-atlas-kubernetes", operatorNamespaceName, testutil.MongodbExample)
 			Expect(k8sClient.Create(ctx, mongodbCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "mongodb-atlas-kubernetes-csv.v0.0.1", Namespace: operatorNamespaceName}, mongodbCSV)
@@ -272,7 +272,7 @@ var _ = Describe("OperandRequest controller", func() {
 			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 
 			By("Creating and Setting status of the ClusterServiceVersions")
-			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", operatorNamespaceName, testutil.JaegerExample)
+			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", "jaeger", operatorNamespaceName, testutil.JaegerExample)
 			Expect(k8sClient.Create(ctx, jaegerCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "jaeger-csv.v0.0.1", Namespace: operatorNamespaceName}, jaegerCSV)
@@ -280,7 +280,7 @@ var _ = Describe("OperandRequest controller", func() {
 				return k8sClient.Status().Update(ctx, jaegerCSV)
 			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 
-			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", operatorNamespaceName, testutil.MongodbExample)
+			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", "mongodb-atlas-kubernetes", operatorNamespaceName, testutil.MongodbExample)
 			Expect(k8sClient.Create(ctx, mongodbCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "mongodb-atlas-kubernetes-csv.v0.0.1", Namespace: operatorNamespaceName}, mongodbCSV)
@@ -433,7 +433,7 @@ var _ = Describe("OperandRequest controller", func() {
 			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 
 			By("Creating and Setting status of the ClusterServiceVersions")
-			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", operatorNamespaceName, testutil.JaegerExample)
+			jaegerCSV := testutil.ClusterServiceVersion("jaeger-csv.v0.0.1", "jaeger", operatorNamespaceName, testutil.JaegerExample)
 			Expect(k8sClient.Create(ctx, jaegerCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "jaeger-csv.v0.0.1", Namespace: operatorNamespaceName}, jaegerCSV)
@@ -441,7 +441,7 @@ var _ = Describe("OperandRequest controller", func() {
 				return k8sClient.Status().Update(ctx, jaegerCSV)
 			}, testutil.Timeout, testutil.Interval).Should(Succeed())
 
-			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", operatorNamespaceName, testutil.MongodbExample)
+			mongodbCSV := testutil.ClusterServiceVersion("mongodb-atlas-kubernetes-csv.v0.0.1", "mongodb-atlas-kubernetes", operatorNamespaceName, testutil.MongodbExample)
 			Expect(k8sClient.Create(ctx, mongodbCSV)).Should(Succeed())
 			Eventually(func() error {
 				k8sClient.Get(ctx, types.NamespacedName{Name: "mongodb-atlas-kubernetes-csv.v0.0.1", Namespace: operatorNamespaceName}, mongodbCSV)

--- a/controllers/testutil/test_util.go
+++ b/controllers/testutil/test_util.go
@@ -495,13 +495,16 @@ func SubscriptionStatus(name, namespace, csvVersion string) olmv1alpha1.Subscrip
 	}
 }
 
-func ClusterServiceVersion(name, namespace, example string) *olmv1alpha1.ClusterServiceVersion {
+func ClusterServiceVersion(name, packageName, namespace, example string) *olmv1alpha1.ClusterServiceVersion {
 	return &olmv1alpha1.ClusterServiceVersion{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
 				"alm-examples": example,
+			},
+			Labels: map[string]string{
+				"operators.coreos.com/" + packageName + "." + namespace: "",
 			},
 		},
 		Spec: olmv1alpha1.ClusterServiceVersionSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Ensure that all CSVs tied to a subscription will be deleted when ODLM is deleting an operator.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63676#issuecomment-81421553

### Test
After deleting the OperandRequest, ODLM will list the corresponding operator's CSV by labels, to ensure finding all the CSVs and delete it.
```logs
I0606 00:44:46.646520       1 operandrequest_controller.go:248] Deleting OperandRequest integration-quickstart-ibm-inte-6c1a-keycloak in the namespace test-upgrade
...
I0606 00:44:46.770573       1 reconcile_operator.go:439] Found 1 ClusterServiceVersions for Subscription test-upgrade/keycloak-operator
...
I0606 00:44:46.806260       1 operandrequest_controller.go:248] Deleting OperandRequest edb-keycloak-request in the namespace test-upgrade
...
I0606 00:44:46.894641       1 reconcile_operator.go:439] Found 1 ClusterServiceVersions for Subscription test-upgrade/edb-keycloak
...
I0606 00:44:46.914245       1 reconcile_operator.go:460] Deleting the ClusterServiceVersion, Namespace: test-upgrade, Name: cloud-native-postgresql.v1.22.3
I0606 00:44:46.954314       1 reconcile_operator.go:482] Subscription test-upgrade/edb-keycloak is deleted
...
I0606 00:45:06.802662       1 reconcile_operator.go:460] Deleting the ClusterServiceVersion, Namespace: test-upgrade, Name: rhbk-operator.v22.0.11-opr.1
I0606 00:45:06.831219       1 reconcile_operator.go:482] Subscription test-upgrade/keycloak-operator is deleted
```