### PR TITLE
[CD] Add support for operator aliasing via ConfigName (#1141)

### DIFF
--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -237,7 +237,7 @@ const (
 )
 
 // GetService obtains the service definition with the operand name.
-func (r *OperandConfig) GetService(operandName string, configName string) *ConfigService { // First try to find by configName if it's provided and not empty
+func (r *OperandConfig) GetService(operandName string, configName string) *ConfigService {
 	// First try to find by configName if it's provided
 	if configName != "" {
 		for _, s := range r.Spec.Services {

--- a/api/v1alpha1/operandconfig_types.go
+++ b/api/v1alpha1/operandconfig_types.go
@@ -237,12 +237,23 @@ const (
 )
 
 // GetService obtains the service definition with the operand name.
-func (r *OperandConfig) GetService(operandName string) *ConfigService {
+func (r *OperandConfig) GetService(operandName string, configName string) *ConfigService { // First try to find by configName if it's provided and not empty
+	// First try to find by configName if it's provided
+	if configName != "" {
+		for _, s := range r.Spec.Services {
+			if s.Name == configName {
+				return &s
+			}
+		}
+	}
+
+	// Fall back to operandName if configName is not provided or not found
 	for _, s := range r.Spec.Services {
 		if s.Name == operandName {
 			return &s
 		}
 	}
+
 	return nil
 }
 

--- a/api/v1alpha1/operandregistry_types.go
+++ b/api/v1alpha1/operandregistry_types.go
@@ -56,6 +56,8 @@ type Operator struct {
 	TargetNamespaces []string `json:"targetNamespaces,omitempty"`
 	// Name of the package that defines the applications.
 	PackageName string `json:"packageName"`
+	// Name of service listed in OperandConfig
+	ConfigName string `json:"configName,omitempty"`
 	// Name of the channel to track.
 	Channel string `json:"channel"`
 	// List of channels to fallback when the main channel is not available.

--- a/bundle/manifests/operator.ibm.com_operandregistries.yaml
+++ b/bundle/manifests/operator.ibm.com_operandregistries.yaml
@@ -67,6 +67,9 @@ spec:
                     channel:
                       description: Name of the channel to track.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     description:
                       description: Description of a common service.
                       type: string

--- a/config/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -63,6 +63,9 @@ spec:
                     channel:
                       description: Name of the channel to track.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     description:
                       description: Description of a common service.
                       type: string

--- a/config/e2e/crd/bases/operator.ibm.com_operandregistries.yaml
+++ b/config/e2e/crd/bases/operator.ibm.com_operandregistries.yaml
@@ -61,9 +61,18 @@ spec:
                     channel:
                       description: Name of the channel to track.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     description:
                       description: Description of a common service.
                       type: string
+                    fallbackChannels:
+                      description: List of channels to fallback when the main channel
+                        is not available.
+                      items:
+                        type: string
+                      type: array
                     installMode:
                       description: 'The install mode of an operator, either namespace
                         or cluster. Valid values are: - "namespace" (default): operator

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -120,7 +120,7 @@ func (r *Reconciler) updateStatus(ctx context.Context, instance *operatorv1alpha
 
 		op := op
 
-		service := instance.GetService(op.Name)
+		service := instance.GetService(op.Name, op.ConfigName)
 		if service == nil {
 			continue
 		}

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -240,7 +240,6 @@ func (r *Reconciler) addFinalizer(ctx context.Context, cr *operatorv1alpha1.Oper
 }
 
 func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
-	klog.V(1).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
 	remainingOperands := gset.NewSet()
 	for _, m := range requestInstance.Status.Members {
 		remainingOperands.Add(m.Name)

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -240,6 +240,7 @@ func (r *Reconciler) addFinalizer(ctx context.Context, cr *operatorv1alpha1.Oper
 }
 
 func (r *Reconciler) checkFinalizer(ctx context.Context, requestInstance *operatorv1alpha1.OperandRequest) error {
+	klog.V(1).Infof("Deleting OperandRequest %s in the namespace %s", requestInstance.Name, requestInstance.Namespace)
 	remainingOperands := gset.NewSet()
 	for _, m := range requestInstance.Status.Members {
 		remainingOperands.Add(m.Name)

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -192,7 +192,7 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 				configInstance, err := r.GetOperandConfig(ctx, registryKey)
 				if err == nil {
 					// Check the requested Service Config if exist in specific OperandConfig
-					opdConfig := configInstance.GetService(operand.Name)
+					opdConfig := configInstance.GetService(operand.Name, opdRegistry.ConfigName)
 					if opdConfig == nil && !opdRegistry.UserManaged {
 						klog.V(2).Infof("There is no service: %s from the OperandConfig instance: %s/%s, Skip reconciling Operands", operand.Name, registryKey.Namespace, req.Registry)
 						continue
@@ -586,7 +586,7 @@ func (r *Reconciler) reconcileK8sResource(ctx context.Context, res operatorv1alp
 }
 
 // deleteAllCustomResource remove custom resource base on OperandConfig and CSV alm-examples
-func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, operandName, namespace string) error {
+func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alpha1.ClusterServiceVersion, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, opConfigName, operandName, namespace string) error {
 
 	customeResourceMap := make(map[string]operatorv1alpha1.OperandCRMember)
 	for _, member := range requestInstance.Status.Members {
@@ -638,7 +638,7 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 		return merr
 	}
 
-	service := csc.GetService(operandName)
+	service := csc.GetService(operandName, opConfigName)
 	if service == nil {
 		return nil
 	}
@@ -1332,9 +1332,9 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 }
 
 // deleteAllK8sResource remove k8s resource base on OperandConfig
-func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, operandName, namespace string) error {
+func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, opConfigName, operandName, namespace string) error {
 
-	service := csc.GetService(operandName)
+	service := csc.GetService(operandName, opConfigName)
 	if service == nil {
 		return nil
 	}

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -53,6 +53,7 @@ func (r *Reconciler) reconcileOperator(ctx context.Context, requestInstance *ope
 	for _, m := range requestInstance.Status.Members {
 		remainingOperands.Add(m.Name)
 	}
+
 	// Update request status
 	defer func() {
 		requestInstance.FreshMemberStatus(&remainingOperands)
@@ -230,6 +231,12 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, requestInstance 
 		sub.Annotations[registryKey.Namespace+"."+registryKey.Name+"/config"] = "true"
 		sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/request"] = opt.Channel
 		sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/operatorNamespace"] = namespace
+		// Only add the config annotation if ConfigName is not empty
+		if opt.ConfigName != "" {
+			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/config"] = opt.ConfigName
+		} else {
+			sub.Annotations[requestInstance.Namespace+"."+requestInstance.Name+"."+operand.Name+"/config"] = opt.Name
+		}
 
 		if opt.InstallMode == operatorv1alpha1.InstallModeNoop {
 			isMatchedChannel = true
@@ -445,11 +452,11 @@ func (r *Reconciler) uninstallOperatorsAndOperands(ctx context.Context, operandN
 		klog.Infof("Found %d ClusterServiceVersions for Subscription %s/%s", len(csvList), sub.Namespace, sub.Name)
 		if uninstallOperand {
 			klog.V(2).Infof("Deleting all the Custom Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 			klog.V(2).Infof("Deleting all the k8s Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllK8sResource(ctx, configInstance, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllK8sResource(ctx, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 		}
@@ -533,11 +540,11 @@ func (r *Reconciler) uninstallOperands(ctx context.Context, operandName string, 
 		klog.Infof("Found %d ClusterServiceVersions for package %s/%s", len(csvList), op.Name, namespace)
 		if uninstallOperand {
 			klog.V(2).Infof("Deleting all the Custom Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllCustomResource(ctx, csvList[0], requestInstance, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 			klog.V(2).Infof("Deleting all the k8s Resources for CSV, Namespace: %s, Name: %s", csvList[0].Namespace, csvList[0].Name)
-			if err := r.deleteAllK8sResource(ctx, configInstance, operandName, configInstance.Namespace); err != nil {
+			if err := r.deleteAllK8sResource(ctx, configInstance, op.ConfigName, operandName, configInstance.Namespace); err != nil {
 				return err
 			}
 		}
@@ -613,7 +620,6 @@ func (r *Reconciler) absentOperatorsAndOperands(ctx context.Context, requestInst
 }
 
 func (r *Reconciler) getNeedDeletedOperands(requestInstance *operatorv1alpha1.OperandRequest) gset.Set {
-	klog.V(3).Info("Getting the operator need to be delete")
 	deployedOperands := gset.NewSet()
 	for _, req := range requestInstance.Status.Members {
 		deployedOperands.Add(req.Name)
@@ -739,13 +745,24 @@ func checkSubAnnotationsForUninstall(reqName, reqNs, opName, installMode string,
 	uninstallOperator := true
 	uninstallOperand := true
 
+	// Store the current operator's config name before removing its annotations
+	var currentConfigName string
+	configKey := reqNs + "." + reqName + "." + opName + "/config"
+	if configVal, exists := sub.Annotations[configKey]; exists {
+		currentConfigName = configVal
+	}
+
 	delete(sub.Annotations, reqNs+"."+reqName+"."+opName+"/request")
 	delete(sub.Annotations, reqNs+"."+reqName+"."+opName+"/operatorNamespace")
+	delete(sub.Annotations, configKey)
 
 	var opreqNsSlice []string
 	var operatorNameSlice []string
+	var configNameSlice []string // Track all remaining config names
+
 	namespaceReg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/operatorNamespace`)
 	channelReg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/request`)
+	configReg, _ := regexp.Compile(`^(.*)\.(.*)\.(.*)\/config`)
 
 	for key, value := range sub.Annotations {
 		if namespaceReg.MatchString(key) {
@@ -757,6 +774,10 @@ func checkSubAnnotationsForUninstall(reqName, reqNs, opName, installMode string,
 			keyParts := strings.Split(key, "/")
 			annoPrefix := strings.Split(keyParts[0], ".")
 			operatorNameSlice = append(operatorNameSlice, annoPrefix[len(annoPrefix)-1])
+		}
+		if configReg.MatchString(key) {
+			// Add config name to the list
+			configNameSlice = append(configNameSlice, value)
 		}
 	}
 
@@ -773,8 +794,12 @@ func checkSubAnnotationsForUninstall(reqName, reqNs, opName, installMode string,
 	// When one of following conditions are met, the operand will NOT be uninstalled:
 	// 1. operator is not uninstalled AND intallMode is no-op.
 	// 2. operator is uninstalled AND  at least one other <prefix>/operatorNamespace annotation exists.
-	// 2. remaining <prefix>/request annotation's values contain the same operator name
-	if (!uninstallOperator && installMode == operatorv1alpha1.InstallModeNoop) || (uninstallOperator && len(opreqNsSlice) != 0) || util.Contains(operatorNameSlice, opName) {
+	// 3. remaining <prefix>/request annotation's values contain the same operator name
+	// 4. remaining <prefix>/config annotation's values contain the same configName as this operator
+	if (!uninstallOperator && installMode == operatorv1alpha1.InstallModeNoop) ||
+		(uninstallOperator && len(opreqNsSlice) != 0) ||
+		util.Contains(operatorNameSlice, opName) ||
+		(currentConfigName != "" && util.Contains(configNameSlice, currentConfigName)) {
 		uninstallOperand = false
 	}
 

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -129,7 +129,7 @@ func (r *Reconciler) reconcileOperand(ctx context.Context, requestInstance *oper
 				configInstance, err := r.GetOperandConfig(ctx, registryKey)
 				if err == nil {
 					// Check the requested Service Config if exist in specific OperandConfig
-					opdConfig := configInstance.GetService(operand.Name)
+					opdConfig := configInstance.GetService(operand.Name, opdRegistry.ConfigName)
 					if opdConfig == nil && !opdRegistry.UserManaged {
 						klog.V(2).Infof("There is no service: %s from the OperandConfig instance: %s/%s, Skip reconciling Operands", operand.Name, registryKey.Namespace, req.Registry)
 						continue
@@ -523,7 +523,7 @@ func (r *Reconciler) reconcileK8sResource(ctx context.Context, res operatorv1alp
 }
 
 // deleteAllCustomResource remove custom resource base on OperandConfig and CSV alm-examples
-func (r *Reconciler) deleteAllCustomResource(ctx context.Context, deployment *appsv1.Deployment, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, operandName, namespace string) error {
+func (r *Reconciler) deleteAllCustomResource(ctx context.Context, deployment *appsv1.Deployment, requestInstance *operatorv1alpha1.OperandRequest, csc *operatorv1alpha1.OperandConfig, opConfigName, operandName, namespace string) error {
 
 	customeResourceMap := make(map[string]operatorv1alpha1.OperandCRMember)
 	for _, member := range requestInstance.Status.Members {
@@ -575,7 +575,7 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, deployment *ap
 		return merr
 	}
 
-	service := csc.GetService(operandName)
+	service := csc.GetService(operandName, opConfigName)
 	if service == nil {
 		return nil
 	}
@@ -1268,9 +1268,9 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 }
 
 // deleteAllK8sResource remove k8s resource base on OperandConfig
-func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, operandName, namespace string) error {
+func (r *Reconciler) deleteAllK8sResource(ctx context.Context, csc *operatorv1alpha1.OperandConfig, opConfigName, operandName, namespace string) error {
 
-	service := csc.GetService(operandName)
+	service := csc.GetService(operandName, opConfigName)
 	if service == nil {
 		return nil
 	}

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -911,7 +911,6 @@ func (m *ODLMOperator) processExpressionCondition(ctx context.Context, templateR
 			instanceType, instanceNs, instanceName, key, err)
 		return "", err
 	}
-	klog.Infof("010101 key %s and result is %v", key, result)
 
 	if result {
 		// Use 'then' branch when condition is true

--- a/helm-cluster-scoped/templates/crd.yaml
+++ b/helm-cluster-scoped/templates/crd.yaml
@@ -540,6 +540,9 @@ spec:
                     description:
                       description: Description of a common service.
                       type: string
+                    configName:
+                      description: Name of service listed in OperandConfig
+                      type: string
                     fallbackChannels:
                       description: List of channels to fallback when the main channel
                         is not available.

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -622,7 +622,7 @@ func newOperandConfigCR(name, namespace string) *v1alpha1.OperandConfig {
 		Spec: v1alpha1.OperandConfigSpec{
 			Services: []v1alpha1.ConfigService{
 				{
-					Name: "jaeger",
+					Name: "jaeger-config",
 					Spec: map[string]v1alpha1.ExtensionWithMarker{
 						"jaeger": {
 							RawExtension: runtime.RawExtension{Raw: []byte(`{"strategy": "streaming"}`)}},
@@ -700,6 +700,7 @@ func newOperandRegistryCR(name, namespace, OperatorNamespace string) *v1alpha1.O
 				{
 					Name:            "jaeger",
 					Namespace:       OperatorNamespace,
+					ConfigName:      "jaeger-config",
 					SourceName:      "community-operators",
 					SourceNamespace: "openshift-marketplace",
 					PackageName:     "jaeger",
@@ -731,6 +732,7 @@ func newOperandRegistryCRforKind(name, namespace, OperatorNamespace string) *v1a
 				{
 					Name:            "jaeger",
 					Namespace:       OperatorNamespace,
+					ConfigName:      "jaeger-config",
 					SourceName:      "operatorhubio-catalog",
 					SourceNamespace: "olm",
 					PackageName:     "jaeger",


### PR DESCRIPTION
**What this PR does / why we need it**:
Implement operator aliasing through the ConfigName field to allow multiple operator entries in OperandRegistry to share operand resources by pointing to the same configuration in OperandConfig.

Cherry-pick: https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1141

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66289


