### PR TITLE
Check deployment as pre-req and return error if missing

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -689,6 +689,12 @@ func (m *ODLMOperator) GetDeploymentListFromPackage(ctx context.Context, name, n
 		deployments = append(deployments, &deployment)
 	}
 
+	if len(deployments) == 0 {
+		// give an error message if no deployment found and return  error
+		klog.Errorf("No Deployment found with package name %s:", packageName)
+		return nil, fmt.Errorf("missing deployment with package name %s, please install the %s first", packageName, packageName)
+	}
+
 	klog.V(1).Infof("Get %v / %v Deployment in the namespace %s", len(deployments), len(deploymentList.Items), deploymentNamespace)
 	return deployments, nil
 }


### PR DESCRIPTION
### What this PR does / why we need it: 
Error handling for the case where the OperandRequest of an operator exists, but its deployment is missing in the cluster

### Which issue(s) this PR fixes
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65885

### How to test
Test image: `quay.io/yuchen_shen/odlm:no-deployment`
1. Create OperandRequest for `ibm-events-operator` and there is no events operator deployment in the cluster

**Before the fix, it will be panic error like:**
```
I0211 22:11:13.739803       1 reconcile_operand.go:95] Looking for deployment for the operator: ibm-events-operator
I0211 22:11:13.753482       1 manager.go:643] Get Deployment cloud-native-postgresql-operator with package name ibm-events-operator
I0211 22:11:13.753562       1 manager.go:643] Get Deployment ibm-common-service-operator with package name ibm-events-operator
I0211 22:11:13.753571       1 manager.go:643] Get Deployment ibm-commonui-operator with package name ibm-events-operator
I0211 22:11:13.753580       1 manager.go:643] Get Deployment ibm-iam-operator with package name ibm-events-operator
I0211 22:11:13.753587       1 manager.go:643] Get Deployment operand-deployment-lifecycle-manager with package name ibm-events-operator
I0211 22:11:13.753594       1 manager.go:651] Get 0 / 5 Deployment in the namespace operator-ns
panic: runtime error: index out of range [0] with length 0 [recovered]
	panic: runtime error: index out of range [0] with length 0

goroutine 864 [running]:
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile.func1()
	/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/internal/controller/controller.go:118 +0x1c7
panic({0x18af300?, 0xc0007956f8?})
```
**After test image applied, the error looks like:**
```
I0211 22:12:14.210725       1 reconcile_operand.go:95] Looking for deployment for the operator: ibm-events-operator
I0211 22:12:14.216795       1 manager.go:684] Get Deployment cloud-native-postgresql-operator with package name ibm-events-operator
I0211 22:12:14.216828       1 manager.go:684] Get Deployment ibm-common-service-operator with package name ibm-events-operator
I0211 22:12:14.216844       1 manager.go:684] Get Deployment ibm-commonui-operator with package name ibm-events-operator
I0211 22:12:14.216852       1 manager.go:684] Get Deployment ibm-iam-operator with package name ibm-events-operator
I0211 22:12:14.216859       1 manager.go:684] Get Deployment operand-deployment-lifecycle-manager with package name ibm-events-operator
E0212 19:40:22.145403       1 manager.go:694] No Deployment found with package name ibm-events-operator:
E0212 19:40:22.145430       1 operandrequestnoolm_controller.go:173] failed to reconcile Operands for OperandRequest operator-ns/example1: the following errors occurred:
  - missing deployment with package name ibm-events-operator, please install the ibm-events-operator first
E0212 19:40:22.157502       1 operandrequestnoolm_controller.go:108] failed to patch status for OperandRequest operator-ns/example1: the following errors occurred:
  - missing deployment with package name ibm-events-operator, please install the ibm-events-operator first
```
