### PR TITLE
Bump ODLM version to 4.3.9 for CS 4.6.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ OPERATOR_IMAGE_NAME ?= odlm
 # Current Operator bundle image name
 BUNDLE_IMAGE_NAME ?= odlm-operator-bundle
 # Current Operator version
-OPERATOR_VERSION ?= 4.3.8
+OPERATOR_VERSION ?= 4.3.9
 
 # Kind cluster name
 KIND_CLUSTER_NAME ?= "odlm"

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -132,7 +132,7 @@ metadata:
     createdAt: "2024-09-28T19:55:35Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
-    olm.skipRange: '>=1.2.0 <4.3.8'
+    olm.skipRange: '>=1.2.0 <4.3.9'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -143,7 +143,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: operand-deployment-lifecycle-manager.v4.3.8
+  name: operand-deployment-lifecycle-manager.v4.3.9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -868,7 +868,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: IBM
-  version: 4.3.8
+  version: 4.3.9
   relatedImages:
-    - image: icr.io/cpopen/odlm:4.3.8
+    - image: icr.io/cpopen/odlm:4.3.9
       name: ODLM_IMAGE

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based
       API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
-    olm.skipRange: '>=1.2.0 <4.3.8'
+    olm.skipRange: '>=1.2.0 <4.3.9'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -482,6 +482,6 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/cpopen/odlm:4.3.8
+  - image: icr.io/cpopen/odlm:4.3.9
     name: ODLM_IMAGE
   version: 0.0.0

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "4.3.8"
+	Version = "4.3.9"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump ODLM version to 4.3.9 for CS 4.6.10
