### PR TITLE
Updated function to truncate the label key to 63 characters before checking

### DIFF
--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -690,7 +690,9 @@ func (m *ODLMOperator) DeleteRedundantCSV(ctx context.Context, csvName, operator
 		return nil
 	}
 	// Delete the CSV if the csv does not contain label operators.coreos.com/packageName.operatorNs='' AND does not contains label olm.copiedFrom: operatorNs
-	if _, ok := csv.GetLabels()[fmt.Sprintf("operators.coreos.com/%s.%s", packageName, operatorNs)]; !ok {
+	labelKey := fmt.Sprintf("operators.coreos.com/%s.%s", packageName, operatorNs)
+	labelKey = util.GetFirstNCharacter(labelKey, 63)
+	if _, ok := csv.GetLabels()[labelKey]; !ok {
 		if _, ok := csv.Labels["olm.copiedFrom"]; !ok {
 			klog.Infof("Delete the redundant ClusterServiceVersion %s in the namespace %s", csvName, serviceNs)
 			if err := m.Client.Delete(ctx, csv); err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
Kubernetes labels have a 63 character maximum length. When the constructed label exceeds this limit, Kubernetes automatically truncates it. The function was checking for the full label name, failing to find it, and incorrectly identifying the CSV as redundant, leading to its deletion.

Updated the function to truncate the label key to 63 characters before checking

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69236


