### PR TITLE
introduce api for optional fields in resource object

### DIFF
--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -79,6 +79,61 @@ type ConfigResource struct {
 	// OwnerReferences is the list of owner references.
 	// +optional
 	OwnerReferences []OwnerReference `json:"ownerReferences,omitempty"`
+	// OptionalFields is the list of fields that could be updated additionally.
+	// +optional
+	OptionalFields []OptionalField `json:"optionalFields,omitempty"`
+}
+
+// +kubebuilder:pruning:PreserveUnknownFields
+// OptionalField defines the optional field for the resource.
+type OptionalField struct {
+	// Path is the json path of the field.
+	Path string `json:"path"`
+	// Operation is the operation of the field.
+	Operation Operation `json:"operation"`
+	// MatchExpressions is the match expression of the field.
+	// +optional
+	MatchExpressions []MatchExpression `json:"matchExpressions,omitempty"`
+	// ValueFrom is the field value from the object
+	// +optional
+	ValueFrom *ValueFrom `json:"valueFrom,omitempty"`
+}
+
+// +kubebuilder:pruning:PreserveUnknownFields
+// MatchExpression defines the match expression of the field.
+type MatchExpression struct {
+	// Key is the key of the field.
+	Key string `json:"key"`
+	// Operator is the operator of the field.
+	Operator ExpressionOperator `json:"operator"`
+	// Values is the values of the field.
+	// +optional
+	Values []string `json:"values"`
+	// ObjectRef is the reference of the object.
+	// +optional
+	ObjectRef *ObjectRef `json:"objectRef,omitempty"`
+}
+
+// ObjectRef defines the reference of the object.
+type ObjectRef struct {
+	// APIVersion is the version of the object.
+	APIVersion string `json:"apiVersion"`
+	// Kind is the kind of the object.
+	Kind string `json:"kind"`
+	// Name is the name of the object.
+	Name string `json:"name"`
+	// Namespace is the namespace of the object.
+	// +optional
+	Namespace string `json:"namespace"`
+}
+
+// ValueFrom defines the field value from the object.
+type ValueFrom struct {
+	// Path is the json path of the field.
+	Path string `json:"path"`
+	// ObjectRef is the reference of the object.
+	// +optional
+	ObjectRef *ObjectRef `json:"objectRef,omitempty"`
 }
 
 type OwnerReference struct {
@@ -159,6 +214,26 @@ const (
 	ServiceCreating ServicePhase = "Creating"
 	ServiceNotFound ServicePhase = "Not Found"
 	ServiceNone     ServicePhase = ""
+)
+
+// Operation defines the operation of the field.
+type Operation string
+
+// Operation type.
+const (
+	OperationAdd    Operation = "add"
+	OperationRemove Operation = "remove"
+)
+
+// Operator defines the operator type.
+type ExpressionOperator string
+
+// Operator type.
+const (
+	OperatorIn           ExpressionOperator = "In"
+	OperatorNotIn        ExpressionOperator = "NotIn"
+	OperatorExists       ExpressionOperator = "Exists"
+	OperatorDoesNotExist ExpressionOperator = "DoesNotExist"
 )
 
 // GetService obtains the service definition with the operand name.

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,7 +129,7 @@ metadata:
     categories: Developer Tools, Monitoring, Logging & Tracing, Security
     certified: "false"
     containerImage: icr.io/cpopen/odlm:latest
-    createdAt: "2024-08-27T18:18:40Z"
+    createdAt: "2024-09-28T19:55:35Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
     olm.skipRange: '>=1.2.0 <4.3.6'
@@ -568,6 +568,12 @@ spec:
     spec:
       clusterPermissions:
         - rules:
+            - apiGroups:
+                - apiextensions.k8s.io
+              resources:
+                - customresourcedefinitions
+              verbs:
+                - get
             - apiGroups:
                 - operator.ibm.com
               resources:

--- a/bundle/manifests/operator.ibm.com_operandconfigs.yaml
+++ b/bundle/manifests/operator.ibm.com_operandconfigs.yaml
@@ -109,6 +109,106 @@ spec:
                           namespace:
                             description: Namespace is the namespace of the resource.
                             type: string
+                          optionalFields:
+                            description: OptionalFields is the list of fields that
+                              could be updated additionally.
+                            items:
+                              description: OptionalField defines the optional field
+                                for the resource.
+                              properties:
+                                matchExpressions:
+                                  description: MatchExpressions is the match expression
+                                    of the field.
+                                  items:
+                                    description: MatchExpression defines the match
+                                      expression of the field.
+                                    properties:
+                                      key:
+                                        description: Key is the key of the field.
+                                        type: string
+                                      objectRef:
+                                        description: ObjectRef is the reference of
+                                          the object.
+                                        properties:
+                                          apiVersion:
+                                            description: APIVersion is the version
+                                              of the object.
+                                            type: string
+                                          kind:
+                                            description: Kind is the kind of the object.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the object.
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace
+                                              of the object.
+                                            type: string
+                                        required:
+                                        - apiVersion
+                                        - kind
+                                        - name
+                                        type: object
+                                      operator:
+                                        description: Operator is the operator of the
+                                          field.
+                                        type: string
+                                      values:
+                                        description: Values is the values of the field.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  type: array
+                                operation:
+                                  description: Operation is the operation of the field.
+                                  type: string
+                                path:
+                                  description: Path is the json path of the field.
+                                  type: string
+                                valueFrom:
+                                  description: ValueFrom is the field value from the
+                                    object
+                                  properties:
+                                    objectRef:
+                                      description: ObjectRef is the reference of the
+                                        object.
+                                      properties:
+                                        apiVersion:
+                                          description: APIVersion is the version of
+                                            the object.
+                                          type: string
+                                        kind:
+                                          description: Kind is the kind of the object.
+                                          type: string
+                                        name:
+                                          description: Name is the name of the object.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of the object.
+                                          type: string
+                                      required:
+                                      - apiVersion
+                                      - kind
+                                      - name
+                                      type: object
+                                    path:
+                                      description: Path is the json path of the field.
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              required:
+                              - operation
+                              - path
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
                           ownerReferences:
                             description: OwnerReferences is the list of owner references.
                             items:

--- a/config/crd/bases/operator.ibm.com_operandconfigs.yaml
+++ b/config/crd/bases/operator.ibm.com_operandconfigs.yaml
@@ -105,6 +105,106 @@ spec:
                           namespace:
                             description: Namespace is the namespace of the resource.
                             type: string
+                          optionalFields:
+                            description: OptionalFields is the list of fields that
+                              could be updated additionally.
+                            items:
+                              description: OptionalField defines the optional field
+                                for the resource.
+                              properties:
+                                matchExpressions:
+                                  description: MatchExpressions is the match expression
+                                    of the field.
+                                  items:
+                                    description: MatchExpression defines the match
+                                      expression of the field.
+                                    properties:
+                                      key:
+                                        description: Key is the key of the field.
+                                        type: string
+                                      objectRef:
+                                        description: ObjectRef is the reference of
+                                          the object.
+                                        properties:
+                                          apiVersion:
+                                            description: APIVersion is the version
+                                              of the object.
+                                            type: string
+                                          kind:
+                                            description: Kind is the kind of the object.
+                                            type: string
+                                          name:
+                                            description: Name is the name of the object.
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace
+                                              of the object.
+                                            type: string
+                                        required:
+                                        - apiVersion
+                                        - kind
+                                        - name
+                                        type: object
+                                      operator:
+                                        description: Operator is the operator of the
+                                          field.
+                                        type: string
+                                      values:
+                                        description: Values is the values of the field.
+                                        items:
+                                          type: string
+                                        type: array
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                    x-kubernetes-preserve-unknown-fields: true
+                                  type: array
+                                operation:
+                                  description: Operation is the operation of the field.
+                                  type: string
+                                path:
+                                  description: Path is the json path of the field.
+                                  type: string
+                                valueFrom:
+                                  description: ValueFrom is the field value from the
+                                    object
+                                  properties:
+                                    objectRef:
+                                      description: ObjectRef is the reference of the
+                                        object.
+                                      properties:
+                                        apiVersion:
+                                          description: APIVersion is the version of
+                                            the object.
+                                          type: string
+                                        kind:
+                                          description: Kind is the kind of the object.
+                                          type: string
+                                        name:
+                                          description: Name is the name of the object.
+                                          type: string
+                                        namespace:
+                                          description: Namespace is the namespace
+                                            of the object.
+                                          type: string
+                                      required:
+                                      - apiVersion
+                                      - kind
+                                      - name
+                                      type: object
+                                    path:
+                                      description: Path is the json path of the field.
+                                      type: string
+                                  required:
+                                  - path
+                                  type: object
+                              required:
+                              - operation
+                              - path
+                              type: object
+                              x-kubernetes-preserve-unknown-fields: true
+                            type: array
                           ownerReferences:
                             description: OwnerReferences is the list of owner references.
                             items:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -5,6 +5,12 @@ metadata:
   name: operand-deployment-lifecycle-manager
 rules:
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
   - operator.ibm.com
   resources:
   - auditloggings

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -63,6 +63,7 @@ type clusterObjects struct {
 
 //+kubebuilder:rbac:groups=operator.ibm.com,resources=certmanagers;auditloggings,verbs=get;delete
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=get
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get
 
 //+kubebuilder:rbac:groups=*,namespace="placeholder",resources=*,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=operator.ibm.com,namespace="placeholder",resources=operandrequests;operandrequests/status;operandrequests/finalizers,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/util/util_test.go
+++ b/controllers/util/util_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 var _ = Describe("Get environmental variables", func() {
@@ -256,5 +257,252 @@ var _ = Describe("FindMaxSemver", func() {
 		}
 		expected := ""
 		Expect(FindMaxSemver(curChannel, semverList, semVerChannelMappings)).Should(Equal(expected))
+	})
+})
+
+var _ = Describe("RemoveObjectField", func() {
+	It("Should remove the specified field from the object", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		RemoveObjectField(obj.Object, ".metadata.namespace")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+
+	It("Should remove nested fields from the object", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+					"labels": map[string]interface{}{
+						"app": "myapp",
+					},
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		RemoveObjectField(obj.Object, ".metadata.labels.app")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+					"labels":    map[string]interface{}{},
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+
+	It("Should do nothing if the field does not exist", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		RemoveObjectField(obj.Object, ".metadata.labels.app")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+
+	It("Should remove field and all its nested fields from the object", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+					"labels": map[string]interface{}{
+						"app": "myapp",
+					},
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		RemoveObjectField(obj.Object, ".metadata")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+})
+
+var _ = Describe("AddObjectField", func() {
+	It("Should add a new field to the object", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		AddObjectField(obj.Object, ".metadata.namespace", "default")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name":      "test",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+
+	It("Should add a nested field to the object", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		AddObjectField(obj.Object, ".metadata.labels.app", "myapp")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+					"labels": map[string]interface{}{
+						"app": "myapp",
+					},
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+
+	It("Should overwrite an existing field in the object", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 3,
+				},
+			},
+		}
+
+		AddObjectField(obj.Object, ".spec.replicas", 5)
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"replicas": 5,
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
+	})
+
+	It("Should create nested maps if they do not exist", func() {
+		obj := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+			},
+		}
+
+		AddObjectField(obj.Object, ".spec.template.spec.containers[0].name", "nginx")
+
+		expected := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"metadata": map[string]interface{}{
+					"name": "test",
+				},
+				"spec": map[string]interface{}{
+					"template": map[string]interface{}{
+						"spec": map[string]interface{}{
+							"containers": []interface{}{
+								map[string]interface{}{
+									"name": "nginx",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(obj).Should(Equal(expected))
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
Please design details in https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64888#issuecomment-92166012

**Which issue(s) this PR fixes** 
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64888

### Test procedure

#### Preparation
1. Install latest latest 4.6.x dev driver.
2. Patch ODLM CSV
    - Latest image `quay.io/daniel_fan/odlm:88e3fddf-dirty`
    - Change imagepullpolicy to `Always`
3. Add cluster permission in the cluster role `operand-deployment-lifecycle-manager`
    ```yaml
    - apiGroups:
        - apiextensions.k8s.io
      resources:
        - customresourcedefinitions
      verbs:
        - get
    ```

    <img width="1070" alt="Screenshot 2024-09-29 at 2 09 17 AM" src="https://github.com/user-attachments/assets/2855682f-1ca2-4269-b5bd-6fbd7ee44452">

4.  Update OperandRegistry `common-service`, change `channel: stable-v22` for Keycloak 22 installation
    ```yaml
        - channel: stable-v24   ---------> stable-v22
          fallbackChannels:
            - stable-v22
          installPlanApproval: Automatic
          name: keycloak-operator
          namespace: sc2-dev
          packageName: rhbk-operator
          scope: public
    ```
5. Update OperandConfig `common-service`, to add resource configuration and optional fields
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandConfig
    metadata:
      name: common-service
    spec:
      services:
        ...
        - name: keycloak-operator
          resources:
            - apiVersion: k8s.keycloak.org/v2alpha1
              data:
                spec:
                  resources:        <------------------ new added from here
                    limits:
                      cpu: 1000m
                      ephemeral-storage: 512Mi
                      memory: 1Gi
                    requests:
                      cpu: 1000m
                      ephemeral-storage: 256Mi
                      memory: 1Gi                <------------ end here
                  db:
                    host: keycloak-edb-cluster-rw
                    passwordSecret:
                      key: password
                      name: keycloak-edb-cluster-app
                    usernameSecret:
                      key: username
                      name: keycloak-edb-cluster-app
                    vendor: postgres
                  ...
              force: true
              kind: Keycloak
              name: cs-keycloak
              optionalFields:      <------------------ new added from here
                - matchExpressions:
                    - key: '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.resources'
                      objectRef:
                        apiVersion: apiextensions.k8s.io/v1
                        kind: CustomResourceDefinition
                        name: keycloaks.k8s.keycloak.org
                      operator: Exists
                  operation: remove
                  path: '.spec.unsupported.podTemplate.spec.containers[0].resources'
                - matchExpressions:
                    - key: '.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.resources'
                      objectRef:
                        apiVersion: apiextensions.k8s.io/v1
                        kind: CustomResourceDefinition
                        name: keycloaks.k8s.keycloak.org
                      operator: DoesNotExist
                  operation: remove
                  path: .spec.resources     <------------------ end here
    ```

#### Install Keycloak 22
1. Install Keycloak operator by creating OperandRequest with operand name `keycloak-operator`
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: keycloak-operator
          registry: common-service
    ```
2. ODLM should only install Keycloak 22 operator
3. ODLM should create Keycloak CR without `.spec.resources`, but contains resources configuration in `podTemplate`
    - <Details> <Summary>Example of Keycloak CR</Summary>

        ```yaml
        apiVersion: k8s.keycloak.org/v2alpha1
        kind: Keycloak
        metadata:
          name: cs-keycloak
        spec:
          db:
            host: keycloak-edb-cluster-rw
            passwordSecret:
              key: password
              name: keycloak-edb-cluster-app
            usernameSecret:
              key: username
              name: keycloak-edb-cluster-app
            vendor: postgres
          features:
            enabled:
              - token-exchange
          hostname:
            hostname: keycloak-sc2-dev.apps.installer-cp3pt0.cp.fyre.ibm.com
          http:
            tlsSecret: cs-keycloak-tls-secret
          ingress:
            enabled: false
          instances: 1
          unsupported:
            podTemplate:
              metadata:
                annotations:
                  cloudpakThemesVersion: styles467.css
              spec:
                affinity:
                  nodeAffinity:
                    requiredDuringSchedulingIgnoredDuringExecution:
                      nodeSelectorTerms:
                        - matchExpressions:
                            - key: kubernetes.io/arch
                              operator: In
                              values:
                                - amd64
                                - ppc64le
                                - s390x
                containers:
                  - command:
                      - /bin/sh
                      - /mnt/startup/cs-keycloak-entrypoint.sh
                    resources:
                      limits:
                        cpu: 1000m
                        ephemeral-storage: 512Mi
                        memory: 1Gi
                      requests:
                        cpu: 1000m
                        ephemeral-storage: 256Mi
                        memory: 1Gi
        ```
        </Details>

#### Upgrade to Keycloak 24
1.  Update OperandRegistry `common-service`, change `channel: stable-v24` for Keycloak 24 installation
    ```yaml
        - channel: stable-v22   ---------> stable-v24
          fallbackChannels:
            - stable-v22
          installPlanApproval: Automatic
          name: keycloak-operator
          namespace: sc2-dev
          packageName: rhbk-operator
          scope: public
    ```
2. ODLM should upgrade Keycloak to 24
3. ODLM should update Keycloak CR without `podTemplate` but contains `.spec.resources`.
    - <Details> <Summary>Example of Keycloak CR</Summary>

        ```yaml
        apiVersion: k8s.keycloak.org/v2alpha1
        kind: Keycloak
        metadata:
          name: cs-keycloak
        spec:
          db:
            host: keycloak-edb-cluster-rw
            passwordSecret:
              key: password
              name: keycloak-edb-cluster-app
            usernameSecret:
              key: username
              name: keycloak-edb-cluster-app
            vendor: postgres
          features:
            enabled:
              - token-exchange
          hostname:
            hostname: keycloak-sc2-dev.apps.installer-cp3pt0.cp.fyre.ibm.com
          http:
            tlsSecret: cs-keycloak-tls-secret
          ingress:
            enabled: false
          instances: 1
          resources:
            limits:
              cpu: 1000m
              ephemeral-storage: 512Mi
              memory: 1Gi
            requests:
              cpu: 1000m
              ephemeral-storage: 256Mi
              memory: 1Gi
          unsupported:
            podTemplate:
              metadata:
                annotations:
                  cloudpakThemesVersion: styles467.css
              spec:
                affinity:
                  nodeAffinity:
                    requiredDuringSchedulingIgnoredDuringExecution:
                      nodeSelectorTerms:
                        - matchExpressions:
                            - key: kubernetes.io/arch
                              operator: In
                              values:
                                - amd64
                                - ppc64le
                                - s390x
                containers:
                  - command:
                      - /bin/sh
                      - /mnt/startup/cs-keycloak-entrypoint.sh
                    volumeMounts:
                      - mountPath: /mnt/truststore
                        name: truststore-volume
                      - mountPath: /mnt/startup
                        name: startup-volume
                      - mountPath: /mnt/trust-ca
                        name: trust-ca-volume
                      - mountPath: /opt/keycloak/providers
                        name: cs-keycloak-theme
                      - mountPath: /mnt/user-profile
                        name: user-profile-volume
                volumes:
                  - emptyDir:
                      sizeLimit: 2Mi
                    name: truststore-volume
                  - configMap:
                      name: cs-keycloak-entrypoint
                    name: startup-volume
                  - configMap:
                      name: cs-keycloak-ca-certs
                      optional: true
                    name: trust-ca-volume
                  - configMap:
                      items:
                        - key: cloudpak-theme.jar
                          path: cloudpak-theme.jar
                      name: cs-keycloak-theme
                    name: cs-keycloak-theme
                  - configMap:
                      name: cs-keycloak-user-profile
                    name: user-profile-volume
        ```
        </Details>
