### PR TITLE
Array enhancement for ODLM templating system

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -812,19 +812,20 @@ func (m *ODLMOperator) processMapObject(ctx context.Context, key string, mapObj 
 			if err != nil {
 				return err
 			}
-			klog.Infof("000000 key is %s and value is %v", key, valueRef)
-			// Check if the returned value is a JSON array string and the field should be an array
-			if strings.HasPrefix(valueRef, "[") && strings.HasSuffix(valueRef, "]") {
-				// Try to unmarshal it as an array
-				var arrayValue []interface{}
-				if err := json.Unmarshal([]byte(valueRef), &arrayValue); err == nil {
-					// Successfully unmarshaled as array, use the array directly
-					finalObject[key] = arrayValue
-					continue
+			if valueRef != "" {
+				// Check if the returned value is a JSON array string and the field should be an array
+				if strings.HasPrefix(valueRef, "[") && strings.HasSuffix(valueRef, "]") {
+					var arrayValue []interface{}
+					if err := json.Unmarshal([]byte(valueRef), &arrayValue); err == nil {
+						finalObject[key] = arrayValue
+						continue
+					}
 				}
-				// If unmarshaling fails, fall through to use the string value
+				finalObject[key] = valueRef
+			} else {
+				klog.V(3).Infof("Empty value reference returned for key %s, deleting key %s from finalObject", key, key)
+				delete(finalObject, key)
 			}
-			finalObject[key] = valueRef
 		} else {
 			if finalObject[key] == nil {
 				// Skip if the key doesn't exist in finalObject

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -1167,19 +1167,36 @@ func (m *ODLMOperator) GetValueFromSource(ctx context.Context, source *util.Valu
 
 	// Get value from Object
 	if source.ObjectRef != nil {
-		return m.ParseObjectRef(ctx, source.ObjectRef, instanceType, instanceName, instanceNs)
+		val, err := m.ParseObjectRef(ctx, source.ObjectRef, instanceType, instanceName, instanceNs)
+		if err != nil {
+			return "", err
+		} else if val == "" && source.Required {
+			return "", errors.Errorf("Failed to get required value from source %s, retry in few second", source.ObjectRef.Name)
+		}
+		return val, nil
 	}
 
 	// Get value from Secret
 	if source.SecretKeyRef != nil {
-		return m.ParseSecretKeyRef(ctx, source.SecretKeyRef, instanceType, instanceName, instanceNs)
+		val, err := m.ParseSecretKeyRef(ctx, source.SecretKeyRef, instanceType, instanceName, instanceNs)
+		if err != nil {
+			return "", err
+		} else if val == "" && source.Required {
+			return "", errors.Errorf("Failed to get required value from source %s, retry in few second", source.SecretKeyRef.Name)
+		}
+		return val, nil
 	}
 
 	// Get value from ConfigMap
 	if source.ConfigMapKeyRef != nil {
-		return m.ParseConfigMapRef(ctx, source.ConfigMapKeyRef, instanceType, instanceName, instanceNs)
+		val, err := m.ParseConfigMapRef(ctx, source.ConfigMapKeyRef, instanceType, instanceName, instanceNs)
+		if err != nil {
+			return "", err
+		} else if val == "" && source.Required {
+			return "", errors.Errorf("Failed to get required value from source %s, retry in few second", source.ConfigMapKeyRef.Name)
+		}
+		return val, nil
 	}
-
 	return "", nil
 }
 

--- a/controllers/operator/manager_test.go
+++ b/controllers/operator/manager_test.go
@@ -1083,6 +1083,41 @@ func TestGetValueFromBranch(t *testing.T) {
 			expectError:    false,
 		},
 		{
+			name: "Branch with array containing map values with reference",
+			branch: &util.ValueSource{
+				Array: []util.ValueSource{
+					{Literal: "value1"},
+					{
+						Map: map[string]interface{}{
+							"hostname": "backend-service",
+							"enabled":  true,
+							"port":     8080,
+						},
+					},
+					{
+						Map: map[string]interface{}{
+							"apikey": map[string]interface{}{
+								"secretKeyRef": map[string]interface{}{
+									"name": "test-secret",
+									"key":  "token",
+								},
+							},
+						},
+					},
+					{
+						ConfigMapKeyRef: &util.ConfigMapRef{
+							Name: "test-cm",
+							Key:  "test-key",
+						},
+					},
+				},
+			},
+			branchName:     "test-branch",
+			key:            "test-key",
+			expectedResult: `["value1",{"enabled":true,"hostname":"backend-service","port":8080},{"apikey":"eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"},"test-key-value"]`,
+			expectError:    false,
+		},
+		{
 			name: "Branch with array containing reference values",
 			branch: &util.ValueSource{
 				Array: []util.ValueSource{

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -82,9 +82,10 @@ type ValueComparison struct {
 }
 
 type ValueSource struct {
-	Literal string                 `json:"literal,omitempty"`
-	Map     map[string]interface{} `json:"map,omitempty"` // Add this for arbitrary key-value pairs
-	Array   []ValueSource          `json:"array,omitempty"`
+	Literal  string                 `json:"literal,omitempty"`
+	Map      map[string]interface{} `json:"map,omitempty"` // Add this for arbitrary key-value pairs
+	Array    []ValueSource          `json:"array,omitempty"`
+	Required bool                   `json:"required,omitempty"` // Add this line to support required flag
 
 	// Dynamic references
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -82,7 +82,9 @@ type ValueComparison struct {
 }
 
 type ValueSource struct {
-	Literal string `json:"literal,omitempty"`
+	Literal string                 `json:"literal,omitempty"`
+	Map     map[string]interface{} `json:"map,omitempty"` // Add this for arbitrary key-value pairs
+	Array   []ValueSource          `json:"array,omitempty"`
 
 	// Dynamic references
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`
@@ -94,9 +96,9 @@ type DefaultObjectRef struct {
 	Required        bool          `json:"required,omitempty"`
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`
 	SecretKeyRef    *SecretRef    `json:"secretKeyRef,omitempty"`
+	ObjectRef       *ObjectRef    `json:"objectRef,omitempty"`
+	DefaultValue    string        `json:"defaultValue,omitempty"`
 	// RouteRef        *RouteRef     `json:"routePathRef,omitempty"`
-	ObjectRef    *ObjectRef `json:"objectRef,omitempty"`
-	DefaultValue string     `json:"defaultValue,omitempty"`
 }
 
 type ConfigMapRef struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added array and map support to the OperandConfig templating system, specifically in conditional branches. 
#### Key Features
1. Array Support in Conditional Branches
    Users can now define arrays of mixed item types in `then` and `else` branches. It can contain literals, ConfigMap references, Secret references, or Object references
2. Map Structure Support
    Array items can include complex map structures with arbitrary key-value pairs

**Which issue(s) this PR fixes**
general ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66114
keycloak 26: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65922

**How to test:**
1. Test image: `quay.io/yuchen_shen/odlm:templating`
2. Install keycloak 26+
3. Apply cs image: `quay.io/yuchen_shen/cs_operator:hostnamev2` , which comes from [PR2347](https://github.com/IBM/ibm-common-service-operator/pull/2437)
4. Check if kc 26 is working