### PR TITLE
Create all role and rolebindings in each namespace

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -8,7 +8,11 @@ metadata:
 
 {{- $chartName := .Chart.Name }}
 {{- $operaterNamespace := .Values.global.operatorNamespace }}
-{{- range $i := .Values.global.tetheredNamespace }}
+
+{{- $namespaces := .Values.global.tetheredNamespace | default list -}}
+{{- $namespaces = append $namespaces .Values.global.operatorNamespace -}}
+{{- $namespaces = append $namespaces .Values.global.instanceNamespace -}}
+{{- range $i := $namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -11,7 +11,9 @@ metadata:
 
 {{- $namespaces := .Values.global.tetheredNamespace | default list -}}
 {{- $namespaces = append $namespaces .Values.global.operatorNamespace -}}
-{{- $namespaces = append $namespaces .Values.global.instanceNamespace -}}
+{{- if .Values.global.instanceNamespace }}
+  {{- $namespaces = append $namespaces .Values.global.instanceNamespace }}
+{{- end }}
 {{- range $i := $namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -1,10 +1,22 @@
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+apiVersion: v1
+kind: ServiceAccount
 metadata:
   name: operand-deployment-lifecycle-manager
   namespace: {{ .Values.global.operatorNamespace }}
   labels:
     component-id: {{ .Chart.Name }}
+
+{{- $chartName := .Chart.Name }}
+{{- $operaterNamespace := .Values.global.operatorNamespace }}
+{{- range $i := .Values.global.tetheredNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: operand-deployment-lifecycle-manager
+  namespace: {{ $i }}
+  labels:
+    component-id: {{ $chartName }}
 rules:
 - apiGroups:
   - ""
@@ -272,16 +284,15 @@ rules:
   - patch
   - update
   - watch
-
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operand-deployment-lifecycle-manager
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ $i }}
   labels:
-    component-id: {{ .Chart.Name }}
+    component-id: {{ $chartName }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -289,26 +300,17 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: operand-deployment-lifecycle-manager
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ $operaterNamespace }}
 ---
 
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: operand-deployment-lifecycle-manager
-  namespace: {{ .Values.global.operatorNamespace }}
-  labels:
-    component-id: {{ .Chart.Name }}
-
----
 ### role only for olm
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: operand-deployment-lifecycle-manager.v4.4.0
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ $i }}
   labels:
-    component-id: {{ .Chart.Name }}
+    component-id: {{ $chartName }}
 rules:
 - apiGroups:
   - operators.coreos.com
@@ -320,16 +322,15 @@ rules:
   - get
   - update
   - patch
-
 ---
 ### rolebinding only for olm
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: operand-deployment-lifecycle-manager.v4.4.0
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ $i }}
   labels:
-    component-id: {{ .Chart.Name }}
+    component-id: {{ $chartName}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -337,4 +338,5 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: operand-deployment-lifecycle-manager
-  namespace: {{ .Values.global.operatorNamespace }}
+  namespace: {{ $operaterNamespace }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -5,6 +5,7 @@
 global:
   tetheredNamespace: [tenant1,tenant2]
   operatorNamespace: operator-ns
+  instanceNamespace: services-ns
 
 # Note there are no leading or trailing /'s
 cpfs:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,9 +3,9 @@
 
 # The following global values could be overridden by top-level values
 global:
-  tetheredNamespace: [tenant1,tenant2]
+  tetheredNamespace: []
   operatorNamespace: operator-ns
-  instanceNamespace: services-ns
+  instanceNamespace: 
 
 # Note there are no leading or trailing /'s
 cpfs:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,6 +1,11 @@
 # imagePullPrefix: icr.io
 # imagePullSecret: ibm-entitlement-key
 
+# The following global values could be overridden by top-level values
+global:
+  tetheredNamespace: [tenant1,tenant2]
+  operatorNamespace: operator-ns
+
 # Note there are no leading or trailing /'s
 cpfs:
   imageRegistryNamespaceOperator: cpopen


### PR DESCRIPTION
**What this PR does / why we need it**: 
All charts created the operator's RBAC in all the namespaces for the tenant instead of namespace scope operator doing the permission projection.

**Slack discussion:** https://ibm-cloudplatform.slack.com/archives/C085K4TSJ5S/p1739389039395679

**How to test**:
1. Running `helm template ./helm > tmp.yaml` to check if all the values passed in correctly
2. Apply the helm charts on OCP without NSS operator, and check if ODLM working properly.
