### PR TITLE
Enhance Kubernetes Resource Quantity Comparisons in Templating System

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -32,6 +32,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -961,13 +962,41 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		return leftVal, rightVal, nil
 	}
 
+	// Helper function to compare values with support for Kubernetes resource units
+	compareValues := func(leftVal, rightVal string) (leftIsGreater bool, rightIsEqual bool, rightIsGreater bool, err error) {
+		// Check if both are resource quantities
+		leftQty, leftErr := resource.ParseQuantity(strings.TrimSpace(leftVal))
+		rightQty, rightErr := resource.ParseQuantity(strings.TrimSpace(rightVal))
+
+		// If both are valid Kubernetes quantities, compare their values
+		if leftErr == nil && rightErr == nil {
+			cmp := leftQty.Cmp(rightQty)
+			return cmp > 0, cmp == 0, cmp < 0, nil
+		}
+
+		// Fall back to standard float parsing
+		leftNum, leftFloatErr := strconv.ParseFloat(strings.TrimSpace(leftVal), 64)
+		rightNum, rightFloatErr := strconv.ParseFloat(strings.TrimSpace(rightVal), 64)
+
+		if leftFloatErr == nil && rightFloatErr == nil {
+			return leftNum > rightNum, leftNum == rightNum, leftNum < rightNum, nil
+		}
+
+		// Fall back to string comparison
+		return leftVal > rightVal, leftVal == rightVal, leftVal < rightVal, nil
+	}
+
 	// Handle basic comparison operators
 	if expr.Equal != nil {
 		leftVal, rightVal, err := getComparisonValues(expr.Equal.Left, expr.Equal.Right)
 		if err != nil {
 			return false, err
 		}
-		return leftVal == rightVal, nil
+		_, isEqual, _, err := compareValues(leftVal, rightVal)
+		if err != nil {
+			return false, err
+		}
+		return isEqual, nil
 	}
 
 	if expr.NotEqual != nil {
@@ -975,7 +1004,11 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		if err != nil {
 			return false, err
 		}
-		return leftVal != rightVal, nil
+		_, isEqual, _, err := compareValues(leftVal, rightVal)
+		if err != nil {
+			return false, err
+		}
+		return !isEqual, nil
 	}
 
 	if expr.GreaterThan != nil {
@@ -984,13 +1017,11 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 			return false, err
 		}
 
-		leftNum, leftErr := strconv.ParseFloat(strings.TrimSpace(leftVal), 64)
-		rightNum, rightErr := strconv.ParseFloat(strings.TrimSpace(rightVal), 64)
-
-		if leftErr == nil && rightErr == nil {
-			return leftNum > rightNum, nil
+		leftGreater, _, _, err := compareValues(leftVal, rightVal)
+		if err != nil {
+			return false, err
 		}
-		return leftVal > rightVal, nil
+		return leftGreater, nil
 	}
 
 	if expr.LessThan != nil {
@@ -999,13 +1030,11 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 			return false, err
 		}
 
-		leftNum, leftErr := strconv.ParseFloat(strings.TrimSpace(leftVal), 64)
-		rightNum, rightErr := strconv.ParseFloat(strings.TrimSpace(rightVal), 64)
-
-		if leftErr == nil && rightErr == nil {
-			return leftNum < rightNum, nil
+		_, _, leftLess, err := compareValues(leftVal, rightVal)
+		if err != nil {
+			return false, err
 		}
-		return leftVal < rightVal, nil
+		return leftLess, nil
 	}
 
 	// Handle logical operators

--- a/controllers/operator/manager_test.go
+++ b/controllers/operator/manager_test.go
@@ -561,7 +561,7 @@ func TestEvaluateExpression(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "GreaterThan comparison with strings",
+			name: "GreaterThan comparison with strings - true",
 			expr: &util.LogicalExpression{
 				GreaterThan: &util.ValueComparison{
 					Left:  &util.ValueSource{Literal: "xyz"},
@@ -594,7 +594,7 @@ func TestEvaluateExpression(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "LessThan comparison with strings",
+			name: "LessThan comparison with strings - true",
 			expr: &util.LogicalExpression{
 				LessThan: &util.ValueComparison{
 					Left:  &util.ValueSource{Literal: "abc"},
@@ -602,6 +602,128 @@ func TestEvaluateExpression(t *testing.T) {
 				},
 			},
 			expectedResult: true,
+			expectError:    false,
+		},
+		// Kubernetes resource quantity tests
+		{
+			name: "GreaterThan comparison with memory quantities - true",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "10Gi"},
+					Right: &util.ValueSource{Literal: "2Gi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "GreaterThan comparison with memory quantities - false",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "100Mi"},
+					Right: &util.ValueSource{Literal: "1Gi"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "LessThan comparison with memory quantities - true",
+			expr: &util.LogicalExpression{
+				LessThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "500Mi"},
+					Right: &util.ValueSource{Literal: "1Gi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "LessThan comparison with memory quantities - false",
+			expr: &util.LogicalExpression{
+				LessThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "5Gi"},
+					Right: &util.ValueSource{Literal: "2Gi"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "Equal comparison with CPU quantities",
+			expr: &util.LogicalExpression{
+				Equal: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1000m"},
+					Right: &util.ValueSource{Literal: "1"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "Equal comparison with different unit formats",
+			expr: &util.LogicalExpression{
+				Equal: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1Gi"},
+					Right: &util.ValueSource{Literal: "1024Mi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "GreaterThan comparison with CPU quantities",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "2"},
+					Right: &util.ValueSource{Literal: "1500m"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "GreaterThan comparison with mixed format units",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1Mi"},
+					Right: &util.ValueSource{Literal: "1024Ki"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "Mixed resource types - comparing memory and CPU",
+			expr: &util.LogicalExpression{
+				Equal: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "100m"},
+					Right: &util.ValueSource{Literal: "100Mi"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "NotEqual comparison with memory quantities - true",
+			expr: &util.LogicalExpression{
+				NotEqual: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "2Gi"},
+					Right: &util.ValueSource{Literal: "1Gi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "NotEqual comparison with memory quantities - false",
+			expr: &util.LogicalExpression{
+				NotEqual: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1Gi"},
+					Right: &util.ValueSource{Literal: "1024Mi"},
+				},
+			},
+			expectedResult: false,
 			expectError:    false,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhanced the `EvaluateExpression` function to properly handle Kubernetes resource quantities during value comparisons. Values with Kubernetes resource units (like Gi, Mi, Ki, m) were being compared correctly for now.


**Which issue(s) this PR fixes** :
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66114
 
**Examples**: 
Now correctly handles:

- Memory comparisons: "10Gi" > "2Gi"
- CPU comparisons: "2" > "1500m"
- Mixed unit comparisons: "1Gi" = "1024Mi"
- Different resource types: "100m" CPU ≠ "100Mi" memory

Test image: `quay.io/yuchen_shen/odlm:templating`