### PR TITLE
Tolerate both opt.channel and opt.FallbackChannels for one operator

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -399,7 +399,9 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 				oldObject := e.ObjectOld.(*olmv1alpha1.Subscription)
 				newObject := e.ObjectNew.(*olmv1alpha1.Subscription)
 				if oldObject.Labels != nil && oldObject.Labels[constant.OpreqLabel] == "true" {
-					return (oldObject.Status.InstalledCSV != "" && newObject.Status.InstalledCSV != "" && oldObject.Status.InstalledCSV != newObject.Status.InstalledCSV)
+					statusToggle := (oldObject.Status.InstalledCSV != "" && newObject.Status.InstalledCSV != "" && oldObject.Status.InstalledCSV != newObject.Status.InstalledCSV)
+					metadataToggle := !reflect.DeepEqual(oldObject.Annotations, newObject.Annotations)
+					return statusToggle || metadataToggle
 				}
 				return false
 			},

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -254,9 +254,12 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 				sub.Spec.Channel = minChannel
 			}
 
+			channels := []string{opt.Channel}
+			if channels = append(channels, opt.FallbackChannels...); util.Contains(channels, sub.Spec.Channel) {
+				isMatchedChannel = true
+			}
 			// update the spec iff channel in sub matches channel
 			if sub.Spec.Channel == opt.Channel {
-				isMatchedChannel = true
 				sub.Spec.CatalogSource = opt.SourceName
 				sub.Spec.CatalogSourceNamespace = opt.SourceNamespace
 				sub.Spec.Package = opt.PackageName


### PR DESCRIPTION
### What this PR does / why we need it**:
When OperandRequest requests `cloud-native-postgresql` first, and request `cloud-native-postgresql-v1.22` later, both OperandRequest could be in `Running` status because `cloud-native-postgresql-v1.22` would tolerate `stable` channel from `cloud-native-postgresql`.

### Which issue(s) this PR fixes:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65181

### Test
1. Install 4.6 dev build
2. Patch ODLM image `` in CSV and change imagePullPolicy to `Always`
3. Create two OperandRequets in sequence
    ```yaml
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      name: edb-service-stable
    spec:
      requests:
        - operands:
            - name: cloud-native-postgresql
          registry: common-service
    ---
    kind: OperandRequest
    apiVersion: operator.ibm.com/v1alpha1
    metadata:
      name: edb-service-stable-1-22
    spec:
      requests:
        - operands:
            - name: cloud-native-postgresql-v1.22
          registry: common-service
    ```
4. Check both OperandRequests are stable and have phase `Running`
    ```console
    ➜  ~ oc get operandrequest
    NAME                      AGE   PHASE     CREATED AT
    edb-service-stable        59s   Running   2024-11-20T17:29:35Z
    edb-service-stable-1-22   59s   Running   2024-11-20T17:29:35Z
    ```
5. Check Postgres operator subscription have following configurations
    - `.spec.channel` is `stable`
    - Two annotations indicating the channels requested by OperandRequests. One is `stable` and one is `stable-v1.22`
    ```console
    ➜  ~ oc get subscription cloud-native-postgresql -ojsonpath='{.spec.channel}'
    stable%
    
    ➜  ~ oc get subscription cloud-native-postgresql -ojsonpath='{.metadata.annotations}' | jq
    {
      "sc2-dev.common-service/config": "true",
      "sc2-dev.common-service/registry": "true",
      "sc2-dev.edb-service-stable-1-22.cloud-native-postgresql-v1.22/operatorNamespace": "sc2-dev",
      "sc2-dev.edb-service-stable-1-22.cloud-native-postgresql-v1.22/request": "stable-v1.22",
      "sc2-dev.edb-service-stable.cloud-native-postgresql/operatorNamespace": "sc2-dev",
      "sc2-dev.edb-service-stable.cloud-native-postgresql/request": "stable"
    }
    ```