### PR TITLE
Array enhancement for ODLM templating system (#1136)

### DIFF
--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -82,7 +82,10 @@ type ValueComparison struct {
 }
 
 type ValueSource struct {
-	Literal string `json:"literal,omitempty"`
+	Literal  string                 `json:"literal,omitempty"`
+	Map      map[string]interface{} `json:"map,omitempty"` // Add this for arbitrary key-value pairs
+	Array    []ValueSource          `json:"array,omitempty"`
+	Required bool                   `json:"required,omitempty"` // Add this line to support required flag
 
 	// Dynamic references
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`
@@ -94,9 +97,9 @@ type DefaultObjectRef struct {
 	Required        bool          `json:"required,omitempty"`
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`
 	SecretKeyRef    *SecretRef    `json:"secretKeyRef,omitempty"`
+	ObjectRef       *ObjectRef    `json:"objectRef,omitempty"`
+	DefaultValue    string        `json:"defaultValue,omitempty"`
 	// RouteRef        *RouteRef     `json:"routePathRef,omitempty"`
-	ObjectRef    *ObjectRef `json:"objectRef,omitempty"`
-	DefaultValue string     `json:"defaultValue,omitempty"`
 }
 
 type ConfigMapRef struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
Added array and map support to the OperandConfig templating system, specifically in conditional branches. 
cherry-pick: https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1136

**Which issue(s) this PR fixes**
general ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66114
keycloak 26: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/65922

**How to test:**
1. Test image: `quay.io/yuchen_shen/odlm:templating`
2. Install keycloak 26+
3. Apply cs image: `quay.io/yuchen_shen/cs_operator:hostnamev2` , which comes from [PR2347](https://github.com/IBM/ibm-common-service-operator/pull/2437)
4. Check if kc 26 is working