### PR TITLE
Discover private CatalogSource only if no catalog cluster permission exists

### DIFF
--- a/controllers/operator/manager_test.go
+++ b/controllers/operator/manager_test.go
@@ -224,6 +224,7 @@ func TestGetFirstAvailableSemverChannelFromCatalog(t *testing.T) {
 type MockReader struct {
 	PackageManifestList *operatorsv1.PackageManifestList
 	CatalogSourceList   *olmv1alpha1.CatalogSourceList
+	CreatedObjects      map[string]client.Object
 }
 
 func (m *MockReader) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
@@ -245,6 +246,20 @@ func (m *MockReader) List(ctx context.Context, list client.ObjectList, opts ...c
 	if packageManifestList, ok := list.(*operatorsv1.PackageManifestList); ok {
 		packageManifestList.Items = m.PackageManifestList.Items
 	}
+	return nil
+}
+
+func (m *MockReader) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if m.CreatedObjects == nil {
+		m.CreatedObjects = make(map[string]client.Object)
+	}
+
+	// Generate a unique key based on the object's name and namespace
+	key := fmt.Sprintf("%s/%s", obj.GetNamespace(), obj.GetName())
+
+	// Store the object in the map
+	m.CreatedObjects[key] = obj
+
 	return nil
 }
 


### PR DESCRIPTION
Issue: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65336

### Context
Added permission check function to verify if it has the required permission, and then read catalog source by checking it before attempting to fetch them. If lacks permissions, limit catalog source processing to those in the operator namespace only.

### How to test
Test image: quay.io/yuchen_shen/odlm:catalog_permission

**Case I:** Apply private CatalogSource for ODLM, IM and EDB
1. Install v4 operator and remove the catalog cluster permission for ODLM
2. IM and EDB could be installed successfully

**Case II:** Apply CatalogSource as usual in `openshift-marketplace`
1.  Install v4 operator and remove the catalog cluster permission for ODLM
2. Request to install IM, will get error msg 
    ```failed to reconcile Operators for OperandRequest non-pravite-catalog/example-service: the following errors occurred:
    - failed to find catalogsource for subscription openshift-marketplace/ibm-iam-operator
    ```
**Case III**: Apply CatalogSource as usual in `openshift-marketplace`
1.  Install v4 operator and keep the cluster permission
2. Request to install IM, everything will be installed 

 
