### PR TITLE
Refactor members and services status update

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -93,4 +93,7 @@ const (
 
 	//DefaultCRRetryNumber is the default maximum number of retry for reconciling a custom resource
 	DefaultCRRetryNumber = 3
+
+	//StatusMonitoredServices is the annotation key for monitored services
+	StatusMonitoredServices = "status-monitored-services"
 )

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -326,17 +326,16 @@ func (r *Reconciler) reconcileCRwithConfig(ctx context.Context, service *operato
 					merr.Add(err)
 					continue
 				}
-				statusSpec, err := r.getOperandStatus(crFromALM)
+				statusFromCR, err := r.getOperandStatus(crFromALM)
 				if err != nil {
 					return err
 				}
 				serviceKind := crFromALM.GetKind()
-				if serviceKind != "OperandRequest" && statusSpec.ObjectName != "" {
+				if serviceKind != "OperandRequest" && statusFromCR.ObjectName != "" {
 					var resources []operatorv1alpha1.OperandStatus
-					resources = append(resources, statusSpec)
-					serviceSpec := newServiceStatus(operandName, operatorNamespace, resources)
-					seterr := requestInstance.SetServiceStatus(ctx, serviceSpec, r.Client, mu)
-					if seterr != nil {
+					resources = append(resources, statusFromCR)
+					serviceStatus := newServiceStatus(operandName, operatorNamespace, resources)
+					if seterr := requestInstance.SetServiceStatus(ctx, serviceStatus, r.Client, mu); seterr != nil {
 						return seterr
 					}
 				}
@@ -410,15 +409,15 @@ func (r *Reconciler) reconcileCRwithRequest(ctx context.Context, requestInstance
 			if err := r.updateCustomResource(ctx, crFromRequest, requestKey.Namespace, operand.Kind, operand.Spec.Raw, map[string]interface{}{}, requestInstance); err != nil {
 				return err
 			}
-			statusSpec, err := r.getOperandStatus(crFromRequest)
+			statusFromCR, err := r.getOperandStatus(crFromRequest)
 			if err != nil {
 				return err
 			}
-			if operand.Kind != "OperandRequest" && statusSpec.ObjectName != "" {
+			if operand.Kind != "OperandRequest" && statusFromCR.ObjectName != "" {
 				var resources []operatorv1alpha1.OperandStatus
-				resources = append(resources, statusSpec)
-				serviceSpec := newServiceStatus(operand.Name, operatorNamespace, resources)
-				seterr := requestInstance.SetServiceStatus(ctx, serviceSpec, r.Client, mu)
+				resources = append(resources, statusFromCR)
+				serviceStatus := newServiceStatus(operand.Name, operatorNamespace, resources)
+				seterr := requestInstance.SetServiceStatus(ctx, serviceStatus, r.Client, mu)
 				if seterr != nil {
 					return seterr
 				}
@@ -481,7 +480,6 @@ func newServiceStatus(operatorName string, namespace string, resources []operato
 		}
 	}
 	serviceSpec.Status = status //TODO logic to determine readiness
-	// serviceSpec.LastUpdateTime = time.Now().Format(time.RFC3339)
 	serviceSpec.Resources = resources
 	return serviceSpec
 }
@@ -1357,4 +1355,46 @@ func (r *Reconciler) setOwnerReferences(ctx context.Context, controlledRes *unst
 		}
 	}
 	return nil
+}
+
+func (r *Reconciler) ServiceStatusIsReady(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) (bool, error) {
+	requestedServicesSet := make(map[string]struct{})
+	for _, req := range requestInstance.Spec.Requests {
+		registryKey := requestInstance.GetRegistryKey(req)
+		registryInstance, err := r.GetOperandRegistry(ctx, registryKey)
+		if err != nil {
+			klog.Errorf("Failed to get OperandRegistry %s, %v", registryKey, err)
+			return false, err
+		}
+		if registryInstance.Annotations != nil && registryInstance.Annotations[constant.StatusMonitoredServices] != "" {
+			monitoredServices := strings.Split(registryInstance.Annotations[constant.StatusMonitoredServices], ",")
+			for _, operand := range req.Operands {
+				if util.Contains(monitoredServices, operand.Name) {
+					requestedServicesSet[operand.Name] = struct{}{}
+				}
+			}
+		}
+	}
+
+	if len(requestedServicesSet) != 0 {
+		if len(requestInstance.Status.Services) == 0 {
+			klog.Infof("Waiting for status.services to be instantiated for OperandRequest %s/%s ...", requestInstance.Namespace, requestInstance.Name)
+			return false, nil
+		}
+		if len(requestedServicesSet) != len(requestInstance.Status.Services) {
+			klog.Infof("Waiting for statuf of all requested services to be instantiated for OperandRequest %s/%s ...", requestInstance.Namespace, requestInstance.Name)
+			return false, nil
+		}
+
+		// wait for the status of the requested services to be ready
+		for _, s := range requestInstance.Status.Services {
+			if _, ok := requestedServicesSet[s.OperatorName]; ok {
+				if s.Status != "Ready" {
+					klog.Infof("Waiting for status of service %s to be Ready for OperandRequest %s/%s ...", s.OperatorName, requestInstance.Namespace, requestInstance.Name)
+					return false, nil
+				}
+			}
+		}
+	}
+	return true, nil
 }

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1382,7 +1382,7 @@ func (r *Reconciler) ServiceStatusIsReady(ctx context.Context, requestInstance *
 			return false, nil
 		}
 		if len(requestedServicesSet) != len(requestInstance.Status.Services) {
-			klog.Infof("Waiting for statuf of all requested services to be instantiated for OperandRequest %s/%s ...", requestInstance.Namespace, requestInstance.Name)
+			klog.Infof("Waiting for status of all requested services to be instantiated for OperandRequest %s/%s ...", requestInstance.Namespace, requestInstance.Name)
 			return false, nil
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

- Remove hardcoded `services` name, and use annotation in OperandRegistry for service status check. See details in PR https://github.com/IBM/ibm-common-service-operator/pull/2032
- Remove `ibm-iam-operator` from the service status check list given `ibm-iam-operator` represents CPFS v3 whose service status is not applicable.
- Move `members` status reset into `InitRequestStatus` status, and avoid unnecessary status update call to APIServer

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63673#issuecomment-81231213
Mainly the idea is to remove `ibm-iam-operator` from the service status check list, so ODLM will not be stuck at reconciling the same OperandRequest with `ibm-iam-operator` all the time.

### Test
After patching the cluster with following setting, the OperandRequest is reconciled successfully, and returns `Ready` service status.
- Using the dev image ODLM `quay.io/opencloudio/odlm:72615106`
- OperandRegistry with annotation `status-monitored-services: 'ibm-idp-config-ui-operator,ibm-mongodb-operator,ibm-im-operator'`

```yaml
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  resourceVersion: '392447827'
  name: multi-requests
  uid: ca222165-15b0-4256-8c8b-d44ec716a865
  creationTimestamp: '2024-06-07T18:42:01Z'
  generation: 1
  namespace: test-upgrade
  finalizers:
    - finalizer.request.ibm.com
  labels:
    app.kubernetes.io/instance: operand-deployment-lifecycle-manager
    app.kubernetes.io/managed-by: operand-deployment-lifecycle-manager
    app.kubernetes.io/name: operand-deployment-lifecycle-manager
    test-upgrade.common-service/config: 'true'
    test-upgrade.common-service/registry: 'true'
spec:
  requests:
    - operands:
        - name: ibm-im-operator
        - name: ibm-idp-config-ui-operator
      registry: common-service
status:
  conditions:
    - lastTransitionTime: '2024-06-07T18:42:01Z'
      lastUpdateTime: '2024-06-07T18:42:01Z'
      message: Not found subscription ibm-im-operator in the cluster
      reason: Not found subscription
      status: 'False'
      type: NotFound
    - lastTransitionTime: '2024-06-07T18:42:01Z'
      lastUpdateTime: '2024-06-07T18:42:01Z'
      message: Updating subscription ibm-im-operator
      reason: Updating subscription
      status: 'True'
      type: Updating
    - lastTransitionTime: '2024-06-07T18:42:01Z'
      lastUpdateTime: '2024-06-07T18:42:01Z'
      message: Not found subscription ibm-idp-config-ui-operator in the cluster
      reason: Not found subscription
      status: 'False'
      type: NotFound
    - lastTransitionTime: '2024-06-07T18:42:01Z'
      lastUpdateTime: '2024-06-07T18:42:01Z'
      message: Updating subscription ibm-idp-config-ui-operator
      reason: Updating subscription
      status: 'True'
      type: Updating
    - lastTransitionTime: '2024-06-07T18:42:02Z'
      lastUpdateTime: '2024-06-07T18:42:02Z'
      message: operator ibm-im-operator is ready
      reason: operator is ready
      status: 'True'
      type: Ready
    - lastTransitionTime: '2024-06-07T18:42:01Z'
      lastUpdateTime: '2024-06-07T18:42:01Z'
      message: No channel conflict on subscription ibm-im-operator in the scope
      reason: No channel conflict on subscription
      status: 'True'
      type: NoConflict
    - lastTransitionTime: '2024-06-07T18:42:02Z'
      lastUpdateTime: '2024-06-07T18:42:02Z'
      message: operator ibm-idp-config-ui-operator is ready
      reason: operator is ready
      status: 'True'
      type: Ready
    - lastTransitionTime: '2024-06-07T18:42:01Z'
      lastUpdateTime: '2024-06-07T18:42:01Z'
      message: No channel conflict on subscription ibm-idp-config-ui-operator in the scope
      reason: No channel conflict on subscription
      status: 'True'
      type: NoConflict
    - lastTransitionTime: '2024-06-07T18:42:02Z'
      lastUpdateTime: '2024-06-07T18:42:02Z'
      message: operands from ibm-im-operator are created
      reason: operands are created
      status: 'True'
      type: Ready
    - lastTransitionTime: '2024-06-07T18:42:02Z'
      lastUpdateTime: '2024-06-07T18:42:02Z'
      message: operands from ibm-idp-config-ui-operator are created
      reason: operands are created
      status: 'True'
      type: Ready
  members:
    - name: ibm-im-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
    - name: ibm-idp-config-ui-operator
      phase:
        operandPhase: Running
        operatorPhase: Running
  phase: Running
  services:
    - namespace: test-upgrade
      operatorName: ibm-im-operator
      resources:
        - apiVersion: operator.ibm.com/v1alpha1
          kind: Authentication
          managedResources:
            - apiVersion: v1
              kind: Service
              namespace: test-upgrade
              objectName: platform-auth-service
              status: Ready
            - apiVersion: v1
              kind: Service
              namespace: test-upgrade
              objectName: platform-identity-management
              status: Ready
            - apiVersion: v1
              kind: Service
              namespace: test-upgrade
              objectName: platform-identity-provider
              status: Ready
            - apiVersion: apps/v1
              kind: Deployment
              namespace: test-upgrade
              objectName: platform-auth-service
              status: Ready
            - apiVersion: apps/v1
              kind: Deployment
              namespace: test-upgrade
              objectName: platform-identity-management
              status: Ready
            - apiVersion: apps/v1
              kind: Deployment
              namespace: test-upgrade
              objectName: platform-identity-provider
              status: Ready
            - apiVersion: batch/v1
              kind: Job
              namespace: test-upgrade
              objectName: oidc-client-registration
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: id-mgmt
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: platform-auth
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: platform-id-auth
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: platform-id-provider
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: platform-login
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: platform-oidc
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: saml-ui-callback
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: social-login-callback
              status: Ready
          namespace: test-upgrade
          objectName: example-authentication
          status: Ready
      status: Ready
    - namespace: test-upgrade
      operatorName: ibm-idp-config-ui-operator
      resources:
        - apiVersion: operators.ibm.com/v1alpha1
          kind: CommonWebUI
          managedResources:
            - apiVersion: v1
              kind: Service
              namespace: test-upgrade
              objectName: common-web-ui
              status: Ready
            - apiVersion: apps/v1
              kind: Deployment
              namespace: test-upgrade
              objectName: common-web-ui
              status: Ready
            - apiVersion: route.openshift.io/v1
              kind: Route
              namespace: test-upgrade
              objectName: cp-console
              status: Ready
          namespace: test-upgrade
          objectName: example-commonwebui
          status: Ready
      status: Ready
