### PR TITLE
[CD] Enhance Kubernetes Resource Quantity Comparisons in Templating

### DIFF
--- a/controllers/operator/manager_test.go
+++ b/controllers/operator/manager_test.go
@@ -561,7 +561,7 @@ func TestEvaluateExpression(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "GreaterThan comparison with strings",
+			name: "GreaterThan comparison with strings - true",
 			expr: &util.LogicalExpression{
 				GreaterThan: &util.ValueComparison{
 					Left:  &util.ValueSource{Literal: "xyz"},
@@ -594,7 +594,7 @@ func TestEvaluateExpression(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "LessThan comparison with strings",
+			name: "LessThan comparison with strings - true",
 			expr: &util.LogicalExpression{
 				LessThan: &util.ValueComparison{
 					Left:  &util.ValueSource{Literal: "abc"},
@@ -602,6 +602,128 @@ func TestEvaluateExpression(t *testing.T) {
 				},
 			},
 			expectedResult: true,
+			expectError:    false,
+		},
+		// Kubernetes resource quantity tests
+		{
+			name: "GreaterThan comparison with memory quantities - true",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "10Gi"},
+					Right: &util.ValueSource{Literal: "2Gi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "GreaterThan comparison with memory quantities - false",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "100Mi"},
+					Right: &util.ValueSource{Literal: "1Gi"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "LessThan comparison with memory quantities - true",
+			expr: &util.LogicalExpression{
+				LessThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "500Mi"},
+					Right: &util.ValueSource{Literal: "1Gi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "LessThan comparison with memory quantities - false",
+			expr: &util.LogicalExpression{
+				LessThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "5Gi"},
+					Right: &util.ValueSource{Literal: "2Gi"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "Equal comparison with CPU quantities",
+			expr: &util.LogicalExpression{
+				Equal: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1000m"},
+					Right: &util.ValueSource{Literal: "1"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "Equal comparison with different unit formats",
+			expr: &util.LogicalExpression{
+				Equal: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1Gi"},
+					Right: &util.ValueSource{Literal: "1024Mi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "GreaterThan comparison with CPU quantities",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "2"},
+					Right: &util.ValueSource{Literal: "1500m"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "GreaterThan comparison with mixed format units",
+			expr: &util.LogicalExpression{
+				GreaterThan: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1Mi"},
+					Right: &util.ValueSource{Literal: "1024Ki"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "Mixed resource types - comparing memory and CPU",
+			expr: &util.LogicalExpression{
+				Equal: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "100m"},
+					Right: &util.ValueSource{Literal: "100Mi"},
+				},
+			},
+			expectedResult: false,
+			expectError:    false,
+		},
+		{
+			name: "NotEqual comparison with memory quantities - true",
+			expr: &util.LogicalExpression{
+				NotEqual: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "2Gi"},
+					Right: &util.ValueSource{Literal: "1Gi"},
+				},
+			},
+			expectedResult: true,
+			expectError:    false,
+		},
+		{
+			name: "NotEqual comparison with memory quantities - false",
+			expr: &util.LogicalExpression{
+				NotEqual: &util.ValueComparison{
+					Left:  &util.ValueSource{Literal: "1Gi"},
+					Right: &util.ValueSource{Literal: "1024Mi"},
+				},
+			},
+			expectedResult: false,
 			expectError:    false,
 		},
 		{

--- a/docs/design/operand-deployment-lifecycle-manager.md
+++ b/docs/design/operand-deployment-lifecycle-manager.md
@@ -9,6 +9,11 @@
   - [OperandRegistry Spec](#operandregistry-spec)
   - [OperandConfig Spec](#operandconfig-spec)
     - [How does Operator create the individual operator CR](#how-does-operator-create-the-individual-operator-cr)
+    - [Dynamic Configuration with Templating](#dynamic-configuration-with-templating)
+      - [Value Source Types](#value-source-types)
+      - [Array Support in Templating](#array-support-in-templating)
+      - [Conditional Logic](#conditional-logic)
+      - [Conditional Templating Use Cases](#conditional-templating-use-cases)
   - [OperandRequest Spec](#operandrequest-spec)
     - [OperandRequest sample to create custom resource via OperandConfig](#operandrequest-sample-to-create-custom-resource-via-operandconfig)
     - [OperandRequest sample to create custom resource via OperandRequest](#operandrequest-sample-to-create-custom-resource-via-operandrequest)
@@ -120,90 +125,98 @@ OperandConfig supports a templating system that allows values to be dynamically 
 
 The templating system uses the `templatingValueFrom` field to reference values from ConfigMaps, Secrets, or other Kubernetes objects. When ODLM processes an OperandConfig, it resolves these references to their actual values before creating the operand resources.
 
-Example with templating for a Jenkins service port:
+**Example:** Templating a keycloak ca cert value using a ConfigMap value.
 
 ```yaml
-apiVersion: operator.ibm.com/v1alpha1
-Kind: OperandConfigs
-metadata:
-  name: example-service
-  namespace: example-service-ns
-spec:
-  services:
-  - name: jenkins
-    spec:
-      jenkins:
-        service:
-          port:
-            templatingValueFrom:
-              configMapKeyRef:
-                name: jenkins-config
-                namespace: default  # Optional, defaults to CR namespace
-                key: port
-              required: true 
+  apiVersion: operator.ibm.com/v1alpha1
+  Kind: OperandConfigs
+  metadata:
+    name: common-service
+    namespace: service-ns
+  spec:
+    services:
+    - name: keycloak-operator
+      resources:
+        - apiVersion: v1
+            data:
+              stringData:
+                ca.crt:
+                  templatingValueFrom:
+                    configMapKeyRef:
+                      key: service-ca.crt
+                      name: openshift-service-ca.crt
+                    required: true
+              type: kubernetes.io/tls
+            force: true
+            kind: Secret
+            name: cs-keycloak-tls-secret
 ```
-In this example, instead of hardcoding the port number, ODLM will look up the value from a ConfigMap named jenkins-config using the key port.
+In this example, the `ca.crt` field in the Secret is populated from a key `service-ca.crt` in a ConfigMap named `openshift-service-ca.crt`. The `templatingValueFrom` field specifies how to retrieve the value, and the `required: true` flag indicates that this value must be present for the configuration to be valid.
 
 #### Value Source Types
-ODLM supports several types of value sources that can be referenced in your OperandConfig:
 
-1. ConfigMap Reference
-Values can be retrieved from ConfigMaps. This is useful for environment-specific configuration that might change between deployments:
-  ```yaml
-  templatingValueFrom:
+ODLM supports several types of value sources that can be referenced using templatingValueFrom:
+
+1. ConfigMap Reference (`configMapKeyRef`)
+    Values can be retrieved from specific keys within ConfigMaps. This is useful for environment-specific configuration that might change between deployments.
+
+    ```yaml
+    templatingValueFrom:
     configMapKeyRef:
-      name: jenkins-config
-      namespace: operator-ns  # Optional
-      key: storage-size
-    required: true
-  ```
+      name: my-configmap        # Name of the ConfigMap
+      namespace: my-namespace  # Optional: Defaults to OperandConfig namespace
+      key: data.key            # Key within the ConfigMap's data field
+    # required: true           # Optional: Defaults to false
+    ```
 
-2. Secret Reference
-For sensitive data like passwords, tokens, or certificates, values can be securely retrieved from Secrets:
-  ```yaml
-  templatingValueFrom:
-    secretKeyRef:
-      name: jenkins-secrets
-      namespace: operator-ns  # Optional
-      key: storage-password
-    required: true
-  ```
+2. Secret Reference (`secretKeyRef`)
+    For sensitive data like passwords, API tokens, or certificates, values can be securely retrieved from specific keys within Secrets.
 
-3. Object Reference
-Values can be pulled from any Kubernetes object's fields using JSONPath notation. This is powerful for building dependencies between resources:
-  ```yaml
-  templatingValueFrom:
+    ```yaml
+    templatingValueFrom:
+      secretKeyRef:
+        name: my-secret           # Name of the Secret
+        namespace: my-namespace  # Optional: Defaults to OperandConfig namespace
+        key: data.key            # Key within the Secret's data field
+      # required: true           # Optional: Defaults to false
+    ```
+
+3. Object Reference (`objectRef`) 
+    Values can be pulled from any field within any Kubernetes object using JSONPath notation.
+
+    ```yaml
+    templatingValueFrom:
     objectRef:
-      apiVersion: v1
-      kind: PersistentVolumeClaim
-      name: jenkins-pvc
-      namespace: operator-ns  # Optional
-      path: .spec.resources.requests.storage
-    required: true 
-  ```
+      apiVersion: apps/v1
+      kind: Deployment
+      name: my-deployment
+      namespace: my-namespace  # Optional: Defaults to OperandConfig namespace
+      path: .status.replicas   # JSONPath expression to the desired field
+    # required: true           # Optional: Defaults to false
+    ```
 
-4. Default Value
-The `default` field can specify a static value or reference other objects similar to the main templating system. This serves as a fallback when the primary references are not available:
-  ```yaml
-  templatingValueFrom:
-    default:
-      required: true
+4. Default Value (`default`)
+    The `default` field can specify a static value or reference other objects similar to the main templating system. This serves as a fallback when the primary references are not available:
+    ```yaml
+    templatingValueFrom:
+      default:
+        required: true
+        configMapKeyRef:
+          name: defaults
+          key: standard-storage
       configMapKeyRef:
-        name: defaults
+        name: global-defaults
         key: standard-storage
-    configMapKeyRef:
-      name: global-defaults
-      key: standard-storage
-    secretKeyRef:
-      name: backup-config
-      key: storage-value
-    objectRef:
-      apiVersion: v1
-      kind: PersistentVolume
-      name: reference-pv
-      path: .spec.capacity.storage
-  ```
-  In this example, if none of the primary value sources (configMapKeyRef, secretKeyRef, objectRef) in the main templatingValueFrom provide a value, ODLM will try to resolve values from the default section. It will first check the static defaultValue, then try the Object, Secret, and ConfigMap references in order until it finds a value. This provides multiple layers of fallbacks for your configuration.
+      secretKeyRef:
+        name: backup-config
+        key: storage-value
+      objectRef:
+        apiVersion: v1
+        kind: PersistentVolume
+        name: reference-pv
+        path: .spec.capacity.storage
+    ```
+    In this example, if none of the primary value sources (configMapKeyRef, secretKeyRef, objectRef) in the main templatingValueFrom provide a value, ODLM will try to resolve values from the default section. It will first check the static defaultValue, then try the Object, Secret, and ConfigMap references in order until it finds a value. This provides multiple layers of fallbacks for your configuration.
 
 #### Array Support in Templating
 
@@ -211,11 +224,11 @@ ODLM's templating system also supports complex array values, allowing you to def
 
 Arrays can contain:
 
-1. **Literal values** - Simple string values directly included in the array
-2. **Map structures** - Key-value pairs for complex configuration
-3. **Reference types** - ConfigMap, Secret, and Object references
+*   **Literal values** (`literal`) - Simple static values (strings, numbers, booleans) directly included.
+*   **Map structures** (`map`) - Key-value pairs defining complex objects.
+*   **Reference types** -  Direct references using `configMapKeyRef`, `secretKeyRef`, or `objectRef`
 
-Here's an example of using arrays in a conditional template:
+**Examples:**
 
 ```yaml
 templatingValueFrom:
@@ -265,31 +278,77 @@ The resulting array preserves the structure of each item while resolving any ref
 Empty values in conditional branches are properly handled - if a condition evaluates to false and no else branch is provided, the corresponding field will be removed from the final configuration rather than being set to an empty value.
 
 #### Conditional Logic
-1. The templating system supports conditional expressions that allow you to define different values based on runtime conditions in your cluster. This enables dynamic configuration that adapts to the environment:
-  ```yaml
-  templatingValueFrom:
-    conditional:
-      expression:
-        equal:  # Other options: notEqual, greaterThan, lessThan
-          left:
-            objectRef:
-              apiVersion: v1
-              kind: ConfigMap
-              name: cluster-info
-              namespace: default
-              path: .data.environment
-          right:
-            literal: "production"
-      then:
-        literal: "50Gi"  # Value if condition is true
-      else:
-        literal: "10Gi"
-  ```
-In this example, if the ConfigMap cluster-info has an environment value of "production", the larger storage size will be used.
+The templating system in ODLM offers powerful conditional logic capabilities that allow dynamic configuration based on cluster state. 
+This enables administrators to create flexible, environment-aware configurations without manual intervention.
 
-2. For more complex scenarios, you can combine multiple conditions using logical operators:
-  ```yaml
-  templatingValueFrom:
+1. Simple Conditional Expressions
+    Basic conditional expressions evaluate a condition and provide different values based on the result:
+  
+    **Examples:**
+
+    ```yaml
+    templatingValueFrom:
+      conditional:
+        expression:
+          equal:
+            left:
+              objectRef:
+                apiVersion: v1
+                kind: ConfigMap
+                name: cluster-info
+                namespace: default
+                path: .data.environment
+            right:
+              literal: "production"
+        then:
+          literal: "50Gi"  # Value if condition is true
+        else:
+          literal: "10Gi"  # Value if condition is false
+    ```
+    This example configures storage size based on the environment value in `cluster-info` ConfigMap - using 50Gi for production environments and 10Gi for others.
+
+2. Comparison Operations
+    The templating system supports multiple comparison operators: 
+    *   **`equal`**: Checks if `left` == `right`.
+    *   **`notEqual`**: Checks if `left` != `right`.
+    *   **`greaterThan`**: Checks if `left` > `right`.
+    *   **`lessThan`**: Checks if `left` <> `right`.
+
+    The `left` and `right` operands can be static `literal` values or dynamic references (`configMapKeyRef`, `secretKeyRef`, `objectRef`).
+
+    **Examples:**
+
+    ```yaml
+    templatingValueFrom:
+      conditional:
+        expression:
+          greaterThan:
+            left:
+              objectRef:
+                apiVersion: v1
+                kind: PersistentVolumeClaim
+                name: data-pvc
+                path: .spec.resources.requests.storage
+            right:
+              literal: "10Gi"
+        then:
+          literal: "LargeVolumePolicy"
+        else:
+          literal: "StandardVolumePolicy"
+    ```
+    This example checks if the storage request of a PersistentVolumeClaim is greater than 10Gi and sets a specific volume policy accordingly.
+
+3. Advanced Expression Evaluation
+    Complex conditions can be created using logical operators (`and`, `or`, `not`). These operators take a list of sub-expressions.
+
+    - **`and`**: All sub-expressions must be true.
+    - **`or`**: At least one sub-expression must be true.
+    - **`not`**: Negates the truth value of a sub-expression.
+
+    **Examples:**
+
+    ```yaml
+    templatingValueFrom:
     conditional:
       expression:
         and:
@@ -302,21 +361,81 @@ In this example, if the ConfigMap cluster-info has an environment value of "prod
                   path: .data.environment
               right:
                 literal: "production"
-          - greaterThan:
+          - notEqual:
               left:
                 objectRef:
                   apiVersion: v1
-                  kind: PersistentVolumeClaim
-                  name: jenkins-pvc
-                  path: .status.capacity.storage
+                  kind: ConfigMap
+                  name: cluster-info
+                  path: .data.region
               right:
-                literal: "5Gi"
+                literal: "dev-region"
       then:
-        literal: "3"  # replicas value if condition is true
+        literal: "3"  # replicas value for production in non-dev regions
       else:
-        literal: "1"  # replicas value if condition is false
-  ```
-This example sets the number of replicas to 3 only if the environment is "production" AND the existing PVC capacity is greater than 5Gi.
+        literal: "1"  # replicas value for other environments
+    ```
+    This example sets the number of replicas to 3 only if the environment is "production" AND the region is not "dev-region". Otherwise, it defaults to 1 replica.
+
+4. Kubernetes resource quantities
+    The system intelligently handles resource quantity comparisons, automatically parsing Kubernetes resource notation:
+    *   **CPU**: `m` (millicores), e.g., `500m`, `1` (whole core)
+    *   **Memory**: `Ki`, `Mi`, `Gi`, `Ti`, `Pi`, `Ei` (kibibytes, mebibytes, gibibytes, etc.), e.g., `256Mi`, `4Gi`
+    *   **Storage**: Same units as Memory, often used for PersistentVolumes, e.g., `10Gi`, `1Ti`
+    This allows for direct comparison without manual conversion.
+
+    **Examples:**
+
+    ```yaml
+    templatingValueFrom:
+    conditional:
+      expression:
+        greaterThan:
+          left:
+            objectRef:
+              apiVersion: v1
+              kind: Node
+              name: worker-1
+              path: .status.allocatable.memory
+          right:
+            literal: "16Gi"
+      then:
+        literal: "8Gi"  # Higher memory limit for nodes with >16Gi
+      else:
+        literal: "4Gi"  # Lower memory limit for smaller nodes
+    ```
+    This example checks if the allocatable memory of a node is greater than 16Gi and sets a higher memory limit accordingly.
+
+5. Numeric and String Comparisons
+    The comparison operators perform type-aware comparisons based on the resolved values of the `left` and `right` operands:
+
+    *   **Numeric Comparison:** If both values can be interpreted as numbers, a numeric comparison is performed. String representations of numbers are converted.
+        - 5 > 3 evaluates to true.
+        - "5" > "3" evaluates to true (strings are converted to numbers).
+        - "10Gi" > "5Gi" evaluates to true (Kubernetes quantities are compared numerically).
+        - "500m" < "1" evaluates to true (CPU quantities are compared numerically).
+    *   **String Comparison:** If values cannot be interpreted as numbers, a lexicographical (alphabetical) string comparison is performed.
+        - "abc" < "xyz" evaluates to true.
+        - "apple" > "banana" evaluates to false.
+
+6. Use Cases
+
+    The templating system's conditional logic capabilities enable several powerful use cases that help manage complex deployment scenarios:
+
+    - **CRD Version Detection and Compatibility**
+
+      CRD Version Detection: Automatically adjust configuration fields based on the version of installed CRDs, enabling smooth upgrades and backward compatibility.
+
+    - **Version-Specific Config Handling**
+
+      Support multiple versions by detecting the operator devlopment and adjusting the CR configuration accordingly.
+
+    - **Complex Multi-Condition Logic**
+
+      Combine multiple conditions with logical operators to make sophisticated decisions about configuration settings, such as enabling or disabling features based on multiple criteria (e.g., matching operator versions, and CRD support, CRD upgrade/downgrade).
+
+
+  These examples demonstrate how conditional templating enables sophisticated, dynamic configuration that can adapt to cluster state, operator versions, and environment settings, making your deployments more resilient and reducing the need for manual configuration changes during upgrades or when deploying to different environments.
 
 ### How does Operator create the individual operator CR
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhanced the `EvaluateExpression` function to properly handle Kubernetes resource quantities during value comparisons. Values with Kubernetes resource units (like Gi, Mi, Ki, m) were being compared correctly for now.
Cherry-pick: https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1147

**Which issue(s) this PR fixes** :
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66114
 
**Examples**: 
Now correctly handles:

- Memory comparisons: "10Gi" > "2Gi"
- CPU comparisons: "2" > "1500m"
- Mixed unit comparisons: "1Gi" = "1024Mi"
- Different resource types: "100m" CPU ≠ "100Mi" memory

Test image: `quay.io/yuchen_shen/odlm:templating`