### PR TITLE
Helm OperandBindInfo deletion secret and configmap cleanup 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,7 +319,7 @@ build-test-operator-image: config-docker ## Build the operator test image.
 
 build-push-test-image: build-test-operator-image ## Build and push the operator test image.
 	@echo "Pushing the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_TEST_TAG) docker image to $(DEV_REGISTRY)..."
-	@docker push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_TEST_TAG)
+	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_TEST_TAG)
 
 ##@ Release
 

--- a/Makefile
+++ b/Makefile
@@ -307,7 +307,7 @@ docker-push:
 
 build-operator-dev-image: ## Build the operator dev image.
 	@echo "Building the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME) docker image..."
-	@docker build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) \
+	@$(CONTAINER_TOOL) build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) \
 	--build-arg VCS_REF=$(VCS_REF) --build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
 	--build-arg GOARCH=$(LOCAL_ARCH) -f Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -313,7 +313,7 @@ build-operator-dev-image: ## Build the operator dev image.
 
 build-test-operator-image: config-docker ## Build the operator test image.
 	@echo "Building the $(OPERATOR_IMAGE_NAME) docker image for testing..."
-	@docker build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_TEST_TAG) \
+	@$(CONTAINER_TOOL) build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(OPERATOR_TEST_TAG) \
 	--build-arg VCS_REF=$(VCS_REF) --build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
 	--build-arg GOARCH=$(LOCAL_ARCH) -f Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -328,13 +328,13 @@ build-push-dev-image: build-operator-dev-image  ## Build and push the operator d
 	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
 
 build-push-bundle-image: yq
-	@docker build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) .
+	@$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) .
 	@echo "Pushing the $(BUNDLE_IMAGE_NAME) docker image for $(LOCAL_ARCH)..."
-	@docker push $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
+	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
 
 build-catalog-source:
 	@opm -u docker index add --bundles $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) --tag $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
-	@docker push $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
+	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
 
 build-catalog: build-push-bundle-image build-catalog-source
 

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ build-push-test-image: build-test-operator-image ## Build and push the operator 
 
 build-push-dev-image: build-operator-dev-image  ## Build and push the operator dev images.
 	@echo "Pushing the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) docker image to $(DEV_REGISTRY)..."
-	@docker push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
+	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
 
 build-push-bundle-image: yq
 	@docker build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) .

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -739,6 +739,8 @@ func nestedBasicType(obj map[string]interface{}, fields ...string) (string, bool
 	}
 }
 
+// cleanupCopies deletes all copied secrets and configmaps when an OperandBindInfo is deleted.
+// Only resources labeled with OpbiTypeLabel="copy" are deleted, preserving original resources.
 func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operatorv1alpha1.OperandBindInfo) error {
 	secretList := &corev1.SecretList{}
 	cmList := &corev1.ConfigMapList{}

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -760,6 +760,9 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 			if err := r.Delete(ctx, &secretList.Items[i]); err != nil {
 				return err
 			}
+			klog.V(1).Infof("Deleted copied secret %s/%s", secretList.Items[i].Namespace, secretList.Items[i].Name)
+		} else {
+			klog.V(1).Infof("Skipping deletion of original secret %s/%s", secretList.Items[i].Namespace, secretList.Items[i].Name)
 		}
 	}
 
@@ -770,6 +773,9 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 			if err := r.Delete(ctx, &cmList.Items[i]); err != nil {
 				return err
 			}
+			klog.V(1).Infof("Deleted copied configmap %s/%s", cmList.Items[i].Namespace, cmList.Items[i].Name)
+		} else {
+			klog.V(1).Infof("Skipping deletion of original configmap %s/%s", cmList.Items[i].Namespace, cmList.Items[i].Name)
 		}
 	}
 	// Update finalizer to allow delete CR

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -763,9 +763,13 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 		}
 	}
 
+	// Only delete copied configmaps, not original ones
 	for i := range cmList.Items {
-		if err := r.Delete(ctx, &cmList.Items[i]); err != nil {
-			return err
+		// Check if this is a copied configmap (not an original)
+		if cmList.Items[i].Labels[constant.OpbiTypeLabel] == "copy" {
+			if err := r.Delete(ctx, &cmList.Items[i]); err != nil {
+				return err
+			}
 		}
 	}
 	// Update finalizer to allow delete CR

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -753,9 +753,13 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 		return err
 	}
 
+	// Only delete copied secrets, not original ones
 	for i := range secretList.Items {
-		if err := r.Delete(ctx, &secretList.Items[i]); err != nil {
-			return err
+		// Check if this is a copied secret (not an original)
+		if secretList.Items[i].Labels[constant.OpbiTypeLabel] == "copy" {
+			if err := r.Delete(ctx, &secretList.Items[i]); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes secrets and configmaps that were created with an operandbindinfo as a copy. Keep the original secret and configmaps. Update part of Makefile to use ```CONTAINER_TOOL``` for consistency.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69132

Testing done on a cluster installed with helm using test image for odlm:
```quay.io/jeremy_cheng/odlm:42d2b303-dirty```

