### PR TITLE
Add Conditional Logic Support to ODLM Templating System

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -1100,7 +1100,7 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	}
 
 	// Handle logical operators
-	if expr.And != nil && len(expr.And) > 0 {
+	if len(expr.And) > 0 {
 		for _, subExpr := range expr.And {
 			result, err := m.EvaluateExpression(ctx, subExpr, instanceType, instanceName, instanceNs)
 			if err != nil {
@@ -1113,7 +1113,7 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		return true, nil
 	}
 
-	if expr.Or != nil && len(expr.Or) > 0 {
+	if len(expr.Or) > 0 {
 		for _, subExpr := range expr.Or {
 			result, err := m.EvaluateExpression(ctx, subExpr, instanceType, instanceName, instanceNs)
 			if err != nil {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -799,7 +799,7 @@ func (m *ODLMOperator) ParseValueReferenceInObject(ctx context.Context, key stri
 	case map[string]any:
 		return m.processMapObject(ctx, key, obj, finalObject, instanceType, instanceName, instanceNs)
 	case []any:
-		return m.processArrayObject(ctx, key, obj, finalObject, instanceType, instanceName, instanceNs)
+		return m.processArrayObject(ctx, key, finalObject, instanceType, instanceName, instanceNs)
 	}
 	return nil
 }
@@ -830,7 +830,7 @@ func (m *ODLMOperator) processMapObject(ctx context.Context, key string, mapObj 
 }
 
 // processArrayObject handles array-type objects
-func (m *ODLMOperator) processArrayObject(ctx context.Context, key string, arrayObj []interface{}, finalObject map[string]interface{}, instanceType, instanceName, instanceNs string) error {
+func (m *ODLMOperator) processArrayObject(ctx context.Context, key string, finalObject map[string]interface{}, instanceType, instanceName, instanceNs string) error {
 	if finalArray, ok := finalObject[key].([]interface{}); ok {
 		for i := range finalArray {
 			if mapItem, ok := finalArray[i].(map[string]interface{}); ok {

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -45,15 +45,59 @@ type TemplateValueRef struct {
 	Required        bool              `json:"required,omitempty"`
 	Default         *DefaultObjectRef `json:"default,omitempty"`
 	ConfigMapKeyRef *ConfigMapRef     `json:"configMapKeyRef,omitempty"`
-	SecretRef       *SecretRef        `json:"secretKeyRef,omitempty"`
+	SecretKeyRef    *SecretRef        `json:"secretKeyRef,omitempty"`
+	ObjectRef       *ObjectRef        `json:"objectRef,omitempty"`
+	Conditional     *ConditionalRef   `json:"conditional,omitempty"`
 	// RouteRef        *RouteRef         `json:"routePathRef,omitempty"`
-	ObjectRef *ObjectRef `json:"objectRef,omitempty"`
+}
+
+type ConditionalRef struct {
+	// If-else condition
+	IfValue *ValueSource `json:"ifValue,omitempty"`
+	Equals  string       `json:"equals,omitempty"`
+
+	// Expression-based condition
+	Expression *LogicalExpression `json:"expression,omitempty"`
+
+	// Results
+	Then *ValueSource `json:"then,omitempty"`
+	Else *ValueSource `json:"else,omitempty"`
+}
+
+type LogicalExpression struct {
+	// Basic comparison operators
+	Equal       *ValueComparison `json:"equal,omitempty"`
+	NotEqual    *ValueComparison `json:"notEqual,omitempty"`
+	GreaterThan *ValueComparison `json:"greaterThan,omitempty"`
+	LessThan    *ValueComparison `json:"lessThan,omitempty"`
+
+	// Logical operators
+	And []*LogicalExpression `json:"and,omitempty"`
+	Or  []*LogicalExpression `json:"or,omitempty"`
+	Not *LogicalExpression   `json:"not,omitempty"`
+
+	// Simple value reference for direct value evaluation
+	Value *ValueSource `json:"value,omitempty"`
+}
+
+type ValueComparison struct {
+	Left  *ValueSource `json:"left,omitempty"`
+	Right *ValueSource `json:"right,omitempty"`
+}
+
+type ValueSource struct {
+	Literal string `json:"literal,omitempty"`
+
+	// Dynamic references
+	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`
+	SecretKeyRef    *SecretRef    `json:"secretKeyRef,omitempty"`
+	ObjectRef       *ObjectRef    `json:"objectRef,omitempty"`
 }
 
 type DefaultObjectRef struct {
 	Required        bool          `json:"required,omitempty"`
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`
-	SecretRef       *SecretRef    `json:"secretKeyRef,omitempty"`
+	SecretKeyRef    *SecretRef    `json:"secretKeyRef,omitempty"`
 	// RouteRef        *RouteRef     `json:"routePathRef,omitempty"`
 	ObjectRef    *ObjectRef `json:"objectRef,omitempty"`
 	DefaultValue string     `json:"defaultValue,omitempty"`

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -52,10 +52,6 @@ type TemplateValueRef struct {
 }
 
 type ConditionalRef struct {
-	// If-else condition
-	IfValue *ValueSource `json:"ifValue,omitempty"`
-	Equals  string       `json:"equals,omitempty"`
-
 	// Expression-based condition
 	Expression *LogicalExpression `json:"expression,omitempty"`
 


### PR DESCRIPTION
### What this PR does / why we need it:
This enhancement added powerful conditional logic capabilities to the ODLM templating system, allowing for dynamic selection of values based on runtime conditions. The implementation supports both simple equality-based conditions and complex expressions with logical operators.

### Which issue(s) this PR fixes 
general ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66114
keycloak 26: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65922

### How to test:
1. Test image: quay.io/yuchen_shen/odlm:templating
2. Install keycloak 26+
3. Enable backchannel in OperandConfig Keycloak cr
```
data:
    spec:
    ...
    additionalOptions:                          <----- newly added
      - name: hostname-backchannel-dynamic
        value: "true"
    ...
    ...
    proxy:
      headers: xforwarded
    features:
      enabled:
        - token-exchange
        - admin-fine-grained-authz

```
and modify `.spec.hostname` section as beblow:
```
hostname:
    hostname:
      templatingValueFrom:
        conditional:
          expression:
            and:        
              - equal:                    
                  left:
                    objectRef:
                      apiVersion: k8s.keycloak.org/v2alpha1
                      kind: Keycloak
                      name: cs-keycloak
                      path: '.spec.additionalOptions[0].name'
                  right:
                    literal: hostname-backchannel-dynamic
              - equal:                         
                  left:
                    objectRef:
                      apiVersion: k8s.keycloak.org/v2alpha1
                      kind: Keycloak
                      name: cs-keycloak
                      path: '.spec.additionalOptions[0].value'
                  right:
                    literal: 'true'
         then:          
            objectRef:
              apiVersion: route.openshift.io/v1
              kind: Route
              name: keycloak
              path: 'https://+.spec.host'
          else:
            objectRef:
              apiVersion: route.openshift.io/v1
              kind: Route
              name: keycloak
              path: .spec.host
```
4. Check hostname in Keycloak CR (version 26+)
```
spec:
  hostname:
    hostname: 'https://<ns>-keycloak.apps.<domain>.cp.fyre.ibm.com'
```
