### PR TITLE
[WIP] Enhance cleanup of OperandRequest for non-OLM case

### DIFF
--- a/controllers/operandrequestnoolm/reconcile_operator.go
+++ b/controllers/operandrequestnoolm/reconcile_operator.go
@@ -360,6 +360,12 @@ func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandN
 		} else if deploymentList != nil {
 			klog.Infof("Found %d Deployment for package %s/%s", len(deploymentList), op.Name, namespace)
 			if uninstallOperand {
+				// delete the configmap
+				klog.V(1).Infof("Deleting the Configmap %s/%s", cm.Namespace, cm.Name)
+				if err := r.deleteOpReqCM(ctx, requestInstance, cm); err != nil {
+					return err
+				}
+
 				klog.V(1).Infof("Deleting all the Custom Resources for Deployment, Namespace: %s, Name: %s", deploymentList[0].Namespace, deploymentList[0].Name)
 				if err := r.deleteAllCustomResource(ctx, deploymentList[0], requestInstance, configInstance, operandName, configInstance.Namespace); err != nil {
 					return err

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -169,6 +169,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operand-deployment-lifecycle-manager
+  namespace: {{ .Values.operatorNamespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role


### PR DESCRIPTION
**What this PR does / why we need it**: 
Test and enhance the cleanup logic for uninstalling operator resources

**What include**:
1. Updated the annotation in the operator ConfigMap by adding or deleting the related OperandRequest. If there are no more requests for that operator, the ConfigMap will be deleted as well.

**Continue Testing**