### PR TITLE
[CD] Fix operand deletion inconsistency in Keycloak upgrade case

### DIFF
--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -795,11 +795,12 @@ func checkSubAnnotationsForUninstall(reqName, reqNs, opName, installMode string,
 	// 1. operator is not uninstalled AND intallMode is no-op.
 	// 2. operator is uninstalled AND  at least one other <prefix>/operatorNamespace annotation exists.
 	// 3. remaining <prefix>/request annotation's values contain the same operator name
-	// 4. remaining <prefix>/config annotation's values contain the same configName as this operator
+	// 4. currentConfigName is found AND remaining <prefix>/config annotation's values contain the same configName as this operator
+	// 5. currentConfigName is empty (not found in annotations)
 	if (!uninstallOperator && installMode == operatorv1alpha1.InstallModeNoop) ||
 		(uninstallOperator && len(opreqNsSlice) != 0) ||
 		util.Contains(operatorNameSlice, opName) ||
-		(currentConfigName != "" && util.Contains(configNameSlice, currentConfigName)) {
+		(currentConfigName != "" && util.Contains(configNameSlice, currentConfigName)) || currentConfigName == "" {
 		uninstallOperand = false
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes an issue where operands were unexpectedly deleted after upgrading from a CS pre-4.6.12 version to the latest one when Keycloak operators with shared config names were switched
Cherry-pick: https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1151

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66421

**How to test**:
1. Test image: quay.io/yuchen_shen/odlm:operand_deletion
2. **Case one**, fresh install CS 4.6.12, request `keycloak-operator`, switch the name to `keycloak-operator-v26` when all the pods for 24 are ready, and check if the keycloak CR is deleted and recreated. It should be kept.
3. **Case two**, fresh install pre-4.6.12 CS version, request `keycloak-operator`, upgrade CS to the latest SC2 version and using the test image for ODLM, and then switch the Opreq to `keycloak-operator-v26`, check if the Keycloak CR is kept as 24 one. 