### PR TITLE
add additional events permission to ODLM

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -33,6 +33,7 @@ rules:
   - services
   - serviceaccounts
   - pods #for EDB
+  - events
   verbs:
   - create
   - delete


### PR DESCRIPTION
**What this PR does / why we need it**: While testing BR, ODLM is failing due to a lack of permissions to patch events resource. I believe this is related to removing the wildcard permissions in in a previous PR https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1124.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
