### PR TITLE
Bump ODLM version to 4.3.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ OPERATOR_IMAGE_NAME ?= odlm
 # Current Operator bundle image name
 BUNDLE_IMAGE_NAME ?= odlm-operator-bundle
 # Current Operator version
-OPERATOR_VERSION ?= 4.3.16
+OPERATOR_VERSION ?= 4.3.17
 
 # Kind cluster name
 KIND_CLUSTER_NAME ?= "odlm"

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -132,7 +132,7 @@ metadata:
     createdAt: "2024-09-28T19:55:35Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
-    olm.skipRange: '>=1.2.0 <4.3.16'
+    olm.skipRange: '>=1.2.0 <4.3.17'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.32.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
@@ -150,7 +150,7 @@ metadata:
     operatorframework.io/arch.ppc64le: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/os.linux: supported
-  name: operand-deployment-lifecycle-manager.v4.3.16
+  name: operand-deployment-lifecycle-manager.v4.3.17
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -875,7 +875,7 @@ spec:
   minKubeVersion: 1.19.0
   provider:
     name: IBM
-  version: 4.3.16
+  version: 4.3.17
   relatedImages:
-    - image: icr.io/cpopen/odlm:4.3.16
+    - image: icr.io/cpopen/odlm:4.3.17
       name: ODLM_IMAGE

--- a/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/config/manifests/bases/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -11,7 +11,7 @@ metadata:
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based
       API to manage the lifecycle of operands.
     nss.operator.ibm.com/managed-operators: ibm-odlm
-    olm.skipRange: '>=1.2.0 <4.3.16'
+    olm.skipRange: '>=1.2.0 <4.3.17'
     operators.openshift.io/infrastructure-features: '["disconnected"]'
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -489,6 +489,6 @@ spec:
   provider:
     name: IBM
   relatedImages:
-  - image: icr.io/cpopen/odlm:4.3.16
+  - image: icr.io/cpopen/odlm:4.3.17
     name: ODLM_IMAGE
   version: 0.0.0

--- a/version/version.go
+++ b/version/version.go
@@ -17,5 +17,5 @@
 package version
 
 var (
-	Version = "4.3.16"
+	Version = "4.3.17"
 )


### PR DESCRIPTION
What this PR does / why we need it:
Update ODLM to 4.3.17 for CS 4.6.19