### PR TITLE
Optimize ODLM controller caching and resource watching

### DIFF
--- a/controllers/k8sutil/cache.go
+++ b/controllers/k8sutil/cache.go
@@ -40,9 +40,6 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 	cacheFreshLabelSelector := labels.SelectorFromSet(
 		labels.Set{constant.BindInfoRefreshLabel: "enabled"},
 	)
-	cacheOpreqLabelSelector := labels.SelectorFromSet(
-		labels.Set{constant.OpreqLabel: "true"},
-	)
 
 	watchNamespace := util.GetWatchNamespace()
 	watchNamespaces := strings.Split(watchNamespace, ",")
@@ -72,8 +69,8 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 		&appsv1.Deployment{}:                 {Label: cacheFreshLabelSelector},
 		&appsv1.DaemonSet{}:                  {Label: cacheFreshLabelSelector},
 		&appsv1.StatefulSet{}:                {Label: cacheFreshLabelSelector},
-		&olmv1alpha1.ClusterServiceVersion{}: {},                               // Cache is needed because the action for deleting the ODLM-managed CSVs
-		&olmv1alpha1.Subscription{}:          {Label: cacheOpreqLabelSelector}, // Cache only ODLM-managed subscriptions
+		&olmv1alpha1.ClusterServiceVersion{}: {}, // Cache is needed because the action for deleting CSVs
+		&olmv1alpha1.Subscription{}:          {}, // Cache all subscriptions for any labeled and unlabeled subscriptions
 	}
 
 	// set cache options

--- a/controllers/k8sutil/cache.go
+++ b/controllers/k8sutil/cache.go
@@ -19,6 +19,7 @@ package k8sutil
 import (
 	"strings"
 
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -38,6 +39,9 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 	)
 	cacheFreshLabelSelector := labels.SelectorFromSet(
 		labels.Set{constant.BindInfoRefreshLabel: "enabled"},
+	)
+	cacheOpreqLabelSelector := labels.SelectorFromSet(
+		labels.Set{constant.OpreqLabel: "true"},
 	)
 
 	watchNamespace := util.GetWatchNamespace()
@@ -63,11 +67,13 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 	// set byObject to watch the resources
 	// the cache will watch the resources with the label selector
 	cacheByObject := map[client.Object]cache.ByObject{
-		&corev1.Secret{}:      {Label: cacheWatchedLabelSelector},
-		&corev1.ConfigMap{}:   {Label: cacheWatchedLabelSelector},
-		&appsv1.Deployment{}:  {Label: cacheFreshLabelSelector},
-		&appsv1.DaemonSet{}:   {Label: cacheFreshLabelSelector},
-		&appsv1.StatefulSet{}: {Label: cacheFreshLabelSelector},
+		&corev1.Secret{}:                     {Label: cacheWatchedLabelSelector},
+		&corev1.ConfigMap{}:                  {Label: cacheWatchedLabelSelector},
+		&appsv1.Deployment{}:                 {Label: cacheFreshLabelSelector},
+		&appsv1.DaemonSet{}:                  {Label: cacheFreshLabelSelector},
+		&appsv1.StatefulSet{}:                {Label: cacheFreshLabelSelector},
+		&olmv1alpha1.ClusterServiceVersion{}: {},                               // Cache is needed because the action for deleting the ODLM-managed CSVs
+		&olmv1alpha1.Subscription{}:          {Label: cacheOpreqLabelSelector}, // Cache only ODLM-managed subscriptions
 	}
 
 	// set cache options

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -1158,13 +1158,22 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			return hasOpbiLabel
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			labels := e.ObjectNew.GetLabels()
-			if labels == nil {
-				return false
+			// Check if either old or new object has the ODLM bindinfo label
+			// This ensures reconciliation runs when the label is removed
+			newLabels := e.ObjectNew.GetLabels()
+			oldLabels := e.ObjectOld.GetLabels()
+
+			if newLabels == nil {
+				newLabels = make(map[string]string)
 			}
-			// Only watch resources with ODLM bindinfo label
-			_, hasOpbiLabel := labels[constant.OpbiTypeLabel]
-			return hasOpbiLabel
+			if oldLabels == nil {
+				oldLabels = make(map[string]string)
+			}
+
+			_, hasOpbiLabelNew := newLabels[constant.OpbiTypeLabel]
+			_, hasOpbiLabelOld := oldLabels[constant.OpbiTypeLabel]
+
+			return hasOpbiLabelNew || hasOpbiLabelOld
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
 			labels := e.Object.GetLabels()

--- a/controllers/operandbindinfo/operandbindinfo_controller.go
+++ b/controllers/operandbindinfo/operandbindinfo_controller.go
@@ -1145,15 +1145,35 @@ func (r *Reconciler) refreshPodsFromDaemonSet(ns, name, resourceType string) err
 
 // SetupWithManager adds OperandBindInfo controller to the manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Only watch Secrets and ConfigMaps that have the ODLM label
+	// This prevents caching all Secrets/ConfigMaps in watched namespaces
 	bindablePredicates := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return true
+			labels := e.Object.GetLabels()
+			if labels == nil {
+				return false
+			}
+			// Only watch resources with ODLM bindinfo label
+			_, hasOpbiLabel := labels[constant.OpbiTypeLabel]
+			return hasOpbiLabel
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return true
+			labels := e.ObjectNew.GetLabels()
+			if labels == nil {
+				return false
+			}
+			// Only watch resources with ODLM bindinfo label
+			_, hasOpbiLabel := labels[constant.OpbiTypeLabel]
+			return hasOpbiLabel
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return true
+			labels := e.Object.GetLabels()
+			if labels == nil {
+				return false
+			}
+			// Only watch resources with ODLM bindinfo label
+			_, hasOpbiLabel := labels[constant.OpbiTypeLabel]
+			return hasOpbiLabel
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR optimizes the ODLM controller's caching and watching behavior to improve performance and reduce memory consumption. It makes two key changes:

1. **Cache Optimization**: Adds resources to the cache configuration:
   - ClusterServiceVersion resources are cached to support deletion actions
   - Subscription resources are cached to handle both labeled and unlabeled resources

2. **Predicate Filtering**: Implements label-based filtering for Secret and ConfigMap watches in the OperandBindInfo controller. Instead of watching all Secrets and ConfigMaps in watched namespaces, the controller now only watches resources that have the ODLM bindinfo label (`constant.OpbiTypeLabel`). This significantly reduces the number of cached resources and prevents unnecessary reconciliation triggers.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.ibm.com/PrivateCloud-analytics/CPD-Quality/issues/98796

**Verification**:

Memory usage after applying this fix is within acceptable limits:

```bash
$ oc adm top pod operand-deployment-lifecycle-manager-54bd6f8f6f-d8dvv -n operator-ns
NAME                                                    CPU(cores)   MEMORY(bytes)   
operand-deployment-lifecycle-manager-54bd6f8f6f-d8dvv   78m          115Mi
```

The ODLM pod is running with 115Mi memory usage, which is well below the typical memory limits, confirming that the optimization successfully reduces memory consumption.