### PR TITLE
[CD] Support templating system to properly handle boolean values (#1162)

### DIFF
--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -86,6 +86,7 @@ type ValueSource struct {
 	Map      map[string]interface{} `json:"map,omitempty"` // Add this for arbitrary key-value pairs
 	Array    []ValueSource          `json:"array,omitempty"`
 	Required bool                   `json:"required,omitempty"` // Add this line to support required flag
+	Boolean  *bool                  `json:"boolean,omitempty"`  // Add boolean support
 
 	// Dynamic references
 	ConfigMapKeyRef *ConfigMapRef `json:"configMapKeyRef,omitempty"`


### PR DESCRIPTION
**What this PR does / why we need it**:
This change will enhance our templating system to properly handle boolean values, allowing Keycloak CR to correctly specify boolean fields as first-class citizens rather than just as strings

Cherry-pick:https://github.com/IBM/operand-deployment-lifecycle-manager/pull/1162

**Which issue(s) this PR fixes** 
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66572

**How to test**:
1. Test images
    CS: quay.io/yuchen_shen/cs_operator:kc_warning
    ODLM: quay.io/yuchen_shen/odlm:kc_warning
2. Install CS 4.6.14 and replaced by above images
3. Request a Keycloak 26 and check the `backchannelDynamic` is under `hostname` field and no warning msg
