### PR TITLE
Find semantic versioning from channel

### DIFF
--- a/controllers/util/util_test.go
+++ b/controllers/util/util_test.go
@@ -111,3 +111,102 @@ var _ = Describe("Differs", func() {
 		Expect(Differs(list, s)).Should(BeFalse())
 	})
 })
+
+var _ = Describe("FindSemantic", func() {
+	It("Should return the semantic vX version substring", func() {
+		input := "stable-v1"
+		expected := "v1"
+		Expect(FindSemantic(input)).Should(Equal(expected))
+	})
+
+	It("Should return the semantic vX.Y version substring", func() {
+		input := "fast-v1.2"
+		expected := "v1.2"
+		Expect(FindSemantic(input)).Should(Equal(expected))
+	})
+
+	It("Should return the original semantic vX.Y version substring", func() {
+		input := "v1.2"
+		expected := "v1.2"
+		Expect(FindSemantic(input)).Should(Equal(expected))
+	})
+
+	It("Should return the semantic vX.Y.Z version substring", func() {
+		input := "stable-v1.2.3"
+		expected := "v1.2.3"
+		Expect(FindSemantic(input)).Should(Equal(expected))
+	})
+
+	It("Should return an empty string if no semantic version is found", func() {
+		input := "This is a test string without a semantic version"
+		expected := "v0.0.0"
+		Expect(FindSemantic(input)).Should(Equal(expected))
+	})
+
+	It("Should return the first semantic version substring", func() {
+		input := "This is a test v1.2.3 string with v0.1.0 multiple semantic versions"
+		expected := "v1.2.3"
+		Expect(FindSemantic(input)).Should(Equal(expected))
+	})
+})
+
+var _ = Describe("FindMinSemver", func() {
+	It("Should return the minimal semantic version from annotations", func() {
+		annotations := map[string]string{
+			"namespace-a.common-service.operator-a/request": "stable",
+			"namespace-b.common-service.operator-b/request": "stable-v1.0",
+			"namespace-c.common-service.operator-c/request": "stable-v1.1.0",
+			"namespace-d.common-service.operator-d/request": "stable-v1.2.0",
+		}
+		curChannel := "stable-v1.3.0"
+		expected := "stable"
+		Expect(FindMinSemver(annotations, curChannel)).Should(Equal(expected))
+	})
+
+	It("Should return the minimal semantic version from annotations", func() {
+		annotations := map[string]string{
+			"namespace-b.common-service.operator-b/request": "v4.0",
+			"namespace-c.common-service.operator-c/request": "v4.1",
+			"namespace-d.common-service.operator-d/request": "v4.2",
+		}
+		curChannel := "v3"
+		expected := "v4.0"
+		Expect(FindMinSemver(annotations, curChannel)).Should(Equal(expected))
+	})
+
+	It("Should return the current channel if it exists in annotations", func() {
+		annotations := map[string]string{
+			"namespace-a.common-service.operator-a/request": "stable",
+			"namespace-b.common-service.operator-b/request": "stable-v1.0",
+			"namespace-c.common-service.operator-c/request": "stable-v1.1.0",
+			"namespace-d.common-service.operator-d/request": "stable-v1.2",
+		}
+		curChannel := "stable-v1.1.0"
+		expected := "stable-v1.1.0"
+		Expect(FindMinSemver(annotations, curChannel)).Should(Equal(expected))
+	})
+
+	It("Should return the current channel if it exists in annotations", func() {
+		annotations := map[string]string{
+			"namespace-a.common-service.operator-a/request": "stable",
+			"namespace-b.common-service.operator-b/request": "v1.0",
+			"namespace-c.common-service.operator-c/request": "v2.0",
+			"namespace-d.common-service.operator-d/request": "v2.0",
+		}
+		curChannel := "stable"
+		expected := "stable"
+		Expect(FindMinSemver(annotations, curChannel)).Should(Equal(expected))
+	})
+
+	It("Should return an empty string if no valid semantic versions are found", func() {
+		annotations := map[string]string{
+			"namespace-a.common-service.operator-a/config": "stable",
+			"namespace-b.common-service.operator-b/config": "stable-v1.0",
+			"namespace-c.common-service.operator-c/config": "stable-v1.1.0",
+			"namespace-d.common-service.operator-d/config": "stable-v1.2",
+		}
+		curChannel := "stable-v2.0.0"
+		expected := ""
+		Expect(FindMinSemver(annotations, curChannel)).Should(Equal(expected))
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:
It is to enable the channel semantic version detection for EDB operator whose channel is `stable` or `stable-vX.Y`
- `stable` channel will be interpreted as version `v0.0.0`
- `stable-v1` channel will be interpreted as version `v1.0.0`
- `stable-v1.2` channel will be interpreted as version `v1.2.0`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/63488

