### PR TITLE
Add ImageCatalog Perms for IBM PG

### DIFF
--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,7 +129,7 @@ metadata:
     categories: Developer Tools, Monitoring, Logging & Tracing, Security
     certified: "false"
     containerImage: icr.io/cpopen/odlm:4.5.8
-    createdAt: "2026-03-17T17:42:34Z"
+    createdAt: "2026-05-12T20:13:27Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -830,6 +830,18 @@ spec:
               resources:
                 - packagemanifests
               verbs:
+                - get
+                - list
+                - patch
+                - update
+                - watch
+            - apiGroups:
+                - pg.ibm.com
+              resources:
+                - imagecatalogs
+              verbs:
+                - create
+                - delete
                 - get
                 - list
                 - patch

--- a/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
+++ b/bundle/manifests/operand-deployment-lifecycle-manager.clusterserviceversion.yaml
@@ -129,7 +129,7 @@ metadata:
     categories: Developer Tools, Monitoring, Logging & Tracing, Security
     certified: "false"
     containerImage: icr.io/cpopen/odlm:4.5.8
-    createdAt: "2026-05-12T20:13:27Z"
+    createdAt: "2026-05-12T21:20:18Z"
     description: The Operand Deployment Lifecycle Manager provides a Kubernetes CRD-based API to manage the lifecycle of operands.
     features.operators.openshift.io/disconnected: "true"
     features.operators.openshift.io/fips-compliant: "true"
@@ -843,10 +843,7 @@ spec:
                 - create
                 - delete
                 - get
-                - list
-                - patch
                 - update
-                - watch
             - apiGroups:
                 - route.openshift.io
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -176,6 +176,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - pg.ibm.com
+  resources:
+  - imagecatalogs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - route.openshift.io
   resources:
   - routes

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -183,10 +183,7 @@ rules:
   - create
   - delete
   - get
-  - list
-  - patch
   - update
-  - watch
 - apiGroups:
   - route.openshift.io
   resources:

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -72,7 +72,7 @@ type clusterObjects struct {
 //+kubebuilder:rbac:groups=k8s.keycloak.org,namespace="placeholder",resources=keycloaks;keycloakrealmimports,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=packages.operators.coreos.com,namespace="placeholder",resources=packagemanifests,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=operators.coreos.com,namespace="placeholder",resources=clusterserviceversions;subscriptions,verbs=create;delete;get;list;patch;update;watch
-//+kubebuilder:rbac:groups=pg.ibm.com,namespace="placeholder",resources=imagecatalogs,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=pg.ibm.com,namespace="placeholder",resources=imagecatalogs,verbs=create;delete;get;update
 
 // Reconcile reads that state of the cluster for a OperandRequest object and makes changes based on the state read
 // and what is in the OperandRequest.Spec

--- a/controllers/operandrequest/operandrequest_controller.go
+++ b/controllers/operandrequest/operandrequest_controller.go
@@ -72,6 +72,7 @@ type clusterObjects struct {
 //+kubebuilder:rbac:groups=k8s.keycloak.org,namespace="placeholder",resources=keycloaks;keycloakrealmimports,verbs=create;delete;get;list;patch;update;watch
 //+kubebuilder:rbac:groups=packages.operators.coreos.com,namespace="placeholder",resources=packagemanifests,verbs=get;list;patch;update;watch
 //+kubebuilder:rbac:groups=operators.coreos.com,namespace="placeholder",resources=clusterserviceversions;subscriptions,verbs=create;delete;get;list;patch;update;watch
+//+kubebuilder:rbac:groups=pg.ibm.com,namespace="placeholder",resources=imagecatalogs,verbs=create;delete;get;list;patch;update;watch
 
 // Reconcile reads that state of the cluster for a OperandRequest object and makes changes based on the state read
 // and what is in the OperandRequest.Spec

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -141,10 +141,7 @@ rules:
   - create
   - delete
   - get
-  - list
-  - patch
   - update
-  - watch
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -134,7 +134,7 @@ rules:
   - patch
   - delete
 - apiGroups:
-  - postgresql.cnpg.io
+  - pg.ibm.com
   resources:
   - imagecatalogs
   verbs:

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -134,6 +134,18 @@ rules:
   - patch
   - delete
 - apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - imagecatalogs
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - roles


### PR DESCRIPTION
**What this PR does / why we need it**:
Implements automatic ImageCatalog resource creation for the `IBM-PG` operand, enabling the `IBM-PG-DB` IBM PostgreSQL Cluster CR to reference images directly from an ImageCatalog instead of having the CS operator update image references.

**Which issue(s) this PR fixes**:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69331

