### PR TITLE
Support templating system to properly handle boolean values

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -722,6 +722,15 @@ func (m *ODLMOperator) processMapObject(ctx context.Context, key string, mapObj 
 			if err != nil {
 				return err
 			}
+
+			if valueRef == "true" {
+				finalObject[key] = true
+				continue
+			} else if valueRef == "false" {
+				finalObject[key] = false
+				continue
+			}
+
 			if valueRef != "" {
 				// Check if the returned value is a JSON array string and the field should be an array
 				if strings.HasPrefix(valueRef, "[") && strings.HasSuffix(valueRef, "]") {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -981,13 +981,11 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	// Helper function to get comparison values
 	getComparisonValues := func(left, right *util.ValueSource) (string, string, error) {
 		leftVal, err := m.GetValueFromSource(ctx, left, instanceType, instanceName, instanceNs)
-		klog.Infof("44444 leftVal: %s", leftVal)
 
 		if err != nil {
 			return "", "", err
 		}
 		rightVal, err := m.GetValueFromSource(ctx, right, instanceType, instanceName, instanceNs)
-		klog.Infof("55555 rightVal: %s", rightVal)
 
 		if err != nil {
 			return "", "", err
@@ -1025,7 +1023,6 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		if err != nil {
 			return false, err
 		}
-		klog.Infof("11111 leftVal: %s, rightVal: %s", leftVal, rightVal)
 		_, isEqual, _ := compareValues(leftVal, rightVal)
 		return isEqual, nil
 	}
@@ -1035,7 +1032,6 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		if err != nil {
 			return false, err
 		}
-		klog.Infof("22222 leftVal: %s, rightVal: %s", leftVal, rightVal)
 		_, isEqual, _ := compareValues(leftVal, rightVal)
 		return !isEqual, nil
 	}
@@ -1064,7 +1060,6 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	if len(expr.And) > 0 {
 		for _, subExpr := range expr.And {
 			result, err := m.EvaluateExpression(ctx, subExpr, instanceType, instanceName, instanceNs)
-			klog.Infof("66666 subExpr: %v, result: %v", subExpr, result)
 			if err != nil {
 				return false, err
 			}
@@ -1078,7 +1073,6 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	if len(expr.Or) > 0 {
 		for _, subExpr := range expr.Or {
 			result, err := m.EvaluateExpression(ctx, subExpr, instanceType, instanceName, instanceNs)
-			klog.Infof("77777 subExpr: %v, result: %v", subExpr, result)
 			if err != nil {
 				return false, err
 			}
@@ -1142,7 +1136,6 @@ func (m *ODLMOperator) GetValueFromSource(ctx context.Context, source *util.Valu
 		} else if val == "" && source.Required {
 			return "", errors.Errorf("Failed to get required value from source %s, retry in few second", source.ObjectRef.Name)
 		}
-		klog.Infof("33333 source.ObjectRef: %s, value: %s", source.ObjectRef.Name, val)
 		return val, nil
 	}
 
@@ -1327,6 +1320,8 @@ func (m *ODLMOperator) GetValueRefFromObject(ctx context.Context, instanceType, 
 		}
 		return "", errors.Wrapf(err, "failed to get %s %s/%s", objKind, objNs, objName)
 	}
+
+	// Comment out the following lines as we do not need to set labels and annotations for the CRD
 
 	// // Set the Value Reference label for the object
 	// m.EnsureLabel(obj, map[string]string{

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -981,10 +981,14 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	// Helper function to get comparison values
 	getComparisonValues := func(left, right *util.ValueSource) (string, string, error) {
 		leftVal, err := m.GetValueFromSource(ctx, left, instanceType, instanceName, instanceNs)
+		klog.Infof("44444 leftVal: %s", leftVal)
+
 		if err != nil {
 			return "", "", err
 		}
 		rightVal, err := m.GetValueFromSource(ctx, right, instanceType, instanceName, instanceNs)
+		klog.Infof("55555 rightVal: %s", rightVal)
+
 		if err != nil {
 			return "", "", err
 		}
@@ -1021,6 +1025,7 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		if err != nil {
 			return false, err
 		}
+		klog.Infof("11111 leftVal: %s, rightVal: %s", leftVal, rightVal)
 		_, isEqual, _ := compareValues(leftVal, rightVal)
 		return isEqual, nil
 	}
@@ -1030,6 +1035,7 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 		if err != nil {
 			return false, err
 		}
+		klog.Infof("22222 leftVal: %s, rightVal: %s", leftVal, rightVal)
 		_, isEqual, _ := compareValues(leftVal, rightVal)
 		return !isEqual, nil
 	}
@@ -1058,6 +1064,7 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	if len(expr.And) > 0 {
 		for _, subExpr := range expr.And {
 			result, err := m.EvaluateExpression(ctx, subExpr, instanceType, instanceName, instanceNs)
+			klog.Infof("66666 subExpr: %v, result: %v", subExpr, result)
 			if err != nil {
 				return false, err
 			}
@@ -1071,6 +1078,7 @@ func (m *ODLMOperator) EvaluateExpression(ctx context.Context, expr *util.Logica
 	if len(expr.Or) > 0 {
 		for _, subExpr := range expr.Or {
 			result, err := m.EvaluateExpression(ctx, subExpr, instanceType, instanceName, instanceNs)
+			klog.Infof("77777 subExpr: %v, result: %v", subExpr, result)
 			if err != nil {
 				return false, err
 			}
@@ -1134,6 +1142,7 @@ func (m *ODLMOperator) GetValueFromSource(ctx context.Context, source *util.Valu
 		} else if val == "" && source.Required {
 			return "", errors.Errorf("Failed to get required value from source %s, retry in few second", source.ObjectRef.Name)
 		}
+		klog.Infof("33333 source.ObjectRef: %s, value: %s", source.ObjectRef.Name, val)
 		return val, nil
 	}
 
@@ -1339,6 +1348,11 @@ func (m *ODLMOperator) GetValueRefFromObject(ctx context.Context, instanceType, 
 
 	sanitizedString, err := util.SanitizeObjectString(path, obj.Object)
 	if err != nil {
+		// Instead of returning an error for a missing path, log it as a warning and return empty string
+		if strings.Contains(err.Error(), "not found") {
+			klog.Warningf("Path %v from %s %s/%s was not found: %v", path, objKind, objNs, objName, err)
+			return "", nil
+		}
 		return "", errors.Wrapf(err, "failed to parse path %v from %s %s/%s", path, obj.GetKind(), obj.GetNamespace(), obj.GetName())
 	}
 

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -1328,19 +1328,19 @@ func (m *ODLMOperator) GetValueRefFromObject(ctx context.Context, instanceType, 
 		return "", errors.Wrapf(err, "failed to get %s %s/%s", objKind, objNs, objName)
 	}
 
-	// Set the Value Reference label for the object
-	m.EnsureLabel(obj, map[string]string{
-		constant.ODLMWatchedLabel: "true",
-	})
-	// Set the Value Reference Annotation for the Secret
-	m.EnsureAnnotation(obj, map[string]string{
-		constant.ODLMReferenceAnnotation: instanceType + "." + instanceNs + "." + instanceName,
-	})
-	// Update the object with the Value Reference label
-	if err := m.Update(ctx, &obj); err != nil {
-		return "", errors.Wrapf(err, "failed to update %s %s/%s", objKind, obj.GetNamespace(), obj.GetName())
-	}
-	klog.V(2).Infof("Set the Value Reference label for %s %s/%s", objKind, obj.GetNamespace(), obj.GetName())
+	// // Set the Value Reference label for the object
+	// m.EnsureLabel(obj, map[string]string{
+	// 	constant.ODLMWatchedLabel: "true",
+	// })
+	// // Set the Value Reference Annotation for the Secret
+	// m.EnsureAnnotation(obj, map[string]string{
+	// 	constant.ODLMReferenceAnnotation: instanceType + "." + instanceNs + "." + instanceName,
+	// })
+	// // Update the object with the Value Reference label
+	// if err := m.Update(ctx, &obj); err != nil {
+	// 	return "", errors.Wrapf(err, "failed to update %s %s/%s", objKind, obj.GetNamespace(), obj.GetName())
+	// }
+	// klog.V(2).Infof("Set the Value Reference label for %s %s/%s", objKind, obj.GetNamespace(), obj.GetName())
 
 	if path == "" {
 		return "", nil

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -86,6 +86,7 @@ type ValueSource struct {
 	Map      map[string]interface{} `json:"map,omitempty"` // Add this for arbitrary key-value pairs
 	Array    []ValueSource          `json:"array,omitempty"`
 	Required bool                   `json:"required,omitempty"` // Add this line to support required flag
+	Boolean  *bool                  `json:"boolean,omitempty"`  // Add boolean support
 
 	// Dynamic references
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will enhance our templating system to properly handle boolean values, allowing Keycloak CR to correctly specify boolean fields as first-class citizens rather than just as strings

**Which issue(s) this PR fixes** 
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66572

**How to test**:
1. Test images
    CS: quay.io/yuchen_shen/cs_operator:kc_warning
    ODLM: quay.io/yuchen_shen/odlm:kc_warning
2. Install CS 4.6.14 and replaced by above images
3. Request a Keycloak 26 and check the `backchannelDynamic` is under `hostname` field and no warning msg
