### PR TITLE
Fix concurrent access issues by copying labels map in SetupWithManager

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -1046,7 +1046,12 @@ func (r *Reconciler) refreshPodsFromDaemonSet(ns, name, resourceType string) err
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	bindablePredicates := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			labels := e.Object.GetLabels()
+			// Make a copy of the labels map to avoid concurrent access issues
+			labels := make(map[string]string)
+			for k, v := range e.Object.GetLabels() {
+				labels[k] = v
+			}
+
 			for labelKey, labelValue := range labels {
 				if labelKey == constant.OpbiTypeLabel {
 					return labelValue == "original"
@@ -1055,7 +1060,12 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			labels := e.ObjectNew.GetLabels()
+			// Make a copy of the labels map to avoid concurrent access issues
+			labels := make(map[string]string)
+			for k, v := range e.ObjectNew.GetLabels() {
+				labels[k] = v
+			}
+
 			for labelKey, labelValue := range labels {
 				if labelKey == constant.OpbiTypeLabel {
 					return labelValue == "original"


### PR DESCRIPTION
**What this PR does / why we need it**:
I am seeing issue that ODLM is crashed due to following error
```
fatal error: concurrent map iteration and map write
goroutine 1117 [running]:
github.com/IBM/operand-deployment-lifecycle-manager/v4/controllers/operandbindinfo.(*Reconciler).SetupWithManager.func2({{0x1c32118?, 0xc00248d900?}, {0x1c32118?, 0xc0017ffe00?}})
/workspace/controllers/operandbindinfo/operandbindinfo_controller.go:1059 +0x7f
sigs.k8s.io/controller-runtime/pkg/predicate.Funcs.Update(...)
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/predicate/predicate.go:88
sigs.k8s.io/controller-runtime/pkg/source/internal.EventHandler.OnUpdate({{0x1c1cd88, 0xc0001368a8}, {0x1c25830, 0xc0002aee80}, {0xc000e9fc40, 0x1, 0x1}}, {0x1965e80, 0xc00248d900}, {0x1965e80, ...})
/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.12.3/pkg/source/internal/eventsource.go:88 +0x372
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
/go/pkg/mod/k8s.io/client-go@v0.24.3/tools/cache/shared_informer.go:816 +0xe8
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
/go/pkg/mod/k8s.io/apimachinery@v0.24.17/pkg/util/wait/wait.go:157 +0x33
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc001975f70, {0x1c05240, 0xc000e0e8d0}, 0x1, 0xc000c65b90)
/go/pkg/mod/k8s.io/apimachinery@v0.24.17/pkg/util/wait/wait.go:158 +0xaf
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0005edf70, 0x3b9aca00, 0x0, 0x1, 0xc000c65b90)
/go/pkg/mod/k8s.io/apimachinery@v0.24.17/pkg/util/wait/wait.go:135 +0x7f
k8s.io/apimachinery/pkg/util/wait.Until(...)
```

It occurs because there is potential dangerous concurrent operation: one go routine is iterating through a map while another is simultaneously writing to it. Therefore, making a local copy before reading the label could help to mitigate this from happening.