### PR TITLE
Revert the host back to default value

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1066,11 +1066,10 @@ func (r *Reconciler) updateK8sResource(ctx context.Context, existingK8sRes unstr
 
 		if k8sResConfig != nil {
 			k8sResConfigDecoded := make(map[string]interface{})
-			k8sResConfigUnmarshalErr := json.Unmarshal(k8sResConfig.Raw, &k8sResConfigDecoded)
-			if k8sResConfigUnmarshalErr != nil {
-				klog.Errorf("failed to unmarshal k8s Resource Config: %v", k8sResConfigUnmarshalErr)
+			if k8sResConfigUnmarshalErr := json.Unmarshal(k8sResConfig.Raw, &k8sResConfigDecoded); k8sResConfigUnmarshalErr != nil {
+				return errors.Wrap(k8sResConfigUnmarshalErr, "failed to unmarshal k8s Resource Config")
 			}
-	
+
 			if host, found := k8sResConfigDecoded["spec"].(map[string]interface{})["host"].(string); found {
 				hostHash := util.CalculateHash(host)
 

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"regexp"
@@ -150,6 +152,14 @@ func StringSliceContentEqual(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func CalculateHash(input string) string {
+	if input == "" {
+		return ""
+	}
+	hashedData := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(hashedData[:7])
 }
 
 // WaitTimeout waits for the waitgroup for the specified max timeout.


### PR DESCRIPTION
**Which issue(s) this PR fixes** 
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64018

**What this PR does / why we need it**:
This PR addresses the need to handle custom `spec.host` values for OpenShift Route resources when creating it. Specifically, if the resource is Route, the `spec.host value` is now dynamically read from the provided OperandConfig template. A hash of the `spec.host` value is then calculated and added to the resource's annotations. If the custom host is empty from Opcon, then the host value from the Route will be reverted back to default


