### PR TITLE
Clean redundant CSV in service ns during the migration

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -154,6 +154,12 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 				continue
 			}
 
+			if err := r.DeleteRedundantCSV(ctx, csv.Name, csv.Namespace, registryKey.Namespace, opdRegistry.PackageName); err != nil {
+				merr.Add(errors.Wrapf(err, "failed to delete the redundant ClusterServiceVersion %s in the namespace %s", csv.Name, csv.Namespace))
+				requestInstance.SetMemberStatus(operand.Name, operatorv1alpha1.OperatorFailed, "", &r.Mutex)
+				continue
+			}
+
 			// find the OperandRequest which has the same operator's channel version as existing subscription.
 			// ODLM will only reconcile Operand based on OperandConfig for this OperandRequest
 			var requestList []string


### PR DESCRIPTION
**What this PR does / why we need it**:
In each reconciliation loop, ODLM will clean the CSV in service namespace when the CSV is redundant.

Usually a redundant CSV is created by OLM when ODLM is moving the operator subscription(ibm-events-operator) from service namespace(ibm-common-services) to operator namespace(openshift-operators), and OLM will still create redundant CSV for the old subscription in the service namespace even though the old subscription has been removed(it is due to OLM cache that is not been refreshed). Subsequently, redundant CSV is causing API overlap with new CSV in operator namespace. Please see details in [here](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63676#issuecomment-81421553).

ODLM will identify one CSV as redundant when CSV does not have labels `olm.copiedFrom` and not have `operators.coreos.com/<packagemanifest>.<namespace>`. Please see [this](https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63676#issuecomment-86834231) for details

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63676#issuecomment-86834231


### Test
After applying the new dev image containing the fix on the cluster, it successfully recovers the cluster from bad state by deleting the redundant CSV in the service namespace `ibm-common-services`
```
I0731 22:40:13.865486 1 manager.go:454] Delete the redundant ClusterServiceVersion ibm-events-operator.v5.0.1 in the namespace ibm-common-services
```
And the new CSV in `openshift-operators` is in `Succeeded` status, together with a good copied CSV in `ibm-common-services`
``` console
➜  oc get csv -n openshift-operators | grep events
ibm-events-operator.v5.0.1                    IBM Events Operator                    5.0.1                                            Succeeded

➜ oc get csv -n ibm-common-services | grep events
ibm-events-operator.v5.0.1                    IBM Events Operator                    5.0.1                                                  Succeeded

➜ oc get csv ibm-events-operator.v5.0.1 -n ibm-common-services -ojsonpath='{.metadata.labels}' | jq
{
  "olm.copiedFrom": "openshift-operators",
  "operatorframework.io/arch.amd64": "supported",
  "operatorframework.io/arch.ppc64le": "supported",
  "operatorframework.io/arch.s390x": "supported",
  "operatorframework.io/os.linux": "supported"
}
```