### PR TITLE
label length limitation

### DIFF
--- a/controllers/constant/constant.go
+++ b/controllers/constant/constant.go
@@ -34,8 +34,8 @@ const (
 	//InternalOpreqLabel is the label used label the OperandRequest internally created by ODLM
 	OperandOnlyLabel string = "operator.ibm.com/operand-only"
 
-	//ODLMReferenceLabel is the label used to label the resources used for ODLM operand value reference
-	ODLMReferenceLabel string = "operator.ibm.com/referenced-by-odlm-resource"
+	//ODLMReferenceAnnotation is the annotation used to annotate the resources used for ODLM operand value reference
+	ODLMReferenceAnnotation string = "operator.ibm.com/referenced-by-odlm-resource"
 
 	//ODLMWatchedLabel is the label used to label the resources watched by ODLM for value reference
 	ODLMWatchedLabel string = "operator.ibm.com/watched-by-odlm"

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -322,11 +322,11 @@ func (r *Reconciler) getConfigToRequestMapper() handler.MapFunc {
 func (r *Reconciler) getReferenceToRequestMapper() handler.MapFunc {
 	ctx := context.Background()
 	return func(object client.Object) []ctrl.Request {
-		labels := object.GetLabels()
-		if labels == nil {
+		annotations := object.GetAnnotations()
+		if annotations == nil {
 			return []ctrl.Request{}
 		}
-		odlmReference, ok := labels[constant.ODLMReferenceLabel]
+		odlmReference, ok := annotations[constant.ODLMReferenceAnnotation]
 		if !ok {
 			return []ctrl.Request{}
 		}

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -835,12 +835,14 @@ func (m *ODLMOperator) GetValueRefFromConfigMap(ctx context.Context, instanceTyp
 		}
 		return "", errors.Wrapf(err, "failed to get Configmap %s/%s", cmNs, cmName)
 	}
-	labelValue := instanceType + "." + instanceNs + "." + instanceName
-	labelValue = util.GetFirstNCharacter(labelValue, 63)
+
 	// Set the Value Reference label for the ConfigMap
 	util.EnsureLabelsForConfigMap(cm, map[string]string{
-		constant.ODLMReferenceLabel: labelValue,
-		constant.ODLMWatchedLabel:   "true",
+		constant.ODLMWatchedLabel: "true",
+	})
+	// Set the Value Reference Annotation for the ConfigMap
+	util.EnsureAnnotationForConfigMap(cm, map[string]string{
+		constant.ODLMReferenceAnnotation: instanceType + "." + instanceNs + "." + instanceName,
 	})
 	// Update the ConfigMap with the Value Reference label
 	if err := m.Update(ctx, cm); err != nil {
@@ -868,8 +870,11 @@ func (m *ODLMOperator) GetValueRefFromSecret(ctx context.Context, instanceType, 
 
 	// Set the Value Reference label for the Secret
 	util.EnsureLabelsForSecret(secret, map[string]string{
-		constant.ODLMReferenceLabel: instanceType + "." + instanceNs + "." + instanceName,
-		constant.ODLMWatchedLabel:   "true",
+		constant.ODLMWatchedLabel: "true",
+	})
+	// Set the Value Reference Annotation for the Secret
+	util.EnsureAnnotationsForSecret(secret, map[string]string{
+		constant.ODLMReferenceAnnotation: instanceType + "." + instanceNs + "." + instanceName,
 	})
 	// Update the Secret with the Value Reference label
 	if err := m.Update(ctx, secret); err != nil {
@@ -899,8 +904,11 @@ func (m *ODLMOperator) GetValueRefFromObject(ctx context.Context, instanceType, 
 
 	// Set the Value Reference label for the object
 	m.EnsureLabel(obj, map[string]string{
-		constant.ODLMReferenceLabel: instanceType + "." + instanceNs + "." + instanceName,
-		constant.ODLMWatchedLabel:   "true",
+		constant.ODLMWatchedLabel: "true",
+	})
+	// Set the Value Reference Annotation for the Secret
+	m.EnsureAnnotation(obj, map[string]string{
+		constant.ODLMReferenceAnnotation: instanceType + "." + instanceNs + "." + instanceName,
 	})
 	// Update the object with the Value Reference label
 	if err := m.Update(ctx, &obj); err != nil {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -835,11 +835,11 @@ func (m *ODLMOperator) GetValueRefFromConfigMap(ctx context.Context, instanceTyp
 		}
 		return "", errors.Wrapf(err, "failed to get Configmap %s/%s", cmNs, cmName)
 	}
-	labelvalue := instanceType + "." + instanceNs + "." + instanceName
-	labelvalue = util.GetFirstNCharacter(labelvalue, 63)
+	labelValue := instanceType + "." + instanceNs + "." + instanceName
+	labelValue = util.GetFirstNCharacter(labelValue, 63)
 	// Set the Value Reference label for the ConfigMap
 	util.EnsureLabelsForConfigMap(cm, map[string]string{
-		constant.ODLMReferenceLabel: labelvalue,
+		constant.ODLMReferenceLabel: labelValue,
 		constant.ODLMWatchedLabel:   "true",
 	})
 	// Update the ConfigMap with the Value Reference label

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -302,11 +302,29 @@ func EnsureLabelsForSecret(secret *corev1.Secret, labels map[string]string) {
 	}
 }
 
+func EnsureAnnotationsForSecret(secret *corev1.Secret, annotatinos map[string]string) {
+	if secret.Annotations == nil {
+		secret.Annotations = make(map[string]string)
+	}
+	for k, v := range annotatinos {
+		secret.Annotations[k] = v
+	}
+}
+
 func EnsureLabelsForConfigMap(cm *corev1.ConfigMap, labels map[string]string) {
 	if cm.Labels == nil {
 		cm.Labels = make(map[string]string)
 	}
 	for k, v := range labels {
+		cm.Labels[k] = v
+	}
+}
+
+func EnsureAnnotationForConfigMap(cm *corev1.ConfigMap, annotations map[string]string) {
+	if cm.Annotations == nil {
+		cm.Annotations = make(map[string]string)
+	}
+	for k, v := range annotations {
 		cm.Labels[k] = v
 	}
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -530,5 +530,5 @@ func GetFirstNCharacter(str string, n int) string {
 	if n >= len(str) {
 		return str
 	}
-	return string(str[:n])
+	return str[:n]
 }

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -525,3 +525,10 @@ func addField(obj map[string]interface{}, fields []string, value interface{}) {
 	// Add the value to the map
 	addField(obj[fields[0]].(map[string]interface{}), fields[1:], value)
 }
+
+func GetFirstNCharacter(str string, n int) string {
+	if n >= len(str) {
+		return str
+	}
+	return string(str[:n])
+}


### PR DESCRIPTION
What this PR does / why we need it:
k8s label name length limit to 64 characters, so olm will cut off any label longer than 64 characters
We rely on label to find csv and subscription, so we also need to cut of the label if it is longer than 64 characters.
Which issue(s) this PR fixes:
script enhancement for # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/64378