### PR TITLE
Refactor Bindinfo controller logic on object event watching and reconciliation triggering condition

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -1046,12 +1046,7 @@ func (r *Reconciler) refreshPodsFromDaemonSet(ns, name, resourceType string) err
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	bindablePredicates := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			// Make a copy of the labels map to avoid concurrent access issues
-			labels := make(map[string]string)
-			for k, v := range e.Object.GetLabels() {
-				labels[k] = v
-			}
-
+			labels := e.Object.GetLabels()
 			for labelKey, labelValue := range labels {
 				if labelKey == constant.OpbiTypeLabel {
 					return labelValue == "original"
@@ -1060,12 +1055,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			// Make a copy of the labels map to avoid concurrent access issues
-			labels := make(map[string]string)
-			for k, v := range e.ObjectNew.GetLabels() {
-				labels[k] = v
-			}
-
+			labels := e.ObjectNew.GetLabels()
 			for labelKey, labelValue := range labels {
 				if labelKey == constant.OpbiTypeLabel {
 					return labelValue == "original"

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -274,7 +274,7 @@ func (r *Reconciler) copySecret(ctx context.Context, sourceName, targetName, sou
 	}
 
 	secret := &corev1.Secret{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: sourceName, Namespace: sourceNs}, secret); err != nil {
+	if err := r.Reader.Get(ctx, types.NamespacedName{Name: sourceName, Namespace: sourceNs}, secret); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("Secret %s is not found from the namespace %s", sourceName, sourceNs)
 			r.Recorder.Eventf(bindInfoInstance, corev1.EventTypeNormal, "NotFound", "No Secret %s in the namespace %s", sourceName, sourceNs)
@@ -376,7 +376,7 @@ func (r *Reconciler) copyConfigmap(ctx context.Context, sourceName, targetName, 
 	}
 
 	cm := &corev1.ConfigMap{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: sourceName, Namespace: sourceNs}, cm); err != nil {
+	if err := r.Reader.Get(ctx, types.NamespacedName{Name: sourceName, Namespace: sourceNs}, cm); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("Configmap %s/%s is not found", sourceNs, sourceName)
 			r.Recorder.Eventf(bindInfoInstance, corev1.EventTypeNormal, "NotFound", "No Configmap %s in the namespace %s", sourceName, sourceNs)
@@ -478,7 +478,7 @@ func (r *Reconciler) copyRoute(ctx context.Context, route operatorv1alpha1.Route
 	}
 
 	sourceRoute := &ocproute.Route{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: route.Name, Namespace: sourceNs}, sourceRoute); err != nil {
+	if err := r.Reader.Get(ctx, types.NamespacedName{Name: route.Name, Namespace: sourceNs}, sourceRoute); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("Route %s/%s is not found", sourceNs, route.Name)
 			r.Recorder.Eventf(bindInfoInstance, corev1.EventTypeNormal, "NotFound", "No Route %s in the namespace %s", route.Name, sourceNs)
@@ -574,7 +574,7 @@ func (r *Reconciler) copyService(ctx context.Context, service operatorv1alpha1.S
 	}
 
 	sourceService := &corev1.Service{}
-	if err := r.Client.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: sourceNs}, sourceService); err != nil {
+	if err := r.Reader.Get(ctx, types.NamespacedName{Name: service.Name, Namespace: sourceNs}, sourceService); err != nil {
 		if apierrors.IsNotFound(err) {
 			klog.V(3).Infof("Route %s/%s is not found", sourceNs, service.Name)
 			r.Recorder.Eventf(bindInfoInstance, corev1.EventTypeNormal, "NotFound", "No Service %s in the namespace %s", service.Name, sourceNs)


### PR DESCRIPTION
### Context
When an object like configMap, secret watched by ODLM has an event happens, ODLM will receive this object event and trigger the OperandBindinfo reconciliation related to this Object.

For example, when ConfigMap `ibmcloud-cluster-info` is updated by IAM operator, ODLM would receive such configmap update event, and trigger OprandBindinfo `ibm-iam-bindinfo` reconciliation because ConfigMap `ibmcloud-cluster-info` contains Bindinfo related label `<ns>.ibm-iam-bindinfo/bindinfo: 'true'`.
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: ibmcloud-cluster-info
  namespace: cd-daily
  labels:
    app: auth-idp
    cd-daily.ibm-iam-bindinfo/bindinfo: 'true'
    operator.ibm.com/managedBy-opbi: original
    operator.ibm.com/watched-by-odlm: 'true'
data:
    ....
```

As an OperandBindinfo reconciliation result, ODLM will update ConfigMap `ibm-iam-bindinfo-ibmcloud-cluster-info` with the same content updated in ConfigMap `ibmcloud-cluster-info`.
```yaml
kind: ConfigMap
apiVersion: v1
metadata:
  name: ibm-iam-bindinfo-ibmcloud-cluster-info
  namespace: cd-daily
  labels:
    app: auth-idp
    cd-daily.ibm-iam-bindinfo/bindinfo: 'true'
    operator.ibm.com/managedBy-opbi: copy
    operator.ibm.com/watched-by-odlm: 'true'
data:
    .....
```

### Issue
When the ConfigMap `ibmcloud-cluster-info` was updated by IAM operator at the first time, ODLM is not able to trigger OperandBindinfo reconciliation, because the ConfigMap `ibmcloud-cluster-info` object received by ODLM via watch events does contain any labels. Subsequently, ODLM could not identify its corresponding OperandBindinfo `ibm-iam-bindinfo`.

**Which issue(s) this PR fixes:
Fixes
- https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/44061
- https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66378
- https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/44033

### Solution
When ODLM receives an object event, object event will come with minimal information like object kind, name and namespace. Based on those information, ODLM will user API reader to get the object directly from the cluster, identify its labels related to OperandBindinfo, and trigger the OperandBindinfo reconciliation.

### Test
ODLM will explicitly get the object from the cluster, to get the latest label and trigger the reconciliation
```
I0409 23:38:38.779050 1 operandbindinfo_controller.go:906] Object cd-daily/ibmcloud-cluster-info found in the cluster
I0409 23:38:38.779405 1 operandbindinfo_controller.go:100] Reconciling OperandBindInfo: cd-daily/ibm-iam-bindinfo
```

If it is a deletion event for an object, ODLM will use the object from watch event, and obtain its labels
```
I0409 23:34:04.810138 1 operandbindinfo_controller.go:901] Object cd-daily/ibm-iam-bindinfo-ibmcloud-cluster-info not found, it is a deleted object, using the cache
I0409 23:34:04.810330 1 operandbindinfo_controller.go:100] Reconciling OperandBindInfo: cd-daily/ibm-iam-bindinfo
```