### PR TITLE
refactor: use K8sHashedData constant and remove unused annotation assignment

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -1283,7 +1283,7 @@ func (r *Reconciler) updateK8sJob(ctx context.Context, existingK8sRes unstructur
 	var existingHashedData string
 	var newHashedData string
 	if annotations := existingRes.GetAnnotations(); annotations != nil {
-		existingHashedData = annotations[constant.HashedData]
+		existingHashedData = annotations[constant.K8sHashedData]
 	}
 
 	if k8sResConfig != nil {
@@ -1298,11 +1298,6 @@ func (r *Reconciler) updateK8sJob(ctx context.Context, existingK8sRes unstructur
 		templatek8sRes.SetKind(kind)
 		templatek8sRes.SetName(name)
 		templatek8sRes.SetNamespace(namespace)
-
-		if newAnnotations == nil {
-			newAnnotations = make(map[string]string)
-		}
-		newAnnotations[constant.HashedData] = newHashedData
 
 		if err := r.deleteK8sResource(ctx, existingRes, newLabels, namespace); err != nil {
 			return errors.Wrap(err, "failed to update k8s resource")

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -1230,7 +1230,7 @@ func (r *Reconciler) updateK8sJob(ctx context.Context, existingK8sRes unstructur
 	var existingHashedData string
 	var newHashedData string
 	if annotations := existingRes.GetAnnotations(); annotations != nil {
-		existingHashedData = annotations[constant.HashedData]
+		existingHashedData = annotations[constant.K8sHashedData]
 	}
 
 	if k8sResConfig != nil {
@@ -1245,11 +1245,6 @@ func (r *Reconciler) updateK8sJob(ctx context.Context, existingK8sRes unstructur
 		templatek8sRes.SetKind(kind)
 		templatek8sRes.SetName(name)
 		templatek8sRes.SetNamespace(namespace)
-
-		if newAnnotations == nil {
-			newAnnotations = make(map[string]string)
-		}
-		newAnnotations[constant.HashedData] = newHashedData
 
 		if err := r.deleteK8sResource(ctx, existingRes, newLabels, namespace); err != nil {
 			return errors.Wrap(err, "failed to update k8s resource")


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR refactors the `updateK8sJob` function to use the correct `K8sHashedData` constant and removes redundant annotation assignment code. The changes ensure consistency in how hashed data annotations are managed for Kubernetes Job resources across both the operandrequest and operandrequestnoolm controllers.

**Changes:**
- Updated annotation key reference from `constant.HashedData` to `constant.K8sHashedData` when reading existing annotations
- Removed redundant code that was manually setting the hash annotation, as `createK8sResource()` already handles this via `util.AddHashAnnotation()`

**Which issue(s) this PR fixes**:

- In first reconciliation, ODLM will create the Job with annotation with odlm prefix - left side on screenshot
- In second reconciliation, ODLM will delete the old job, and create a new job with two annotations with hash value - right side on screenshot

<img width="1684" height="401" alt="Screenshot 2026-04-24 at 14 10 15" src="https://github.com/user-attachments/assets/e6cacb6c-aab5-4b96-bda2-48f52f86c38a" />

After the code changes, ODLM will no longer delete and re-create the job as long as the hash values are the same.
```yaml
kind: Job
apiVersion: batch/v1
metadata:
  annotations:
    description: Migrates EDB PostgreSQL cluster common-service-db to IBM PG Cluster
    operator.ibm.com/operand-depoyment-lifecycle-manager.hashedData: 7f717c6e8478b0
  resourceVersion: '932481469'
```