### PR TITLE
Refactor fallback channel selection to sort by semantic version and find the first available channel

### DIFF
--- a/common/scripts/lint_go.sh
+++ b/common/scripts/lint_go.sh
@@ -15,4 +15,4 @@
 # limitations under the License.
 #
 
-GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=480s
+GOGC=25 golangci-lint run -c ./common/config/.golangci.yml --timeout=600s

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -270,10 +270,14 @@ func findCatalogFromFallbackChannels(fallbackChannels []string, fallBackChannelA
 	// sort fallback channels by semantic version
 	semverlList, semVerChannelMappings := prunedSemverChannel(fallbackChannels)
 
-	maxChannel := util.FindMaxSemver("", semverlList, semVerChannelMappings)
-	if catalogSources, ok := fallBackChannelAndCatalogMapping[maxChannel]; ok {
-		fallbackChannel = maxChannel
-		fallbackCatalog = append(fallbackCatalog, catalogSources...)
+	sort.Sort(semver.ByVersion(semverlList))
+	// find the first available channel from the sorted list in descending order
+	for i := len(semverlList) - 1; i >= 0; i-- {
+		if catalogs, ok := fallBackChannelAndCatalogMapping[semVerChannelMappings[semverlList[i]]]; ok {
+			fallbackChannel = semVerChannelMappings[semverlList[i]]
+			fallbackCatalog = catalogs
+			break
+		}
 	}
 	return fallbackChannel, fallbackCatalog
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Originally when there are multiple fallback channels defined for one operator, ODLM will only fallback to the channel with maximum semantic version.
- For example, if `stable-v1.25` and `stable-v1.22` channel does not exist for Postgres Operator, Postgres operator could not be installed from `stable` channel although it is defined in `fallbackChannels`
```yaml
    - channel: stable-v1.25
      fallbackChannels:
        - stable-v1.22
        - stable
      installPlanApproval: Automatic
      name: common-service-postgresql
      namespace: cd-daily
      packageName: cloud-native-postgresql
      scope: public
```

And we will observe following error messages
```
W0508 15:41:16.073399 1 manager.go:212] Not found PackageManifest cloud-native-postgresql in the namespace cs1 has channel stable-v1.25
E0508 15:41:16.073486 1 manager.go:219] Not found PackageManifest cloud-native-postgresql in the namespace cs1 has fallback channels [stable-v1.22 stable]
I0508 15:41:16.073515 1 manager.go:737] no catalogsource found for cloud-native-postgresql
I0508 15:41:16.073598 1 reconcile_operator.go:338] Creating the Subscription: common-service-postgresql
E0508 15:41:16.073630 1 operandrequest_controller.go:172] failed to reconcile Operators for OperandRequest cs1/example-service: the following errors occurred:
- failed to find catalogsource for subscription cs1/cloud-native-postgresql
```

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/66624

Now ODLM will iterate the entire `fallbackChannels` list, and find the first available channel sorted by semantic version in descending order.

**Test:**
1. install daily dev build
2. Replace ODLM image with `quay.io/daniel_fan/odlm:b227bfa9`
3. Update EDB catalog to only include `stable` channel
    ```yaml
    apiVersion: operators.coreos.com/v1alpha1
    kind: CatalogSource
    metadata:
      name: cloud-native-postgresql-catalog
      namespace: openshift-marketplace
    spec:
      displayName: ibm-cloud-native-postgresql
      image: 'icr.io/cpopen/ibm-cpd-cloud-native-postgresql-operator-catalog@sha256:0b46a3ec66622dd4a96d96243602a21d7a29cd854f67a876ad745ec524337a1f'
      publisher: IBM
      sourceType: grpc
      updateStrategy:
        registryPoll:
          interval: 30m0s
    ```
4. Create OperandRequest to request `common-service-postgresql`
    ```yaml
    apiVersion: operator.ibm.com/v1alpha1
    kind: OperandRequest
    metadata:
      name: example-service
    spec:
      requests:
        - operands:
            - name: common-service-postgresql
          registry: common-service
    ```
5. Verify the Postgres operator is installed from `stable` channel
    ```console
    ➜  ~ oc get subscription
    NAME                                       PACKAGE                       SOURCE                            CHANNEL
    cloud-native-postgresql                    cloud-native-postgresql       cloud-native-postgresql-catalog   stable
    ibm-common-service-operator                ibm-common-service-operator   opencloud-operators               v4.13
    operand-deployment-lifecycle-manager-app   ibm-odlm                      opencloud-operators               v4.5
    ```