### PR TITLE
Use SelfSubjectAccessReview to check ODLM's permission on getting catalog

### DIFF
--- a/controllers/operator/manager_test.go
+++ b/controllers/operator/manager_test.go
@@ -313,7 +313,7 @@ func TestGetCatalogSourceAndChannelFromPackage(t *testing.T) {
 	}
 
 	mockClient.mock.On("Create", ctx, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		sar := args.Get(1).(*authorizationv1.SubjectAccessReview)
+		sar := args.Get(1).(*authorizationv1.SelfSubjectAccessReview)
 		sar.Status.Allowed = true
 	})
 
@@ -434,9 +434,9 @@ func TestCheckResAuth(t *testing.T) {
 	resource := "test-resource"
 	verb := "get"
 
-	// Test when SubjectAccessReview is allowed
+	// Test when SelfSubjectAccessReview is allowed
 	mockClient.mock.On("Create", ctx, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		sar := args.Get(1).(*authorizationv1.SubjectAccessReview)
+		sar := args.Get(1).(*authorizationv1.SelfSubjectAccessReview)
 		sar.Status.Allowed = true
 	})
 
@@ -444,10 +444,10 @@ func TestCheckResAuth(t *testing.T) {
 		t.Errorf("Expected CheckResAuth to return true, but got false")
 	}
 
-	// Test when SubjectAccessReview is not allowed
+	// Test when SelfSubjectAccessReview is not allowed
 	mockClient.mock.ExpectedCalls = nil
 	mockClient.mock.On("Create", ctx, mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
-		sar := args.Get(1).(*authorizationv1.SubjectAccessReview)
+		sar := args.Get(1).(*authorizationv1.SelfSubjectAccessReview)
 		sar.Status.Allowed = false
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
1. ODLM will check its `get` permission on resource `catalogsources` in catalog namespace
    - `hasCatalogPermission := m.CheckResAuth(ctx, pm.Status.CatalogSourceNamespace, "operators.coreos.com", "catalogsources", "get")`
2. ODLM will create object `SelfSubjectAccessReview` to validate its permission on certain resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65427

### Test
1. Deploy SC2 dev build with global catalog in `openshift-marketplace` namespace
2. Update ODLM CSV to update ImagePullPolicy to `Always`, change the verbosity from `-v=1` to `-v=2` and patch image `quay.io/daniel_fan/odlm:1b6ff4cb-dirty`
3. Create an OperandRequest to deploy `ibm-im-operator`
4. IBM IAM Operator should be deployed successfully
5. Review ODLM logs, the operator has permission to `get` catalog in `openshift-marketplace` namespace.
    ```
    I1129 22:02:03.727047 1 reconcile_operator.go:49] Reconciling Operators for OperandRequest: cs4-data/ibm-iam-request
    I1129 22:02:03.755976 1 manager.go:248] Operator get permission in namespace openshift-marketplace for Kind: catalogsources, Allowed: true, Denied: false, Reason: RBAC: allowed by ClusterRoleBinding "operand-deployment-lifec-4K9igqY0bHgV6bQIglRyJ3RqddvJ8xuUotaKnq" of ClusterRole "operand-deployment-lifec-4K9igqY0bHgV6bQIglRyJ3RqddvJ8xuUotaKnq" to ServiceAccount "operand-deployment-lifecycle-manager/cs4-control"
    I1129 22:02:03.757168 1 manager.go:248] Operator get permission in namespace openshift-marketplace for Kind: catalogsources, Allowed: true, Denied: false, Reason: RBAC: allowed by ClusterRoleBinding "operand-deployment-lifec-4K9igqY0bHgV6bQIglRyJ3RqddvJ8xuUotaKnq" of ClusterRole "operand-deployment-lifec-4K9igqY0bHgV6bQIglRyJ3RqddvJ8xuUotaKnq" to ServiceAccount "operand-deployment-lifecycle-manager/cs4-control"
    I1129 22:02:03.757183 1 manager.go:248] Operator get permission in namespace openshift-marketplace for Kind: catalogsources, Allowed: true, Denied: false, Reason: RBAC: allowed by ClusterRoleBinding "operand-deployment-lifec-4K9igqY0bHgV6bQIglRyJ3RqddvJ8xuUotaKnq" of ClusterRole "operand-deployment-lifec-4K9igqY0bHgV6bQIglRyJ3RqddvJ8xuUotaKnq" to ServiceAccount "operand-deployment-lifecycle-manager/cs4-control"
    I1129 22:02:03.759136 1 manager.go:222] Found 1 CatalogSources for PackageManifest cloud-native-postgresql in the namespace cs4-control has channel stable-v1.22
    I1129 22:02:03.759156 1 manager.go:226] The 0th sorted CatalogSource is ibm-operator-catalog in namespace openshift-marketplace with priority: 0
    ```