### PR TITLE
fix Race Condition in Resource Cleanup 

### DIFF
--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -739,6 +739,47 @@ func nestedBasicType(obj map[string]interface{}, fields ...string) (string, bool
 	}
 }
 
+// hasOtherManagers checks if there are other OperandBindInfos managing this resource
+// by examining labels with pattern: namespace.name/bindinfo: "true"
+func (r *Reconciler) hasOtherManagers(ctx context.Context, labels map[string]string, ownerRefs []metav1.OwnerReference, currentBindInfoNs, currentBindInfoName string) bool {
+	currentLabel := currentBindInfoNs + "." + currentBindInfoName + "/bindinfo"
+
+	// Check labels for other OperandBindInfos
+	for key, value := range labels {
+		if strings.HasSuffix(key, "/bindinfo") && value == "true" && key != currentLabel {
+			klog.V(3).Infof("Resource has other OperandBindInfo manager: %s", key)
+			return true
+		}
+	}
+
+	return false
+}
+
+// removeBindInfoReference removes the current OperandBindInfo's label from the resource
+func (r *Reconciler) removeBindInfoReference(ctx context.Context, obj client.Object, bindInfoInstance *operatorv1alpha1.OperandBindInfo) error {
+	labelKey := bindInfoInstance.Namespace + "." + bindInfoInstance.Name + "/bindinfo"
+
+	// Remove the label
+	labels := obj.GetLabels()
+	if labels != nil {
+		if _, exists := labels[labelKey]; exists {
+			klog.V(2).Infof("Removing label %s from resource %s/%s", labelKey, obj.GetNamespace(), obj.GetName())
+			delete(labels, labelKey)
+			obj.SetLabels(labels)
+		} else {
+			klog.V(2).Infof("Label %s not found on resource %s/%s", labelKey, obj.GetNamespace(), obj.GetName())
+		}
+	}
+
+	// Update the resource
+	if err := r.Update(ctx, obj); err != nil {
+		return errors.Wrapf(err, "failed to update resource %s/%s", obj.GetNamespace(), obj.GetName())
+	}
+
+	klog.V(2).Infof("Successfully removed label %s from resource %s/%s", labelKey, obj.GetNamespace(), obj.GetName())
+	return nil
+}
+
 // cleanupCopies deletes all copied secrets and configmaps when an OperandBindInfo is deleted.
 // Only resources labeled with OpbiTypeLabel="copy" are deleted, preserving original resources.
 func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operatorv1alpha1.OperandBindInfo) error {
@@ -759,12 +800,30 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 	for i := range secretList.Items {
 		// Check if this is a copied secret (not an original)
 		if secretList.Items[i].Labels[constant.OpbiTypeLabel] == "copy" {
-			if err := r.Delete(ctx, &secretList.Items[i]); err != nil {
+			secret := &secretList.Items[i]
+			// Check if there are other OperandBindInfos or OperandRequests managing this secret
+			if r.hasOtherManagers(ctx, secret.Labels, secret.GetOwnerReferences(), bindInfoInstance.Namespace, bindInfoInstance.Name) {
+				// Remove only this OperandBindInfo's label and owner reference
+				if err := r.removeBindInfoReference(ctx, secret, bindInfoInstance); err != nil {
+					klog.Errorf("Failed to remove OperandBindInfo reference from secret %s/%s: %v", secret.Namespace, secret.Name, err)
+					return err
+				}
+				klog.V(1).Infof("Removed OperandBindInfo reference from secret %s/%s (other managers exist)", secret.Namespace, secret.Name)
+			} else {
+				// No other managers, safe to delete
+				if err := r.Delete(ctx, secret); err != nil {
+					return err
+				}
+				klog.V(1).Infof("Deleted copied secret %s/%s (no other managers)", secret.Namespace, secret.Name)
+			}
+		} else if secretList.Items[i].Labels[constant.OpbiTypeLabel] == "original" {
+			// For original secrets, just remove the label (don't delete)
+			secret := &secretList.Items[i]
+			if err := r.removeBindInfoReference(ctx, secret, bindInfoInstance); err != nil {
+				klog.Errorf("Failed to remove OperandBindInfo label from original secret %s/%s: %v", secret.Namespace, secret.Name, err)
 				return err
 			}
-			klog.V(1).Infof("Deleted copied secret %s/%s", secretList.Items[i].Namespace, secretList.Items[i].Name)
-		} else {
-			klog.V(1).Infof("Skipping deletion of original secret %s/%s", secretList.Items[i].Namespace, secretList.Items[i].Name)
+			klog.V(1).Infof("Removed OperandBindInfo label from original secret %s/%s", secret.Namespace, secret.Name)
 		}
 	}
 
@@ -772,12 +831,30 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 	for i := range cmList.Items {
 		// Check if this is a copied configmap (not an original)
 		if cmList.Items[i].Labels[constant.OpbiTypeLabel] == "copy" {
-			if err := r.Delete(ctx, &cmList.Items[i]); err != nil {
+			cm := &cmList.Items[i]
+			// Check if there are other OperandBindInfos or OperandRequests managing this configmap
+			if r.hasOtherManagers(ctx, cm.Labels, cm.GetOwnerReferences(), bindInfoInstance.Namespace, bindInfoInstance.Name) {
+				// Remove only this OperandBindInfo's label and owner reference
+				if err := r.removeBindInfoReference(ctx, cm, bindInfoInstance); err != nil {
+					klog.Errorf("Failed to remove OperandBindInfo reference from configmap %s/%s: %v", cm.Namespace, cm.Name, err)
+					return err
+				}
+				klog.V(1).Infof("Removed OperandBindInfo reference from configmap %s/%s (other managers exist)", cm.Namespace, cm.Name)
+			} else {
+				// No other managers, safe to delete
+				if err := r.Delete(ctx, cm); err != nil {
+					return err
+				}
+				klog.V(1).Infof("Deleted copied configmap %s/%s (no other managers)", cm.Namespace, cm.Name)
+			}
+		} else if cmList.Items[i].Labels[constant.OpbiTypeLabel] == "original" {
+			// For original configmaps, just remove the label (don't delete)
+			cm := &cmList.Items[i]
+			if err := r.removeBindInfoReference(ctx, cm, bindInfoInstance); err != nil {
+				klog.Errorf("Failed to remove OperandBindInfo label from original configmap %s/%s: %v", cm.Namespace, cm.Name, err)
 				return err
 			}
-			klog.V(1).Infof("Deleted copied configmap %s/%s", cmList.Items[i].Namespace, cmList.Items[i].Name)
-		} else {
-			klog.V(1).Infof("Skipping deletion of original configmap %s/%s", cmList.Items[i].Namespace, cmList.Items[i].Name)
+			klog.V(1).Infof("Removed OperandBindInfo label from original configmap %s/%s", cm.Namespace, cm.Name)
 		}
 	}
 	// Update finalizer to allow delete CR

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -739,22 +739,6 @@ func nestedBasicType(obj map[string]interface{}, fields ...string) (string, bool
 	}
 }
 
-// hasOtherManagers checks if there are other OperandBindInfos managing this resource
-// by examining labels with pattern: namespace.name/bindinfo: "true"
-func (r *Reconciler) hasOtherManagers(ctx context.Context, labels map[string]string, ownerRefs []metav1.OwnerReference, currentBindInfoNs, currentBindInfoName string) bool {
-	currentLabel := currentBindInfoNs + "." + currentBindInfoName + "/bindinfo"
-
-	// Check labels for other OperandBindInfos
-	for key, value := range labels {
-		if strings.HasSuffix(key, "/bindinfo") && value == "true" && key != currentLabel {
-			klog.V(3).Infof("Resource has other OperandBindInfo manager: %s", key)
-			return true
-		}
-	}
-
-	return false
-}
-
 // removeBindInfoReference removes the current OperandBindInfo's label from the resource
 func (r *Reconciler) removeBindInfoReference(ctx context.Context, obj client.Object, bindInfoInstance *operatorv1alpha1.OperandBindInfo) error {
 	labelKey := bindInfoInstance.Namespace + "." + bindInfoInstance.Name + "/bindinfo"
@@ -801,9 +785,9 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 		// Check if this is a copied secret (not an original)
 		if secretList.Items[i].Labels[constant.OpbiTypeLabel] == "copy" {
 			secret := &secretList.Items[i]
-			// Check if there are other OperandBindInfos or OperandRequests managing this secret
-			if r.hasOtherManagers(ctx, secret.Labels, secret.GetOwnerReferences(), bindInfoInstance.Namespace, bindInfoInstance.Name) {
-				// Remove only this OperandBindInfo's label and owner reference
+			// Check if there are other OperandBindInfos managing this secret
+			if util.HasOtherManagers(secret.Labels, bindInfoInstance.Namespace, bindInfoInstance.Name) {
+				// Remove only this OperandBindInfo's label
 				if err := r.removeBindInfoReference(ctx, secret, bindInfoInstance); err != nil {
 					klog.Errorf("Failed to remove OperandBindInfo reference from secret %s/%s: %v", secret.Namespace, secret.Name, err)
 					return err
@@ -832,9 +816,9 @@ func (r *Reconciler) cleanupCopies(ctx context.Context, bindInfoInstance *operat
 		// Check if this is a copied configmap (not an original)
 		if cmList.Items[i].Labels[constant.OpbiTypeLabel] == "copy" {
 			cm := &cmList.Items[i]
-			// Check if there are other OperandBindInfos or OperandRequests managing this configmap
-			if r.hasOtherManagers(ctx, cm.Labels, cm.GetOwnerReferences(), bindInfoInstance.Namespace, bindInfoInstance.Name) {
-				// Remove only this OperandBindInfo's label and owner reference
+			// Check if there are other OperandBindInfos managing this configmap
+			if util.HasOtherManagers(cm.Labels, bindInfoInstance.Namespace, bindInfoInstance.Name) {
+				// Remove only this OperandBindInfo's label
 				if err := r.removeBindInfoReference(ctx, cm, bindInfoInstance); err != nil {
 					klog.Errorf("Failed to remove OperandBindInfo reference from configmap %s/%s: %v", cm.Namespace, cm.Name, err)
 					return err

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -603,3 +603,18 @@ func GetFirstNCharacter(str string, n int) string {
 	}
 	return str[:n]
 }
+
+// HasOtherManagers checks if there are other OperandBindInfos managing this resource
+// by examining labels with pattern: namespace.name/bindinfo: "true"
+func HasOtherManagers(labels map[string]string, currentBindInfoNs, currentBindInfoName string) bool {
+	currentLabel := currentBindInfoNs + "." + currentBindInfoName + "/bindinfo"
+
+	// Check labels for other OperandBindInfos
+	for key, value := range labels {
+		if strings.HasSuffix(key, "/bindinfo") && value == "true" && key != currentLabel {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
During upgrade scenarios (e.g., EDB → IBM PG), when multiple OperandBindInfos reference the same Secret/ConfigMap, a race condition can occur:

In most cases, uninstallation is faster than installation. As a result, the uninstallation removes the existing configmap im-datastore-edb-cm, and the subsequent installation creates a new one, so everything works as expected.

However, in this case, the installation completed faster than the uninstallation. When the installation attempted to create the ConfigMap, it already existed, so no action was taken. Shortly afterward, the uninstallation deleted the ConfigMap. This caused the IM operand pods to fail to find im-datastore-edb-cm and become stuck.

 **Solution**

Implemented cleanup logic in the `cleanupCopies()` function that:

1. Checks for other managers before deleting resources
2. Removes only the current OperandBindInfo's label if other OperandBindInfo exist
3. Deletes the resource only when no other owner remain
4. Cleans up labels on original resources

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69299
