### PR TITLE
feat: add RBAC rules for status and finalizers resources for PG migration

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -55,6 +55,18 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims/status
+  - services/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get
@@ -73,6 +85,27 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - postgresql.k8s.enterprisedb.io
+  resources:
+  - clusters/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+- apiGroups:
+  - pg.ibm.com
+  resources:
+  - clusters/finalizers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - patch
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -99,6 +132,14 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/status
+  verbs:
+  - get
+  - list
   - watch
 - apiGroups:
   - batch


### PR DESCRIPTION
**What this PR does / why we need it**:
When minimal RBAC is enabled, following permissions are necessary to explicitly call out in ODLM RBAC to address error
```
  - failed to create k8s resource: roles.rbac.authorization.k8s.io "common-service-db-pg-migration-role" is forbidden: user "system:serviceaccount:cs-operators:operand-deployment-lifecycle-manager" (groups=["system:serviceaccounts" "system:serviceaccounts:cs-operators" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["persistentvolumeclaims/status"], Verbs:["get" "list" "watch" "update" "patch" "delete"]}
{APIGroups:[""], Resources:["services/status"], Verbs:["get" "list" "watch" "update" "patch" "delete"]}
{APIGroups:["apps"], Resources:["deployments/status"], Verbs:["get" "list" "watch"]}
{APIGroups:["pg.ibm.com"], Resources:["clusters/finalizers"], Verbs:["create" "get" "list" "watch" "patch" "delete"]}
{APIGroups:["postgresql.k8s.enterprisedb.io"], Resources:["clusters/finalizers"], Verbs:["get" "list" "watch" "patch" "delete"]}
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69279