### PR TITLE
feat: extend RBAC permissions for PG cluster status and resources

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -44,6 +44,7 @@ rules:
   - serviceaccounts
   - pods #for EDB
   - events
+  - persistentvolumeclaims
   verbs:
   - create
   - delete
@@ -57,6 +58,7 @@ rules:
   resources:
   - persistentvolumeclaims/status
   - services/status
+  - pods/status
   verbs:
   - get
   - list
@@ -93,6 +95,18 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - postgresql.k8s.enterprisedb.io
+  resources:
+  - clusters/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
   - patch
   - delete
 - apiGroups:
@@ -104,6 +118,19 @@ rules:
   - get
   - list
   - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - pg.ibm.com
+  resources:
+  - clusters/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
   - patch
   - delete
 - apiGroups:


### PR DESCRIPTION
**What this PR does / why we need it**:
Following permissions are missing from Helm Chart
```
E0430 16:39:51.570006       1 reconcile_operand.go:483] Failed to reconcile k8s resource -- Kind: Role, NamespacedName: /common-service-db-pg-migration-role with error: failed to create k8s resource: roles.rbac.authorization.k8s.io "common-service-db-pg-migration-role" is forbidden: user "system:serviceaccount:operator:operand-deployment-lifecycle-manager" (groups=["system:serviceaccounts" "system:serviceaccounts:operator" "system:authenticated"]) is attempting to grant RBAC permissions not currently held:
{APIGroups:[""], Resources:["persistentvolumeclaims"], Verbs:["get" "list" "watch" "update" "patch" "delete"]}
{APIGroups:[""], Resources:["pods/status"], Verbs:["get" "list" "watch" "update" "patch" "delete"]}
{APIGroups:["pg.ibm.com"], Resources:["clusters/finalizers"], Verbs:["update"]}
{APIGroups:["pg.ibm.com"], Resources:["clusters/status"], Verbs:["create" "get" "list" "watch" "update" "patch" "delete"]}
{APIGroups:["postgresql.k8s.enterprisedb.io"], Resources:["clusters/finalizers"], Verbs:["update"]}
{APIGroups:["postgresql.k8s.enterprisedb.io"], Resources:["clusters/status"], Verbs:["get" "list" "watch" "update" "patch" "delete"]}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69303