### PR TITLE
Remove and replace the wildcard permissions set in the ODLM role

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -14,6 +14,7 @@ rules:
   - secrets
   - services
   - serviceaccounts
+  - pods #for EDB
   verbs:
   - create
   - delete
@@ -51,6 +52,8 @@ rules:
   - apps
   resources:
   - deployments
+  - daemonsets
+  - statefulsets
   verbs:
   - create
   - delete

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -13,6 +13,7 @@ rules:
   - namespaces
   - secrets
   - services
+  - serviceaccounts
   verbs:
   - create
   - delete
@@ -22,9 +23,113 @@ rules:
   - update
   - watch
 - apiGroups:
-  - '*'
+  - postgresql.k8s.enterprisedb.io
   resources:
-  - '*'
+  - clusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - batch
+  resources:
+  - jobs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - certmanager.k8s.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - foundation.ibm.com
+  resources:
+  - navconfigurations
+  - navconfigurations/finalizers
+  - navconfigurations/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operators.ibm.com
+  resources:
+  - commonwebuis
+  # - commonwebuis/finalizers
+  # - commonwebuis/status
+  - switcheritems
+  # - switcheritems/finalizers
+  # - switcheritems/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - operator.ibm.com
+  resources:
+  - authentications
   verbs:
   - create
   - delete


### PR DESCRIPTION
**What this PR does / why we need it**: PA is blocked by the ODLM role including wildcard permissions because they apply namespace scope charts via a tenant admin that has reduced permissions. To circumvent this problem, I have specifically included all resources mentioned in either alm-examples or operandconfig (as listed in the issue linked). I have also included pods because they are required to create the edb-license-role and daemonsets and statefulsets as ODLM was failing without them.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65917

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
