### PR TITLE
CPD-Quality 57014, add default labels to cluster scoped resources

### DIFF
--- a/helm-cluster-scoped/templates/operator.ibm.com_operandbindinfos.yaml
+++ b/helm-cluster-scoped/templates/operator.ibm.com_operandbindinfos.yaml
@@ -11,6 +11,12 @@ metadata:
   name: operandbindinfos.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/templates/operator.ibm.com_operandconfigs.yaml
+++ b/helm-cluster-scoped/templates/operator.ibm.com_operandconfigs.yaml
@@ -11,6 +11,12 @@ metadata:
   name: operandconfigs.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/templates/operator.ibm.com_operandregistries.yaml
+++ b/helm-cluster-scoped/templates/operator.ibm.com_operandregistries.yaml
@@ -11,6 +11,12 @@ metadata:
   name: operandregistries.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/templates/operator.ibm.com_operandrequests.yaml
+++ b/helm-cluster-scoped/templates/operator.ibm.com_operandrequests.yaml
@@ -11,6 +11,12 @@ metadata:
   name: operandrequests.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/templates/operator.ibm.com_operatorconfigs.yaml
+++ b/helm-cluster-scoped/templates/operator.ibm.com_operatorconfigs.yaml
@@ -12,6 +12,12 @@ metadata:
   name: operatorconfigs.operator.ibm.com
   labels:
     component-id: {{ .Chart.Name }}
+    {{- with .Values.cpfs.labels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.cpfs.clusterLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   group: operator.ibm.com
   names:

--- a/helm-cluster-scoped/values.yaml
+++ b/helm-cluster-scoped/values.yaml
@@ -5,6 +5,8 @@
 cpfs:
   imageRegistryNamespaceOperator: cpopen
   imageRegistryNamespaceOperand: cpopen/cpfs
+  labels:
+  clusterLabels:
 
 # other configuration you think you might need for your operator
 # following are examples, not required:


### PR DESCRIPTION
What this PR does / why we need it: CPD BR team requires cluster scoped resources to have both addOnID and tenant operator namespace defined in all cluster resources so they can be appropriately tracked and backed up. Enabling these values allows for flexibly setting both common labels for namespace scoped and cluster scoped resources and cluster specific labels.

Which issue(s) this PR fixes:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/57014