### PR TITLE
use Reader.Get to get resource in cluster

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -312,7 +312,7 @@ func (r *Reconciler) copySecret(ctx context.Context, sourceName, targetName, sou
 		if apierrors.IsAlreadyExists(err) {
 			// If already exist, update the Secret
 			existingSecret := &corev1.Secret{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingSecret); err != nil {
+			if err := r.Reader.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingSecret); err != nil {
 				return false, errors.Wrapf(err, "failed to get secret %s/%s", targetNs, targetName)
 			}
 
@@ -413,7 +413,7 @@ func (r *Reconciler) copyConfigmap(ctx context.Context, sourceName, targetName, 
 		if apierrors.IsAlreadyExists(err) {
 			// If already exist, update the ConfigMap
 			existingCm := &corev1.ConfigMap{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingCm); err != nil {
+			if err := r.Reader.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingCm); err != nil {
 				return false, errors.Wrapf(err, "failed to get ConfigMap %s/%s", targetNs, targetName)
 			}
 
@@ -518,7 +518,7 @@ func (r *Reconciler) copyRoute(ctx context.Context, route operatorv1alpha1.Route
 		if apierrors.IsAlreadyExists(err) {
 			// If already exist, update the ConfigMap
 			existingCm := &corev1.ConfigMap{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingCm); err != nil {
+			if err := r.Reader.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingCm); err != nil {
 				return false, errors.Wrapf(err, "failed to get ConfigMap %s/%s", targetNs, targetName)
 			}
 			if needUpdate := util.CompareConfigMap(cmCopy, existingCm); needUpdate {
@@ -614,7 +614,7 @@ func (r *Reconciler) copyService(ctx context.Context, service operatorv1alpha1.S
 		if apierrors.IsAlreadyExists(err) {
 			// If already exist, update the ConfigMap
 			existingCm := &corev1.ConfigMap{}
-			if err := r.Client.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingCm); err != nil {
+			if err := r.Reader.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingCm); err != nil {
 				return false, errors.Wrapf(err, "failed to get ConfigMap %s/%s", targetNs, targetName)
 			}
 			if needUpdate := util.CompareConfigMap(cmCopy, existingCm); needUpdate {


### PR DESCRIPTION
### Symptom
Some clients report IAM platform-xxx pods and usermgmt pod are restart every 2-5 hours in fresh installed environment. The `bindInfo/restartTime: <timestamp>` annotation matches the timestamp when pods are restarted. 

### Context
ODLM have a feature to watch some resources like secret, configmap, route and .... When those resource got update, ODLM will restart pods who mount those resource in their volume to trigger a reconciliation.

Then way of ODLM restart pods is adding an annotation `bindInfo/restartTime: <timestamp>` to pod deployment/statefulSet/daemonSet, and K8s will create a new pod to update this annotation.

For example, when secret `ibm-iam-bindinfo-platform-auth-secret` update, ODLM will add an annotation `bindinfo/restartTime: 2025-4-22.1359` to `usermgmt` deployment (because usermgmt pod will mount this secret in its volume), and K8s will recreate usermgmt pod.

### Issue
When there is no change in secrets/configmaps, ODLM thought it is update, and it will add annotation to pod. This would trigger the pod recreation and cause this issue

#### Evidence 
We add the following log to ODLM pod:
```
if needUpdate := util.CompareSecret(secretCopy, existingSecret); needUpdate {
	klog.Infof("########need update secret###########")
	klog.Infof("label same %v, secret label %v, existing secret label %v", equality.Semantic.DeepEqual(secretCopy.GetLabels(), existingSecret.GetLabels()), secretCopy.GetLabels(), existingSecret.GetLabels())
        klog.Infof("type same %v, secret type %v, existing secret type %v", equality.Semantic.DeepEqual(secretCopy.Type, existingSecret.Type), secretCopy.Type, existingSecret.Type)
        klog.Infof("data same %v, secret data %v, existing secret data %v", equality.Semantic.DeepEqual(secretCopy.Data, existingSecret.Data), secretCopy.Data, existingSecret.Data)
	klog.Infof("stringdata same %v, secret stringdata %v, existing secret stringdata %v", equality.Semantic.DeepEqual(secretCopy.StringData, existingSecret.StringData), secretCopy.StringData, existingSecret.StringData)
	klog.Infof("owner same %v, secret owner %v, existing secret owner %v", equality.Semantic.DeepEqual(secretCopy.GetOwnerReferences(), existingSecret.GetOwnerReferences()), secretCopy.GetOwnerReferences(), existingSecret.GetOwnerReferences())
	podRefreshment = true
	if err := r.Update(ctx, secretCopy); err != nil {
		return false, errors.Wrapf(err, "failed to update secret %s/%s", targetNs, targetName)
	}
}
```
This is what we saw in the ODLM pod log, when the restart issue happened
```
I0422 13:59:13.140681 1 operandbindinfo_controller.go:328] ########need update secret###########
I0422 13:59:13.140702 1 operandbindinfo_controller.go:329] label same false, secret label map[controller.cert-manager.io/fao:true cpfs-data.ibm-iam-bindinfo/bindinfo:true operator.ibm.com/managedBy-opbi:copy operator.ibm.com/watched-by-cert-manager: operator.ibm.com/watched-by-odlm:true], existing secret label map[]
I0422 13:59:13.140725 1 operandbindinfo_controller.go:330] type same true, secret type kubernetes.io/tls, existing secret type kubernetes.io/tls
I0422 13:59:13.141427 1 operandbindinfo_controller.go:331] data same true, secret data map[ca.crt:[45 45 45 45 45 66 69 71 73 78 32 67 69 82 84 73 70 73 67 65 84 69 45 45 45 45 45 10 77 73 73 68 66 84 67 67 65 101 50 103 65 119 73 66 65 103 73 82 65 79 52 51 79 48 50 66 88 51 97 82 72 80 117 76 74 110 101 84 86 50 119 119 68 81 89 74 75 111 90 73 104 118 99 78 65 81 69 76 66 81 65 119 10 72 68 69 97 77 66 103 71 65 49 85 69 65 120 77 82 89 51 77 116 89 50 69 116 89 50 86 121 100 71 108 109 97 87 78 104 100 71 85 119 72 104 99 78 77 106 85 119 77 122 73 50 77 84 99 49 78 84 85 52 87 104 99 78 10 77 106 99 119 77 122 73 50 77 84 99 49 78 84 85 52 87 106 65 99 77 82 111 119 71 65 89 68 86 81 81 68 69 120 70 106 99 121 49 106 89 83 49 106 90 88 74 48 97 87 90 112 89 50 70 48 90 84 67 67 65 83 73 119 10 68 81 89 74 75 111 90 73 104 118 99 78 65 81 69 66 66 81 65 68 103 103 69 80 65 68 67 67 65 81 111 67 103 103 69 66 65 79 114 97 116 107 70 52 77 57 49 120 97 49 65 104 97 121 109 66 73 80 56 103 100 122 8...
I0422 13:59:13.142635 1 operandbindinfo_controller.go:332] stringdata same true, secret stringdata map[], existing secret stringdata map[]
I0422 13:59:13.142653 1 operandbindinfo_controller.go:333] owner same true, secret owner [{operator.ibm.com/v1alpha1 OperandRequest ibm-iam-service d279eb49-b526-4cab-998f-167d9c2dcf62 <nil> <nil>}], existing secret owner [{operator.ibm.com/v1alpha1 OperandRequest ibm-iam-service d279eb49-b526-4cab-998f-167d9c2dcf62 <nil> <nil>}]
I0422 13:59:13.153181 1 operandbindinfo_controller.go:349] refresh pod with secret cpfs-data/ibm-iam-bindinfo-platform-auth-secret
```

And the timestamp in deployment matches the time when pod restart
```
kind: Deployment
apiVersion: apps/v1
metadata:
  annotations:
    bindinfo/restartTime: 2025-4-22.1359
    bindinfoRefresh/configmap: management-ingress-ibmcloud-cluster-info
    bindinfoRefresh/secret: 'management-ingress-ibmcloud-cluster-ca-cert,ibm-iam-bindinfo-platform-auth-secret'
    deployment.kubernetes.io/revision: '94'
  name: usermgmt
  uid: c48f363e-6b1f-4bc1-acb6-0f7e8e4a14aa
  creationTimestamp: '2025-04-08T14:07:57Z'
```


From the log we can see the only difference here is the label in `existingSecret` is empty. This will make ODLM thought this secret need update, and trigger a pod recreate.

### Root Cause Analysis
This is how we [get this `existingSecret`](https://github.com/IBM/operand-deployment-lifecycle-manager/blob/master/controllers/operandbindinfo/operandbindinfo_controller.go#L315) :
```
existingSecret := &corev1.Secret{}
if err := r.Client.Get(ctx, types.NamespacedName{Namespace: targetNs, Name: targetName}, existingSecret); err != nil {
	return false, errors.Wrapf(err, "failed to get secret %s/%s", targetNs, targetName)
}
```
We can see the resources got from Client.Get doesn't contain any label. Client.Get is a package from [controller-runtime](https://github.com/kubernetes-sigs/controller-runtime/blob/main/pkg/client/client.go), and the [Operator SDK](https://sdk.operatorframework.io/docs/building-operators/golang/references/client/#overview) uses controller-runtime’s Client interface. 
The Client.Get function will [get resources for caches](https://github.com/kubernetes-sigs/controller-runtime/blob/ab6131a999ca9e6ff5bf83dba70dc7751751135f/pkg/client/split.go#L45-L52), which means there could be a issue in `cache-filter` package which ODLM is using.

But that might need sometime, since we need provide a code fix quickly, we plan to use `r.Reader.Get` instead, it will returned by [Manager.GetAPIReader()](https://github.com/kubernetes-sigs/controller-runtime/blob/ab6131a999ca9e6ff5bf83dba70dc7751751135f/pkg/manager/manager.go#L84-L87) to get resource from API server directly.

### Action To Do 
Investigate the cache issue in ODLM.




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66443
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66282
