### PR TITLE
Improve error handling and update to ResourceVersionChangedPredicate for OperandRequest controller

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -181,7 +181,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 
 	// Check if all csv deploy succeed
 	if requestInstance.Status.Phase != operatorv1alpha1.ClusterPhaseRunning {
-		klog.V(2).Info("Waiting for all operators and operands to be deployed successfully ...")
+		klog.Info("Waiting for all operators and operands to be deployed successfully ...")
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	}
 
@@ -406,7 +406,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Watches(&olmv1alpha1.Subscription{}, handler.EnqueueRequestsFromMapFunc(r.getSubToRequestMapper), builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject := e.ObjectOld.(*olmv1alpha1.Subscription)

--- a/controllers/operandrequest/reconcile_operator.go
+++ b/controllers/operandrequest/reconcile_operator.go
@@ -85,6 +85,7 @@ func (r *Reconciler) reconcileOperator(ctx context.Context, requestInstance *ope
 				return utilerrors.NewAggregate([]error{err, patchErr})
 			}
 			klog.Errorf("Failed to get suitable OperandRegistry %s: %v", registryKey.String(), err)
+			return utilerrors.NewAggregate([]error{err, fmt.Errorf("failed to get suitable OperandRegistry %s", registryKey.String())})
 		}
 		merr := &util.MultiErr{}
 

--- a/controllers/operandrequestnoolm/operandrequestnoolm_controller.go
+++ b/controllers/operandrequestnoolm/operandrequestnoolm_controller.go
@@ -179,7 +179,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 	//TODO update this block to check deployments and their operands instead
 	// Check if all csv deploy succeed
 	if requestInstance.Status.Phase != operatorv1alpha1.ClusterPhaseRunning {
-		klog.V(2).Info("Waiting for all operators and operands to be deployed successfully ...")
+		klog.Info("Waiting for all operators and operands to be deployed successfully ...")
 		return ctrl.Result{RequeueAfter: constant.DefaultRequeueDuration}, nil
 	}
 
@@ -351,7 +351,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.getReferenceToRequestMapper), builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject := e.ObjectOld.(*corev1.ConfigMap)

--- a/go.mod
+++ b/go.mod
@@ -19,13 +19,14 @@ require (
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/mod v0.17.0
 	k8s.io/api v0.28.2
-	k8s.io/apiextensions-apiserver v0.28.2
 	k8s.io/apimachinery v0.28.2
 	k8s.io/client-go v0.28.2
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.16.1
 )
+
+require k8s.io/apiextensions-apiserver v0.28.2 // indirect
 
 require (
 	github.com/Shopify/logrus-bugsnag v0.0.0-20240507214313-004243a594f4 // indirect


### PR DESCRIPTION
**What this PR does / why we need it**:
1. In this particular case, the `.metadata.generation` is always `1` in OperandRequest, meaning there is no `.spec` change. However, we prefer to have changes in all `.metadata`, `.spec` and `.status` to trigger the OperandRequest reconciliation. Thus, switching to use `ResourceVersionChangedPredicate`
2. Update error handling when the OperandRegistry for OperandRequest is not found, to re-queue the OperandRequest reconciliation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67381
