### PR TITLE
Check if Object is updated except certain label and annotations

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -376,6 +376,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
+			// If the object is not updated except the ODLMWatchedLabel label or ODLMReferenceAnnotation annotation, return false
+			if !r.ObjectIsUpdatedWithException(&e.ObjectOld, &e.ObjectNew) {
+				return false
+			}
 			labels := e.ObjectNew.GetLabels()
 			if labels != nil {
 				if labelValue, ok := labels[constant.ODLMWatchedLabel]; ok && labelValue == "true" {

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -576,7 +576,7 @@ func (r *Reconciler) reconcileK8sResource(ctx context.Context, res operatorv1alp
 					return err
 				}
 			} else {
-				klog.V(2).Infof("Skip the k8s resource %s/%s which is not created by ODLM", res.Kind, res.Name)
+				klog.V(2).Infof("Skip the k8s resource %s %s/%s whose force field is false", res.Kind, k8sResNs, res.Name)
 			}
 		}
 	} else {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -860,7 +860,7 @@ func (m *ODLMOperator) ParseObjectRef(ctx context.Context, obj *util.ObjectRef, 
 
 func (m *ODLMOperator) GetValueRefFromConfigMap(ctx context.Context, instanceType, instanceName, instanceNs, cmName, cmNs, configMapKey string) (string, error) {
 	cm := &corev1.ConfigMap{}
-	if err := m.Client.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cmNs}, cm); err != nil {
+	if err := m.Reader.Get(ctx, types.NamespacedName{Name: cmName, Namespace: cmNs}, cm); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(2).Infof("Configmap %s/%s is not found", cmNs, cmName)
 			return "", nil
@@ -892,7 +892,7 @@ func (m *ODLMOperator) GetValueRefFromConfigMap(ctx context.Context, instanceTyp
 
 func (m *ODLMOperator) GetValueRefFromSecret(ctx context.Context, instanceType, instanceName, instanceNs, secretName, secretNs, secretKey string) (string, error) {
 	secret := &corev1.Secret{}
-	if err := m.Client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNs}, secret); err != nil {
+	if err := m.Reader.Get(ctx, types.NamespacedName{Name: secretName, Namespace: secretNs}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("Secret %s/%s is not found", secretNs, secretName)
 			return "", nil

--- a/controllers/testutil/test_util.go
+++ b/controllers/testutil/test_util.go
@@ -200,7 +200,7 @@ func OperandConfigObj(name, namespace string) *apiv1alpha1.OperandConfig {
 									}
 								}`),
 							},
-							Force: false,
+							Force: true,
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

We are updating the condition on triggering the reconciliation:
#### Original condition:
The reconciliation will be triggered as long as a ConfigMap or Secret with label `operator.ibm.com/watched-by-odlm: 'true'` is updated.

#### New condition:
The reconciliation will be triggered when a ConfigMap or Secret with label `operator.ibm.com/watched-by-odlm: 'true'` is updated except the `ODLMWatchedLabel` label or `ODLMReferenceAnnotation` annotation.
   - If the only update is about `ODLMWatchedLabel` or `ODLMReferenceAnnotation`, the reconciliation will not be triggered.

#### Reason for such condition changes:
ODLM is adding `ODLMWatchedLabel` label and `ODLMReferenceAnnotation` annotation to any resources that it has reference on in OperandConfig. For example, ODLM is referring a ConfigMap named `openshift-service-ca.crt` in OperandConfig.
```yaml
        - apiVersion: v1
          data:
            stringData:
              ca.crt:
                templatingValueFrom:
                  configMapKeyRef:
                    key: service-ca.crt
                    name: openshift-service-ca.crt
                  required: true
```

In this case, ODLM will add above label and annotation into ConfigMap `openshift-service-ca.crt`
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: openshift-service-ca.crt
  namespace: cd-daily
  uid: 4a2258c4-0d50-48be-8280-e4c25abd3e42
  resourceVersion: '561287534'
  creationTimestamp: '2024-12-11T04:12:53Z'
  labels:
    operator.ibm.com/watched-by-odlm: 'true'
  annotations:
    service.beta.openshift.io/inject-cabundle: 'true'
```

However, OCP does not allow additional annotation to be added into above ConfigMap.
Every time ODLM is adding this annotation into the ConfigMap during the reconciliation, OCP will immediately update the ConfigMap to remove this annotation. Subsequently, this adding/removal actions trigger the next reconciliation of OperandRequest to have add annotation back. Finally it leads to endless reconciliations on OperandRequest.

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65181

### Test
1. Install latest dev build of CPFS.
2. Install both Keycloak and IM in the OperandRequest
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: keycloak-operator
            - name: ibm-im-operator
          registry: common-service
    ```
3. Observe that the phase of OperandRequest is flipping between `Failed` and `Running`
    ```console
    ➜  ~ oc get operandrequest example-service -ojsonpath='{.status.phase}'
    Failed%
    ➜  ~ oc get operandrequest example-service -ojsonpath='{.status.phase}'
    Running%
    ```
4. Patch the ODLM CSV with image `quay.io/daniel_fan/odlm:f5511b8c` and imagePullPolicy `Always`
5. Observe the phase of OperandRequest is now stable
    ```console
    ➜  ~ oc get operandrequest example-service -ojsonpath='{.status.phase}'
    Running%
    ```