### PR TITLE
fix: gracefully handle missing alm-examples annotation in non-OLM deployments

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -289,7 +289,11 @@ func (r *Reconciler) reconcileCRwithConfig(ctx context.Context, service *operato
 		return nil
 	}
 
-	almExamples := csv.GetAnnotations()["alm-examples"]
+	annotations := csv.GetAnnotations()
+	if annotations == nil {
+		return errors.Errorf("service %s has spec defined but CSV %s/%s has nil annotations", service.Name, csv.Namespace, csv.Name)
+	}
+	almExamples := annotations["alm-examples"]
 	if almExamples == "" {
 		return errors.Errorf("service %s has spec defined but CSV %s/%s is missing alm-examples annotation", service.Name, csv.Namespace, csv.Name)
 	}
@@ -672,7 +676,12 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 		return nil
 	}
 
-	almExamples := csv.GetAnnotations()["alm-examples"]
+	annotations := csv.GetAnnotations()
+	if annotations == nil {
+		klog.V(2).Infof("CSV %s/%s has nil annotations, skipping custom resource deletion from alm-examples", csv.Namespace, csv.Name)
+		return nil
+	}
+	almExamples := annotations["alm-examples"]
 	if almExamples == "" {
 		klog.V(2).Infof("CSV %s/%s is missing alm-examples annotation, skipping custom resource deletion from alm-examples", csv.Namespace, csv.Name)
 		return nil

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -283,7 +283,16 @@ func (r *Reconciler) reconcileCRwithConfig(ctx context.Context, service *operato
 		return nil
 	}
 
+	// If no custom resources are defined in the spec, skip alm-examples parsing
+	if len(service.Spec) == 0 {
+		klog.V(2).Infof("No custom resources defined in spec for service %s, skipping alm-examples parsing", service.Name)
+		return nil
+	}
+
 	almExamples := csv.GetAnnotations()["alm-examples"]
+	if almExamples == "" {
+		return errors.Errorf("service %s has spec defined but CSV %s/%s is missing alm-examples annotation", service.Name, csv.Namespace, csv.Name)
+	}
 
 	// Convert CR template string to slice
 	var almExampleList []interface{}
@@ -656,7 +665,19 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, csv *olmv1alph
 	if service == nil {
 		return nil
 	}
+
+	// If no custom resources are defined in the spec, skip alm-examples parsing
+	if len(service.Spec) == 0 {
+		klog.V(2).Infof("No custom resources defined in spec for service %s, skipping deletion from alm-examples", service.Name)
+		return nil
+	}
+
 	almExamples := csv.GetAnnotations()["alm-examples"]
+	if almExamples == "" {
+		klog.V(2).Infof("CSV %s/%s is missing alm-examples annotation, skipping custom resource deletion from alm-examples", csv.Namespace, csv.Name)
+		return nil
+	}
+
 	klog.V(2).Info("Delete all the custom resource from Subscription ", service.Name)
 
 	// Create a slice for crTemplates

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1282,8 +1282,8 @@ func (r *Reconciler) updateK8sJob(ctx context.Context, existingK8sRes unstructur
 
 	var existingHashedData string
 	var newHashedData string
-	if existingRes.GetAnnotations() != nil {
-		existingHashedData = existingRes.GetAnnotations()[constant.HashedData]
+	if annotations := existingRes.GetAnnotations(); annotations != nil {
+		existingHashedData = annotations[constant.HashedData]
 	}
 
 	if k8sResConfig != nil {

--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1340,6 +1340,9 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 	}
 
 	existingAnnos := existingRes.GetAnnotations()
+	if existingAnnos == nil {
+		existingAnnos = make(map[string]string)
+	}
 	existingHostHash := existingAnnos[constant.RouteHash]
 
 	if k8sResConfig != nil {

--- a/controllers/operandrequestnoolm/operandrequestnoolm_controller_test.go
+++ b/controllers/operandrequestnoolm/operandrequestnoolm_controller_test.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"sync"
 
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -159,8 +159,7 @@ var _ = Describe("OperandRequestNoOLM controller", func() {
 			}
 
 			By("Verifying getRegistryToRequestMapper works")
-			mapper := reconciler.getRegistryToRequestMapper()
-			requests := mapper(registry)
+			requests := reconciler.getRegistryToRequestMapper(ctx, registry)
 			Expect(len(requests)).To(BeNumerically(">", 0))
 		})
 
@@ -179,8 +178,7 @@ var _ = Describe("OperandRequestNoOLM controller", func() {
 			}
 
 			By("Verifying getConfigToRequestMapper works")
-			mapper := reconciler.getConfigToRequestMapper()
-			requests := mapper(config)
+			requests := reconciler.getConfigToRequestMapper(ctx, config)
 			Expect(len(requests)).To(BeNumerically(">", 0))
 		})
 
@@ -214,8 +212,7 @@ var _ = Describe("OperandRequestNoOLM controller", func() {
 			}
 
 			By("Verifying getReferenceToRequestMapper works")
-			mapper := reconciler.getReferenceToRequestMapper()
-			requests := mapper(cm)
+			requests := reconciler.getReferenceToRequestMapper(ctx, cm)
 			Expect(len(requests)).To(BeNumerically(">", 0))
 		})
 	})

--- a/controllers/operandrequestnoolm/operandrequestnoolm_suite_test.go
+++ b/controllers/operandrequestnoolm/operandrequestnoolm_suite_test.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	jaegerv1 "github.com/jaegertracing/jaeger-operator/apis/v1"
-	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	nssv1 "github.com/IBM/ibm-namespace-scope-operator/api/v1"
 	apiv1alpha1 "github.com/IBM/operand-deployment-lifecycle-manager/v4/api/v1alpha1"
@@ -61,7 +62,7 @@ func TestOperanRequestNoOLM(t *testing.T) {
 		"OperandRequest NoOLM Controller Suite")
 }
 
-var _ = BeforeSuite(func(done Done) {
+var _ = BeforeSuite(func(ctx SpecContext) {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
 	By("bootstrapping test environment")
@@ -96,8 +97,10 @@ var _ = BeforeSuite(func(done Done) {
 
 	// Start your controllers test logic
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
-		Scheme:             clientgoscheme.Scheme,
-		MetricsBindAddress: "0",
+		Scheme: clientgoscheme.Scheme,
+		Metrics: server.Options{
+			BindAddress: "0",
+		},
 	})
 	Expect(err).ToNot(HaveOccurred())
 
@@ -113,8 +116,7 @@ var _ = BeforeSuite(func(done Done) {
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
-	close(done)
-}, 600)
+})
 
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -1229,8 +1229,8 @@ func (r *Reconciler) updateK8sJob(ctx context.Context, existingK8sRes unstructur
 
 	var existingHashedData string
 	var newHashedData string
-	if existingRes.GetAnnotations() != nil {
-		existingHashedData = existingRes.GetAnnotations()[constant.HashedData]
+	if annotations := existingRes.GetAnnotations(); annotations != nil {
+		existingHashedData = annotations[constant.HashedData]
 	}
 
 	if k8sResConfig != nil {

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -1287,6 +1287,9 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 	}
 
 	existingAnnos := existingRes.GetAnnotations()
+	if existingAnnos == nil {
+		existingAnnos = make(map[string]string)
+	}
 	existingHostHash := existingAnnos[constant.RouteHash]
 
 	if k8sResConfig != nil {

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -231,7 +231,16 @@ func (r *Reconciler) reconcileCRwithConfig(ctx context.Context, service *operato
 		return nil
 	}
 
+	// If no custom resources are defined in the spec, skip alm-examples parsing
+	if len(service.Spec) == 0 {
+		klog.V(2).Infof("No custom resources defined in spec for service %s, skipping alm-examples parsing", service.Name)
+		return nil
+	}
+
 	almExamples := deployment.GetAnnotations()["alm-examples"]
+	if almExamples == "" {
+		return errors.Errorf("service %s has spec defined but deployment %s/%s is missing alm-examples annotation", service.Name, deployment.Namespace, deployment.Name)
+	}
 
 	// Convert CR template string to slice
 	var almExampleList []interface{}
@@ -604,7 +613,19 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, deployment *ap
 	if service == nil {
 		return nil
 	}
+
+	// If no custom resources are defined in the spec, skip alm-examples parsing
+	if len(service.Spec) == 0 {
+		klog.V(2).Infof("No custom resources defined in spec for service %s, skipping deletion from alm-examples", service.Name)
+		return nil
+	}
+
 	almExamples := deployment.GetAnnotations()["alm-examples"]
+	if almExamples == "" {
+		klog.V(2).Infof("Deployment %s/%s is missing alm-examples annotation, skipping custom resource deletion from alm-examples", deployment.Namespace, deployment.Name)
+		return nil
+	}
+
 	klog.V(2).Info("Delete all the custom resource from Subscription ", service.Name)
 
 	// Create a slice for crTemplates

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -237,7 +237,11 @@ func (r *Reconciler) reconcileCRwithConfig(ctx context.Context, service *operato
 		return nil
 	}
 
-	almExamples := deployment.GetAnnotations()["alm-examples"]
+	annotations := deployment.GetAnnotations()
+	if annotations == nil {
+		return errors.Errorf("service %s has spec defined but deployment %s/%s has nil annotations", service.Name, deployment.Namespace, deployment.Name)
+	}
+	almExamples := annotations["alm-examples"]
 	if almExamples == "" {
 		return errors.Errorf("service %s has spec defined but deployment %s/%s is missing alm-examples annotation", service.Name, deployment.Namespace, deployment.Name)
 	}
@@ -620,7 +624,12 @@ func (r *Reconciler) deleteAllCustomResource(ctx context.Context, deployment *ap
 		return nil
 	}
 
-	almExamples := deployment.GetAnnotations()["alm-examples"]
+	annotations := deployment.GetAnnotations()
+	if annotations == nil {
+		klog.V(2).Infof("Deployment %s/%s has nil annotations, skipping custom resource deletion from alm-examples", deployment.Namespace, deployment.Name)
+		return nil
+	}
+	almExamples := annotations["alm-examples"]
 	if almExamples == "" {
 		klog.V(2).Infof("Deployment %s/%s is missing alm-examples annotation, skipping custom resource deletion from alm-examples", deployment.Namespace, deployment.Name)
 		return nil

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -1286,11 +1286,10 @@ func (r *Reconciler) updateK8sRoute(ctx context.Context, existingK8sRes unstruct
 		return nil
 	}
 
-	existingAnnos := existingRes.GetAnnotations()
-	if existingAnnos == nil {
-		existingAnnos = make(map[string]string)
+	var existingHostHash string
+	if existingAnnos := existingRes.GetAnnotations(); existingAnnos != nil {
+		existingHostHash = existingAnnos[constant.RouteHash]
 	}
-	existingHostHash := existingAnnos[constant.RouteHash]
 
 	if k8sResConfig != nil {
 		k8sResConfigDecoded := make(map[string]interface{})

--- a/controllers/operatorchecker/operatorchecker_controller.go
+++ b/controllers/operatorchecker/operatorchecker_controller.go
@@ -119,7 +119,11 @@ func (r *Reconciler) getCSVBySubscription(ctx context.Context, subscriptionInsta
 
 	var matchCSVList = []olmv1alpha1.ClusterServiceVersion{}
 	for _, csv := range csvList.Items {
-		csvPackageName := csv.GetAnnotations()["operatorframework.io/properties"]
+		annotations := csv.GetAnnotations()
+		if annotations == nil {
+			continue
+		}
+		csvPackageName := annotations["operatorframework.io/properties"]
 		if strings.Contains(csvPackageName, subscriptionInstance.Spec.Package) {
 			matchCSVList = append(matchCSVList, csv)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a critical bug where ODLM fails to reconcile OperandRequests when operators are deployed via Helm (or any non-OLM method) that lack the `alm-examples` annotation. The fix adds proper validation and graceful handling of missing or empty annotations.

**Key Changes:**
1. **Skip alm-examples parsing when no custom resources are defined** - If `service.Spec` is empty, there's no need to parse alm-examples
2. **Add nil checks for annotations** - Validate that annotations exist before accessing them
3. **Add validation for empty alm-examples** - Return clear error messages when alm-examples is required but missing
4. **Consistent error handling** - Apply the same validation logic in both reconcile and delete operations
5. **Inline nil checks** - Simplify annotation access patterns throughout the codebase
6. **Test improvements** - Update Ginkgo to v2 and refactor test mapper methods for better compatibility

**Which issue(s) this PR fixes**:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69242

**Testing**
Apply the dev image to the cluster, and create OperandRequest requesting `common-service-cnpg`. ODLM is able to successfully reconcile OperandRequest with logs
```console
➜ oc logs operand-deployment-lifecycle-manager-6f844676f5-4nldc | grep "No custom resources defined in spec for service"
I0422 18:43:58.798310       1 reconcile_operand.go:236] No custom resources defined in spec for service common-service-cnpg, skipping alm-examples parsing
I0422 18:44:08.833381       1 reconcile_operand.go:236] No custom resources defined in spec for service common-service-cnpg, skipping alm-examples parsing
```

Here is the status of OperandRequest
```console
➜ oc get operandrequest -A
NAMESPACE   NAME                     AGE     PHASE     CREATED AT
operator    zen-ca-operand-request   4h47m   Running   2026-04-22T13:58:06Z
zen         ibm-iam-service          4h48m   Running   2026-04-22T13:57:23Z
zen         im-needs-database        4h48m   Running   2026-04-22T13:57:25Z
zen         im-needs-ui              3h47m   Running   2026-04-22T14:58:36Z
zen         zen-ca-operand-request   4h48m   Running   2026-04-22T13:57:55Z
```