### PR TITLE
Auto tirgger reconciler if operandconfig stuck at creating status

### DIFF
--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -442,7 +442,20 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject := e.ObjectOld.(*operatorv1alpha1.OperandConfig)
 				newObject := e.ObjectNew.(*operatorv1alpha1.OperandConfig)
-				return !reflect.DeepEqual(oldObject.Spec, newObject.Spec)
+
+				// Trigger on Spec changes
+				if !reflect.DeepEqual(oldObject.Spec, newObject.Spec) {
+					return true
+				}
+
+				// Trigger when OperandConfig status is Creating
+				// This ensures OperandRequest reconciles when OperandConfig is stuck in Creating status
+				if newObject.Status.Phase == operatorv1alpha1.ServiceCreating {
+					klog.V(2).Infof("OperandConfig %s/%s is in Creating status, triggering OperandRequest reconciliation", newObject.Namespace, newObject.Name)
+					return true
+				}
+
+				return false
 			},
 		})).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.getReferenceToRequestMapper), builder.WithPredicates(ReferencePredicates)).

--- a/controllers/operandrequestnoolm/operandrequestnoolm_controller.go
+++ b/controllers/operandrequestnoolm/operandrequestnoolm_controller.go
@@ -388,7 +388,20 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			UpdateFunc: func(e event.UpdateEvent) bool {
 				oldObject := e.ObjectOld.(*operatorv1alpha1.OperandConfig)
 				newObject := e.ObjectNew.(*operatorv1alpha1.OperandConfig)
-				return !reflect.DeepEqual(oldObject.Spec, newObject.Spec)
+
+				// Trigger on Spec changes
+				if !reflect.DeepEqual(oldObject.Spec, newObject.Spec) {
+					return true
+				}
+
+				// Trigger when OperandConfig status is Creating
+				// This ensures OperandRequest reconciles when OperandConfig is stuck in Creating status
+				if newObject.Status.Phase == operatorv1alpha1.ServiceCreating {
+					klog.V(2).Infof("OperandConfig %s/%s is in Creating status, triggering OperandRequest (no-OLM) reconciliation", newObject.Namespace, newObject.Name)
+					return true
+				}
+
+				return false
 			},
 		})).
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.getReferenceToRequestMapper), builder.WithPredicates(ReferencePredicates)).


### PR DESCRIPTION
**What this PR does / why we need it**:

### Problem 
OperandConfig resources remained stuck in "Creating" status indefinitely when OperandRequest controllers stopped reconciling after setting status to "Ready" but before creating resources. The default 3-hour reconciliation cycle prevented timely recovery.

### Solution
Use [OperandConfig watch predicate](https://github.com/IBM/operand-deployment-lifecycle-manager/blob/master/controllers/operandrequest/operandrequest_controller.go#L437) to reconcile operandrequest if operandconfig in `creating` status

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/94887


