### PR TITLE
Correct resource label for caching and use GenerationChangedPredicate for OperandRequest reconciliation triggering

### DIFF
--- a/controllers/k8sutil/cache.go
+++ b/controllers/k8sutil/cache.go
@@ -37,7 +37,7 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 		labels.Set{constant.ODLMWatchedLabel: "true"},
 	)
 	cacheFreshLabelSelector := labels.SelectorFromSet(
-		labels.Set{constant.BindInfoRefreshLabel: "true"},
+		labels.Set{constant.BindInfoRefreshLabel: "enabled"},
 	)
 
 	watchNamespace := util.GetWatchNamespace()

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -406,7 +406,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&olmv1alpha1.Subscription{}, handler.EnqueueRequestsFromMapFunc(r.getSubToRequestMapper), builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject := e.ObjectOld.(*olmv1alpha1.Subscription)

--- a/controllers/operandrequestnoolm/operandrequestnoolm_controller.go
+++ b/controllers/operandrequestnoolm/operandrequestnoolm_controller.go
@@ -351,7 +351,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(options).
-		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+		For(&operatorv1alpha1.OperandRequest{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.getReferenceToRequestMapper), builder.WithPredicates(predicate.Funcs{
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject := e.ObjectOld.(*corev1.ConfigMap)


### PR DESCRIPTION
**What this PR does / why we need it**:
1. Replace `ResourceVersionChangedPredicate` with `GenerationChangedPredicate` for OperandRequest controller.
   - With `ResourceVersionChangedPredicate`, OperandRequest controller updates the status for OperandRequest at the end of reconciliation loop, which will updates the OperandRequest ResourceVersion as well. Thus, such updates will immediately trigger a next reconciliation.
   - With `GenerationChangedPredicate`, only OperandRequest `.spec` changes will trigger the reconciliation, to help avoiding endless reconciliation for OperandRequest.

2. Use correct label `operator.ibm.com/bindinfoRefresh: enabled` to cache deployment, statesulSet and DaemonSet.

**Which issue(s) this PR fixes**:
Fixes:

https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67485
https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/54457

**Test:**
1. image `quay.io/opencloudio/odlm:c973388a`
2. Once applying the dev image, the reconciliation on OperandRequest will stop once they are in `Running` status, instead of endless reconciliation loop.
    - Last reconciliation on `16:01:19.065721`, current time is `17:58`
      <img width="1092" height="760" alt="Screenshot 2025-08-12 at 1 57 29 PM" src="https://github.com/user-attachments/assets/ba972089-d54d-41cd-8a1a-2a261fe3ff5f" />

3. Once applying the dev image, the memory usage for ODLM is kept at low level, which is significantly lower than before
    - Before applying fix image
        <img width="1598" height="1088" alt="fbf01396-fb66-458c-8282-35e92c8a0959" src="https://github.com/user-attachments/assets/b2cbb351-b111-4cb8-8a5d-36de99b3f4c2" />
    - After applying fix image
        <img width="811" height="536" alt="Screenshot 2025-08-12 at 1 54 12 PM" src="https://github.com/user-attachments/assets/0a56d498-1e06-4a44-8ce4-08185892c2cb" />

