### PR TITLE
Add support for operator aliasing via ConfigName

### DIFF
--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -237,12 +237,23 @@ const (
 )
 
 // GetService obtains the service definition with the operand name.
-func (r *OperandConfig) GetService(operandName string) *ConfigService {
+func (r *OperandConfig) GetService(operandName string, configName string) *ConfigService { // First try to find by configName if it's provided and not empty
+	// First try to find by configName if it's provided
+	if configName != "" {
+		for _, s := range r.Spec.Services {
+			if s.Name == configName {
+				return &s
+			}
+		}
+	}
+
+	// Fall back to operandName if configName is not provided or not found
 	for _, s := range r.Spec.Services {
 		if s.Name == operandName {
 			return &s
 		}
 	}
+
 	return nil
 }
 

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -56,6 +56,8 @@ type Operator struct {
 	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
 	// Name of the package that defines the applications.
 	PackageName string `json:"packageName"`
+	// Name of service listed in OperandConfig
+	ConfigName string `json:"configName,omitempty"`
 	// Name of the channel to track.
 	Channel string `json:"channel"`
 	// List of channels to fallback when the main channel is not available.

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -67,6 +67,9 @@ spec:
                     channel:
                       description: Name of the channel to track.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     description:
                       description: Description of a common service.
                       type: string

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -63,6 +63,9 @@ spec:
                     channel:
                       description: Name of the channel to track.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     description:
                       description: Description of a common service.
                       type: string

--- a/config/e2e/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/e2e/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -61,9 +61,18 @@ spec:
                     channel:
                       description: Name of the channel to track.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     description:
                       description: Description of a common service.
                       type: string
+                    fallbackChannels:
+                      description: List of channels to fallback when the main channel
+                        is not available.
+                      items:
+                        type: string
+                      type: array
                     installMode:
                       description: 'The install mode of an operator, either namespace
                         or cluster. Valid values are: - "namespace" (default): operator

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -120,7 +120,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, instance *operatorv1alpha
 
 		op := op
 
-		service := instance.GetService(op.Name)
+		service := instance.GetService(op.Name, op.ConfigName)
 		if service == nil {
 			continue
 		}

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -114,6 +114,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	// Remove finalizer when DeletionTimestamp none zero
 	if !requestInstance.ObjectMeta.DeletionTimestamp.IsZero() {
+		klog.Infof("1111 starting deletion")
 
 		// Check and clean up the subscriptions
 		err := r.checkFinalizer(ctx, requestInstance)
@@ -240,7 +241,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context, cr *operatorv1alpha1.Oper
 }
 
 func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
-	klog.V(1).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
+	klog.Infof("2222 Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
 	remainingOperands := gset.NewSet()
 	for _, m := range requestInstance.Status.Members {
 		remainingOperands.Add(m.Name)

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -114,7 +114,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	// Remove finalizer when DeletionTimestamp none zero
 	if !requestInstance.ObjectMeta.DeletionTimestamp.IsZero() {
-		klog.Infof("1111 starting deletion")
 
 		// Check and clean up the subscriptions
 		err := r.checkFinalizer(ctx, requestInstance)
@@ -241,7 +240,6 @@ func (r *Reconciler) addFinalizer(ctx context.Context, cr *operatorv1alpha1.Oper
 }
 
 func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
-	klog.Infof("2222 Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
 	remainingOperands := gset.NewSet()
 	for _, m := range requestInstance.Status.Members {
 		remainingOperands.Add(m.Name)

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -586,7 +586,7 @@ func (r *Reconciler) reconcileK8sResource(ctx context.Context, res operatorv1alp
 }
 
 // deleteAllCustomResource remove custom resource base on OperandConfig and CSV alm-examples
-func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, op *operatorv1alpha1.Operator, operandName, namespace string) error {
+func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, opConfigName, operandName, namespace string) error {
 
 	customeResourceMap := make(map[string]operatorv1alpha1.OperandCRMember)
 	for _, member := range requestInstance.Status.Members {
@@ -638,7 +638,7 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 		return merr
 	}
 
-	service := csc.GetService(operandName, op.ConfigName)
+	service := csc.GetService(operandName, opConfigName)
 	if service == nil {
 		return nil
 	}
@@ -1332,9 +1332,9 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 }
 
 // deleteAllK8sResource remove k8s resource base on OperandConfig
-func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, op *operatorv1alpha1.Operator, operandName, namespace string) error {
+func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, opConfigName, operandName, namespace string) error {
 
-	service := csc.GetService(operandName, op.ConfigName)
+	service := csc.GetService(operandName, opConfigName)
 	if service == nil {
 		return nil
 	}

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -192,7 +192,7 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 				configInstance, err := r.GetOperandConfig(ctx, registryKey)
 				if err == nil {
 					// Check the requested Service Config if exist in specific OperandConfig
-					opdConfig := configInstance.GetService(operand.Name)
+					opdConfig := configInstance.GetService(operand.Name, opdRegistry.ConfigName)
 					if opdConfig == nil && !opdRegistry.UserManaged {
 						klog.V(2).Infof("There is no service: %s from the OperandConfig instance: %s/%s, Skip reconciling Operands", operand.Name, registryKey.Namespace, req.Registry)
 						continue
@@ -586,7 +586,7 @@ func (r *Reconciler) reconcileK8sResource(ctx context.Context, res operatorv1alp
 }
 
 // deleteAllCustomResource remove custom resource base on OperandConfig and CSV alm-examples
-func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, operandName, namespace string) error {
+func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, op *operatorv1alpha1.Operator, operandName, namespace string) error {
 
 	customeResourceMap := make(map[string]operatorv1alpha1.OperandCRMember)
 	for _, member := range requestInstance.Status.Members {
@@ -638,7 +638,7 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 		return merr
 	}
 
-	service := csc.GetService(operandName)
+	service := csc.GetService(operandName, op.ConfigName)
 	if service == nil {
 		return nil
 	}
@@ -1332,9 +1332,9 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 }
 
 // deleteAllK8sResource remove k8s resource base on OperandConfig
-func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, operandName, namespace string) error {
+func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, op *operatorv1alpha1.Operator, operandName, namespace string) error {
 
-	service := csc.GetService(operandName)
+	service := csc.GetService(operandName, op.ConfigName)
 	if service == nil {
 		return nil
 	}

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -54,7 +54,6 @@ func (r *Reconciler) reconcileOperator(ctx context.Context, requestInstance *ope
 		remainingOperands.Add(m.Name)
 	}
 
-	klog.Infof("3333 Remaining Operands: %v", remainingOperands.ToSlice())
 	// Update request status
 	defer func() {
 		requestInstance.FreshMemberStatus(&remainingOperands)
@@ -453,11 +452,11 @@ func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandN
 		klog.Infof("Found %d ClusterServiceVersions for Subscription %s/%s", len(csvList), sub.Namespace, sub.Name)
 		if uninstallOperand {
 			klog.V(2).Infof("Deleting all the Custom Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, op, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 			klog.V(2).Infof("Deleting all the k8s Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllK8sResource(ctx, configInstance, op, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllK8sResource(ctx, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 		}
@@ -541,11 +540,11 @@ func (r *Reconciler) uninstallOperands(ctx context.Context, operandName string, 
 		klog.Infof("Found %d ClusterServiceVersions for package %s/%s", len(csvList), op.Name, namespace)
 		if uninstallOperand {
 			klog.V(2).Infof("Deleting all the Custom Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, op, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 			klog.V(2).Infof("Deleting all the k8s Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllK8sResource(ctx, configInstance, op, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllK8sResource(ctx, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 		}
@@ -576,7 +575,7 @@ func (r *Reconciler) absentOperatorsAndOperands(ctx context.Context, requestInst
 			}
 		}
 		merr := &util.MultiErr{}
-		remainingOp := needDeletedOperands.Clone() //keycloak-operator
+		remainingOp := needDeletedOperands.Clone()
 		for o := range needDeletedOperands.Iter() {
 			var (
 				o = o
@@ -621,13 +620,10 @@ func (r *Reconciler) absentOperatorsAndOperands(ctx context.Context, requestInst
 }
 
 func (r *Reconciler) getNeedDeletedOperands(requestInstance *operatorv1alpha1.OperandRequest) gset.Set {
-	klog.Info("4444 requestInstance name: ", requestInstance.Name)
 	deployedOperands := gset.NewSet()
 	for _, req := range requestInstance.Status.Members {
 		deployedOperands.Add(req.Name)
 	}
-
-	klog.Infof("5555 Deployed Operands: %v", deployedOperands.ToSlice())
 
 	currentOperands := gset.NewSet()
 	if requestInstance.DeletionTimestamp.IsZero() {
@@ -636,11 +632,9 @@ func (r *Reconciler) getNeedDeletedOperands(requestInstance *operatorv1alpha1.Op
 				currentOperands.Add(op.Name)
 			}
 		}
-		klog.Infof("6666 Current Operands: %v", currentOperands.ToSlice())
 	}
 
 	needDeleteOperands := deployedOperands.Difference(currentOperands)
-	klog.Infof("7777 Need Delete Operands: %v", needDeleteOperands.ToSlice())
 	return needDeleteOperands
 }
 

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -820,7 +820,6 @@ func (m *ODLMOperator) processExpressionCondition(ctx context.Context, templateR
 			instanceType, instanceNs, instanceName, key, err)
 		return "", err
 	}
-	klog.Infof("010101 key %s and result is %v", key, result)
 
 	if result {
 		// Use 'then' branch when condition is true

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -622,7 +622,7 @@ func newOperandConfigCR(name, namespace string) *v1alpha1.OperandConfig {
 		Spec: v1alpha1.OperandConfigSpec{
 			Services: []v1alpha1.ConfigService{
 				{
-					Name: "jaeger",
+					Name: "jaeger-custmized",
 					Spec: map[string]v1alpha1.ExtensionWithMarker{
 						"jaeger": {
 							RawExtension: runtime.RawExtension{Raw: []byte(`{"strategy": "streaming"}`)}},
@@ -700,6 +700,7 @@ func newOperandRegistryCR(name, namespace, OperatorNamespace string) *v1alpha1.O
 				{
 					Name:            "jaeger",
 					Namespace:       OperatorNamespace,
+					ConfigName:      "keycloak-operator",
 					SourceName:      "community-operators",
 					SourceNamespace: "openshift-marketplace",
 					PackageName:     "jaeger",

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -622,7 +622,7 @@ func newOperandConfigCR(name, namespace string) *v1alpha1.OperandConfig {
 		Spec: v1alpha1.OperandConfigSpec{
 			Services: []v1alpha1.ConfigService{
 				{
-					Name: "jaeger-custmized",
+					Name: "jaeger-config",
 					Spec: map[string]v1alpha1.ExtensionWithMarker{
 						"jaeger": {
 							RawExtension: runtime.RawExtension{Raw: []byte(`{"strategy": "streaming"}`)}},
@@ -700,7 +700,7 @@ func newOperandRegistryCR(name, namespace, OperatorNamespace string) *v1alpha1.O
 				{
 					Name:            "jaeger",
 					Namespace:       OperatorNamespace,
-					ConfigName:      "keycloak-operator",
+					ConfigName:      "jaeger-config",
 					SourceName:      "community-operators",
 					SourceNamespace: "openshift-marketplace",
 					PackageName:     "jaeger",

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -732,6 +732,7 @@ func newOperandRegistryCRforKind(name, namespace, OperatorNamespace string) *v1a
 				{
 					Name:            "jaeger",
 					Namespace:       OperatorNamespace,
+					ConfigName:      "jaeger-config",
 					SourceName:      "operatorhubio-catalog",
 					SourceNamespace: "olm",
 					PackageName:     "jaeger",


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement operator aliasing through the ConfigName field to allow multiple operator entries in OperandRegistry to share operand resources by pointing to the same configuration in OperandConfig.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66289

**How to test**:
1. Test image: quay.io/yuchen_shen/odlm:deletion
2. install `keycloak-operator` and then switch to `keycloak-operaot-v26`, all the keycloak resources will not be deleted

