### PR TITLE
Update rbac yaml template due to error when using variables inside of loop

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -19,9 +19,6 @@ metadata:
 {{- if .Values.global.instanceNamespace }}
   {{- $namespaces = append $namespaces .Values.global.instanceNamespace }}
 {{- end }}
-{{- if .Values.cpfs.labels }}
-  {{- $labels := .Values.cpfs.labels }}
-{{- end }}
 {{- range $i := $namespaces }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -32,10 +29,10 @@ metadata:
   labels:
     component-id: {{ $chartName }}
     {{- if .Values.cpfs.labels }}
-      {{- with $labels }}
+      {{- with .Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
-    {{- end }}
+    {{- end}}
 rules:
 - apiGroups:
   - ""
@@ -314,10 +311,10 @@ metadata:
   labels:
     component-id: {{ $chartName }}
     {{- if .Values.cpfs.labels }}
-      {{- with $labels }}
+      {{- with .Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
-    {{- end }}
+    {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -337,10 +334,10 @@ metadata:
   labels:
     component-id: {{ $chartName }}
     {{- if .Values.cpfs.labels }}
-      {{- with $labels }}
+      {{- with .Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
-    {{- end }}
+    {{- end}}
 rules:
 - apiGroups:
   - operators.coreos.com
@@ -362,10 +359,10 @@ metadata:
   labels:
     component-id: {{ $chartName}}
     {{- if .Values.cpfs.labels }}
-      {{- with $labels }}
+      {{- with .Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
-    {{- end }}
+    {{- end}}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -28,8 +28,8 @@ metadata:
   namespace: {{ $i }}
   labels:
     component-id: {{ $chartName }}
-    {{- if .Values.cpfs.labels }}
-      {{- with .Values.cpfs.labels }}
+    {{- if $.Values.cpfs.labels }}
+      {{- with $.Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
     {{- end}}
@@ -310,8 +310,8 @@ metadata:
   namespace: {{ $i }}
   labels:
     component-id: {{ $chartName }}
-    {{- if .Values.cpfs.labels }}
-      {{- with .Values.cpfs.labels }}
+    {{- if $.Values.cpfs.labels }}
+      {{- with $.Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
     {{- end}}
@@ -333,8 +333,8 @@ metadata:
   namespace: {{ $i }}
   labels:
     component-id: {{ $chartName }}
-    {{- if .Values.cpfs.labels }}
-      {{- with .Values.cpfs.labels }}
+    {{- if $.Values.cpfs.labels }}
+      {{- with $.Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
     {{- end}}
@@ -358,8 +358,8 @@ metadata:
   namespace: {{ $i }}
   labels:
     component-id: {{ $chartName}}
-    {{- if .Values.cpfs.labels }}
-      {{- with .Values.cpfs.labels }}
+    {{- if $.Values.cpfs.labels }}
+      {{- with $.Values.cpfs.labels }}
         {{- toYaml . | nindent 4 }}
       {{- end }}
     {{- end}}


### PR DESCRIPTION
**What this PR does / why we need it**: When testing the helm charts with the updated conditional labeling today, I saw a problem with the rbac.yaml. It is because of how variables are referenced from inside of a loop. This PR fixes this bug

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/67932