### PR TITLE
Use PackageName name as the name of subscription

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -100,6 +100,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 		if reflect.DeepEqual(existingInstance.Status, requestInstance.Status) {
 			return
 		}
+
+		// Update requestInstance's resource version to avoid conflicts
+		requestInstance.ResourceVersion = existingInstance.ResourceVersion
 		if err := r.Client.Status().Patch(ctx, requestInstance, client.MergeFrom(existingInstance)); err != nil && !apierrors.IsNotFound(err) {
 			reconcileErr = utilerrors.NewAggregate([]error{reconcileErr, fmt.Errorf("error while patching OperandRequest.Status: %v", err)})
 		}

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -667,7 +667,7 @@ func (r *Reconciler) generateClusterObjects(o *operatorv1alpha1.Operator, regist
 	// Subscription Object
 	sub := &olmv1alpha1.Subscription{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        o.Name,
+			Name:        o.PackageName,
 			Namespace:   namespace,
 			Labels:      labels,
 			Annotations: annotations,
@@ -683,7 +683,7 @@ func (r *Reconciler) generateClusterObjects(o *operatorv1alpha1.Operator, regist
 		},
 	}
 	sub.SetGroupVersionKind(schema.GroupVersionKind{Group: olmv1alpha1.SchemeGroupVersion.Group, Kind: "Subscription", Version: olmv1alpha1.SchemeGroupVersion.Version})
-	klog.V(3).Info("Generating Subscription:  ", o.Name, " in the Namespace: ", namespace)
+	klog.V(3).Info("Generating Subscription:  ", o.PackageName, " in the Namespace: ", namespace)
 	co.subscription = sub
 	return co
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
This fix will ensure that no duplicate subscriptions are created based on the same operator package name and different channels. Instead, if there are two OperandRequests with the same operator but different channels, ODLM will create only one subscription with the package name, as only one operator/subscription with a single channel is allowed to be installed in one tenant.

**Which issue(s) this PR fixes** 
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64818

**Before/After fix in**
Request two same operator with diff channel
```
apiVersion: operator.ibm.com/v1alpha1
kind: OperandRequest
metadata:
  name: example-service
spec:
  requests:
    - operands:
        - name: cloud-native-postgresql-v1.22
        - name: cloud-native-postgresql
      registry: common-service
```

Before fix will see fail to create two subs:
<img width="1568" alt="Screenshot 2024-09-25 at 21 50 59" src="https://github.com/user-attachments/assets/242ee801-81a2-45c4-b9a4-ed255e5169f9">

After fix, successfully created one sub:
<img width="1491" alt="Screenshot 2024-09-25 at 22 25 16" src="https://github.com/user-attachments/assets/7af1f98e-ae83-48c5-845c-88d7252e2510">


