### PR TITLE
disable irrelevant logging messages that can be misleading

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -641,11 +641,11 @@ func (m *ODLMOperator) GetDeploymentListFromPackage(ctx context.Context, name, n
 		// 	continue
 		// }
 		// annotation := fmt.Sprintf("\"packageName\":\"%s\"", packageName)
-		klog.V(1).Infof("Get Deployment %s with package name %s", deployment.Name, packageName)
+		klog.V(2).Infof("Check if deployment %s matches package name %s", deployment.Name, packageName)
 		if !strings.Contains(deployment.Annotations["packageName"], packageName) {
 			continue
 		}
-		klog.V(1).Infof("Get Deployment %s in the namespace %s", deployment.Name, deploymentNamespace)
+		klog.V(2).Infof("Deployment %s in the namespace %s matches package name %s.", deployment.Name, deploymentNamespace, packageName)
 		deployments = append(deployments, &deployment)
 	}
 
@@ -655,7 +655,7 @@ func (m *ODLMOperator) GetDeploymentListFromPackage(ctx context.Context, name, n
 		return nil, fmt.Errorf("missing deployment with package name %s, please install the %s first", packageName, packageName)
 	}
 
-	klog.V(1).Infof("Get %v / %v Deployment in the namespace %s", len(deployments), len(deploymentList.Items), deploymentNamespace)
+	klog.V(1).Infof("Found deployment matching package name %s in the namespace %s", packageName, deploymentNamespace)
 	return deployments, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**: Disable certain logging messages in no olm scenario as they are misleading and create a lot of noise in the ODLM logs when installing via helm chart.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66009

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
