### PR TITLE
Remove olm api from ODLM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 endif
 
 # Default image repo
-QUAY_REGISTRY ?= quay.io/opencloudio
+QUAY_REGISTRY ?= quay.io/yuchen_li1
 ICR_REIGSTRY ?= icr.io/cpopen
 
 ifeq ($(BUILD_LOCALLY),0)
@@ -97,9 +97,9 @@ else
 DEV_REGISTRY := ${QUAY_REGISTRY}
 endif
 
-RELEASE_IMAGE ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
-RELEASE_IMAGE_ARCH ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
-LOCAL_ARCH_IMAGE ?= $(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
+RELEASE_IMAGE ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf
+RELEASE_IMAGE_ARCH ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):cncf
+LOCAL_ARCH_IMAGE ?= $(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):cncf
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= odlm
@@ -307,7 +307,7 @@ docker-push:
 
 build-operator-dev-image: ## Build the operator dev image.
 	@echo "Building the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME) docker image..."
-	@$(CONTAINER_TOOL) build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) \
+	@$(CONTAINER_TOOL) build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf \
 	--build-arg VCS_REF=$(VCS_REF) --build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
 	--build-arg GOARCH=$(LOCAL_ARCH) -f Dockerfile .
 
@@ -324,25 +324,25 @@ build-push-test-image: build-test-operator-image ## Build and push the operator 
 ##@ Release
 
 build-push-dev-image: build-operator-dev-image  ## Build and push the operator dev images.
-	@echo "Pushing the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) docker image to $(DEV_REGISTRY)..."
-	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
+	@echo "Pushing the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf docker image to $(DEV_REGISTRY)..."
+	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf
 
 build-push-bundle-image: yq
-	@$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) .
+	@$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf .
 	@echo "Pushing the $(BUNDLE_IMAGE_NAME) docker image for $(LOCAL_ARCH)..."
-	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
+	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf
 
 build-catalog-source:
-	@opm -u docker index add --bundles $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) --tag $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
-	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
+	@opm -u docker index add --bundles $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf --tag $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:cncf
+	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:cncf
 
 build-catalog: build-push-bundle-image build-catalog-source
 
 multiarch-image: config-docker ## Generate multiarch images for operator image.
-	@MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(DOCKER_REGISTRY) $(OPERATOR_IMAGE_NAME) $(BUILD_VERSION) $(RELEASE_VERSION)
+	@MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(DOCKER_REGISTRY) $(OPERATOR_IMAGE_NAME) cncf $(RELEASE_VERSION)
 	
 run-bundle:
-	$(OPERATOR_SDK) run bundle $(QUAY_REGISTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) --install-mode OwnNamespace
+	$(OPERATOR_SDK) run bundle $(QUAY_REGISTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf --install-mode OwnNamespace
 
 cleanup-bundle:
 	$(OPERATOR_SDK) cleanup ibm-odlm

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,9 @@ else
 DEV_REGISTRY := ${QUAY_REGISTRY}
 endif
 
-RELEASE_IMAGE ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf
-RELEASE_IMAGE_ARCH ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):cncf
-LOCAL_ARCH_IMAGE ?= $(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):cncf
+RELEASE_IMAGE ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
+RELEASE_IMAGE_ARCH ?= $(DOCKER_REGISTRY)/$(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
+LOCAL_ARCH_IMAGE ?= $(OPERATOR_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
 
 # Current Operator image name
 OPERATOR_IMAGE_NAME ?= odlm
@@ -307,7 +307,7 @@ docker-push:
 
 build-operator-dev-image: ## Build the operator dev image.
 	@echo "Building the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME) docker image..."
-	@$(CONTAINER_TOOL) build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf \
+	@$(CONTAINER_TOOL) build -t $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) \
 	--build-arg VCS_REF=$(VCS_REF) --build-arg RELEASE_VERSION=$(RELEASE_VERSION) \
 	--build-arg GOARCH=$(LOCAL_ARCH) -f Dockerfile .
 
@@ -324,25 +324,25 @@ build-push-test-image: build-test-operator-image ## Build and push the operator 
 ##@ Release
 
 build-push-dev-image: build-operator-dev-image  ## Build and push the operator dev images.
-	@echo "Pushing the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf docker image to $(DEV_REGISTRY)..."
-	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):cncf
+	@echo "Pushing the $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION) docker image to $(DEV_REGISTRY)..."
+	@$(CONTAINER_TOOL) push $(DEV_REGISTRY)/$(OPERATOR_IMAGE_NAME):$(BUILD_VERSION)
 
 build-push-bundle-image: yq
-	@$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf .
+	@$(CONTAINER_TOOL) build -f bundle.Dockerfile -t $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) .
 	@echo "Pushing the $(BUNDLE_IMAGE_NAME) docker image for $(LOCAL_ARCH)..."
-	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf
+	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION)
 
 build-catalog-source:
-	@opm -u docker index add --bundles $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf --tag $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:cncf
-	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:cncf
+	@opm -u docker index add --bundles $(ICR_REIGSTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) --tag $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
+	@$(CONTAINER_TOOL) push $(ICR_REIGSTRY)/$(OPERATOR_IMAGE_NAME)-catalog:$(BUILD_VERSION)
 
 build-catalog: build-push-bundle-image build-catalog-source
 
 multiarch-image: config-docker ## Generate multiarch images for operator image.
-	@MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(DOCKER_REGISTRY) $(OPERATOR_IMAGE_NAME) cncf $(RELEASE_VERSION)
+	@MAX_PULLING_RETRY=20 RETRY_INTERVAL=30 common/scripts/multiarch_image.sh $(DOCKER_REGISTRY) $(OPERATOR_IMAGE_NAME) $(BUILD_VERSION) $(RELEASE_VERSION)
 	
 run-bundle:
-	$(OPERATOR_SDK) run bundle $(QUAY_REGISTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):cncf --install-mode OwnNamespace
+	$(OPERATOR_SDK) run bundle $(QUAY_REGISTRY)/$(BUNDLE_IMAGE_NAME)-$(LOCAL_ARCH):$(BUILD_VERSION) --install-mode OwnNamespace
 
 cleanup-bundle:
 	$(OPERATOR_SDK) cleanup ibm-odlm

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,7 @@ endif
 endif
 
 # Default image repo
-QUAY_REGISTRY ?= quay.io/yuchen_li1
+QUAY_REGISTRY ?= quay.io/opencloudio
 ICR_REIGSTRY ?= icr.io/cpopen
 
 ifeq ($(BUILD_LOCALLY),0)

--- a/controllers/k8sutil/cache.go
+++ b/controllers/k8sutil/cache.go
@@ -19,7 +19,6 @@ package k8sutil
 import (
 	"strings"
 
-	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -64,13 +63,13 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 	// set byObject to watch the resources
 	// the cache will watch the resources with the label selector
 	cacheByObject := map[client.Object]cache.ByObject{
-		&corev1.Secret{}:                     {Label: cacheWatchedLabelSelector},
-		&corev1.ConfigMap{}:                  {Label: cacheWatchedLabelSelector},
-		&appsv1.Deployment{}:                 {Label: cacheFreshLabelSelector},
-		&appsv1.DaemonSet{}:                  {Label: cacheFreshLabelSelector},
-		&appsv1.StatefulSet{}:                {Label: cacheFreshLabelSelector},
-		&olmv1alpha1.ClusterServiceVersion{}: {}, // Cache is needed because the action for deleting CSVs
-		&olmv1alpha1.Subscription{}:          {}, // Cache all subscriptions for any labeled and unlabeled subscriptions
+		&corev1.Secret{}:      {Label: cacheWatchedLabelSelector},
+		&corev1.ConfigMap{}:   {Label: cacheWatchedLabelSelector},
+		&appsv1.Deployment{}:  {Label: cacheFreshLabelSelector},
+		&appsv1.DaemonSet{}:   {Label: cacheFreshLabelSelector},
+		&appsv1.StatefulSet{}: {Label: cacheFreshLabelSelector},
+		// &olmv1alpha1.ClusterServiceVersion{}: {}, // Cache is needed because the action for deleting CSVs
+		// &olmv1alpha1.Subscription{}:          {}, // Cache all subscriptions for any labeled and unlabeled subscriptions
 	}
 
 	// set cache options

--- a/controllers/k8sutil/cache.go
+++ b/controllers/k8sutil/cache.go
@@ -19,9 +19,11 @@ package k8sutil
 import (
 	"strings"
 
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/rest"
 	"k8s.io/klog"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -31,7 +33,7 @@ import (
 	"github.com/IBM/operand-deployment-lifecycle-manager/v4/controllers/util"
 )
 
-func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
+func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options, config *rest.Config) ctrl.Options {
 
 	cacheWatchedLabelSelector := labels.SelectorFromSet(
 		labels.Set{constant.ODLMWatchedLabel: "true"},
@@ -68,8 +70,12 @@ func NewODLMCache(isolatedModeEnable bool, opts ctrl.Options) ctrl.Options {
 		&appsv1.Deployment{}:  {Label: cacheFreshLabelSelector},
 		&appsv1.DaemonSet{}:   {Label: cacheFreshLabelSelector},
 		&appsv1.StatefulSet{}: {Label: cacheFreshLabelSelector},
-		// &olmv1alpha1.ClusterServiceVersion{}: {}, // Cache is needed because the action for deleting CSVs
-		// &olmv1alpha1.Subscription{}:          {}, // Cache all subscriptions for any labeled and unlabeled subscriptions
+	}
+
+	// Only cache OLM resources if OLM API exists in the cluster
+	if util.IsOLMInstalled(config) {
+		cacheByObject[&olmv1alpha1.ClusterServiceVersion{}] = cache.ByObject{} // Cache is needed because the action for deleting CSVs
+		cacheByObject[&olmv1alpha1.Subscription{}] = cache.ByObject{}          // Cache all subscriptions for any labeled and unlabeled subscriptions
 	}
 
 	// set cache options

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/mohae/deepcopy"
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -184,48 +185,82 @@ func (r *Reconciler) updateStatus(ctx context.Context, instance *operatorv1alpha
 			continue
 		}
 
-		// Looking for the CSV
-		namespace := r.GetOperatorNamespace(op.InstallMode, op.Namespace)
-		sub, err := r.GetSubscription(ctx, op.Name, namespace, registryInstance.Namespace, op.PackageName)
+		var almExamples string
+		var sub *olmv1alpha1.Subscription
 
-		if sub == nil && err == nil {
-			klog.V(3).Infof("There is no Subscription %s or %s in the namespace %s", op.Name, op.PackageName, namespace)
-			if len(merr.Errors) != 0 {
-				return merr
+		if no_olm := util.GetNoOLM(); no_olm != "true" {
+			// Looking for the CSV
+			namespace := r.GetOperatorNamespace(op.InstallMode, op.Namespace)
+			sub, err := r.GetSubscription(ctx, op.Name, namespace, registryInstance.Namespace, op.PackageName)
+
+			if sub == nil && err == nil {
+				klog.V(3).Infof("There is no Subscription %s or %s in the namespace %s", op.Name, op.PackageName, namespace)
+				if len(merr.Errors) != 0 {
+					return merr
+				}
+				continue
 			}
-			continue
-		}
 
-		if err != nil {
-			return errors.Wrapf(err, "failed to get Subscription %s or %s in the namespace %s", op.Name, op.PackageName, namespace)
-		}
-
-		if _, ok := sub.Labels[constant.OpreqLabel]; !ok {
-			// Subscription existing and not managed by OperandRequest controller
-			klog.V(1).Infof("Subscription %s in the namespace %s isn't created by ODLM", sub.Name, sub.Namespace)
-		}
-
-		csv, err := r.GetClusterServiceVersion(ctx, sub)
-
-		if err != nil {
-			return errors.Wrapf(err, "failed to get ClusterServiceVersion for the Subscription %s/%s", namespace, sub.Name)
-		}
-
-		if csv == nil {
-			klog.Warningf("ClusterServiceVersion for the Subscription %s/%s doesn't exist, retry...", namespace, sub.Name)
-			if len(merr.Errors) != 0 {
-				return merr
+			if err != nil {
+				return errors.Wrapf(err, "failed to get Subscription %s or %s in the namespace %s", op.Name, op.PackageName, namespace)
 			}
-			continue
-		}
 
-		almExamples := csv.ObjectMeta.Annotations["alm-examples"]
-		if almExamples == "" {
-			klog.Warningf("Notfound alm-examples in the ClusterServiceVersion %s/%s", csv.Namespace, csv.Name)
-			if len(merr.Errors) != 0 {
-				return merr
+			if _, ok := sub.Labels[constant.OpreqLabel]; !ok {
+				// Subscription existing and not managed by OperandRequest controller
+				klog.V(1).Infof("Subscription %s in the namespace %s isn't created by ODLM", sub.Name, sub.Namespace)
 			}
-			continue
+
+			csv, err := r.GetClusterServiceVersion(ctx, sub)
+
+			if err != nil {
+				return errors.Wrapf(err, "failed to get ClusterServiceVersion for the Subscription %s/%s", namespace, sub.Name)
+			}
+
+			if csv == nil {
+				klog.Warningf("ClusterServiceVersion for the Subscription %s/%s doesn't exist, retry...", namespace, sub.Name)
+				if len(merr.Errors) != 0 {
+					return merr
+				}
+				continue
+			}
+
+			almExamples = csv.ObjectMeta.Annotations["alm-examples"]
+			if almExamples == "" {
+				klog.Warningf("Notfound alm-examples in the ClusterServiceVersion %s/%s", csv.Namespace, csv.Name)
+				if len(merr.Errors) != 0 {
+					return merr
+				}
+				continue
+			}
+		} else {
+			// Get deployment for no-OLM mode
+			namespace := r.GetOperatorNamespace(op.InstallMode, op.Namespace)
+			deploymentList, err := r.GetDeploymentListFromPackage(ctx, op.PackageName, namespace)
+			if err != nil {
+				merr.Add(err)
+				if len(merr.Errors) != 0 {
+					return merr
+				}
+				continue
+			}
+
+			if len(deploymentList) == 0 || deploymentList[0] == nil {
+				klog.Warningf("Deployment for %s in the namespace %s is not ready yet or not exist, retry", op.Name, namespace)
+				if len(merr.Errors) != 0 {
+					return merr
+				}
+				continue
+			}
+
+			deployment := deploymentList[0]
+			almExamples = deployment.ObjectMeta.Annotations["alm-examples"]
+			if almExamples == "" {
+				klog.Warningf("Notfound alm-examples in the Deployment %s/%s", deployment.Namespace, deployment.Name)
+				if len(merr.Errors) != 0 {
+					return merr
+				}
+				continue
+			}
 		}
 
 		var crTemplates []interface{}

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -99,7 +99,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, instance *operatorv1alpha1.OperandConfig) error {
-	klog.Info("Updating OperandConfig status")
 	// Create an empty ServiceStatus map
 	klog.V(3).Info("Initializing OperandConfig status")
 

--- a/controllers/operandconfig/operandconfig_controller.go
+++ b/controllers/operandconfig/operandconfig_controller.go
@@ -99,6 +99,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Re
 }
 
 func (r *Reconciler) updateStatus(ctx context.Context, instance *operatorv1alpha1.OperandConfig) error {
+	klog.Info("Updating OperandConfig status")
 	// Create an empty ServiceStatus map
 	klog.V(3).Info("Initializing OperandConfig status")
 

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -437,13 +437,13 @@ func (m *ODLMOperator) ListOperandRequestsByConfig(ctx context.Context, key type
 func (m *ODLMOperator) GetSubscription(ctx context.Context, name, operatorNs, servicesNs, packageName string) (*olmv1alpha1.Subscription, error) {
 	klog.V(3).Infof("Fetch Subscription %s in operatorNamespace %s and servicesNamespace %s", name, operatorNs, servicesNs)
 
+	// might break helm chart on Opneshift ENV
 	no_olm := os.Getenv("NO_OLM")
 	klog.Infof("NO_OLM: %s", no_olm)
 	if no_olm == "true" {
 		klog.Info("No subscription, this is NO_OLM deployment")
 		return nil, nil
 	}
-	klog.Infof("NO_OLM: %s", no_olm)
 
 	tenantScope := make(map[string]struct{})
 	for _, ns := range []string{operatorNs, servicesNs} {

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -437,11 +436,9 @@ func (m *ODLMOperator) ListOperandRequestsByConfig(ctx context.Context, key type
 func (m *ODLMOperator) GetSubscription(ctx context.Context, name, operatorNs, servicesNs, packageName string) (*olmv1alpha1.Subscription, error) {
 	klog.V(3).Infof("Fetch Subscription %s in operatorNamespace %s and servicesNamespace %s", name, operatorNs, servicesNs)
 
-	// might break helm chart on Opneshift ENV
-	no_olm := os.Getenv("NO_OLM")
-	klog.Infof("NO_OLM: %s", no_olm)
-	if no_olm == "true" {
-		klog.Info("No subscription, this is NO_OLM deployment")
+	// Check if OLM is installed in the cluster
+	if !util.IsOLMInstalled(m.Config) {
+		klog.Info("No subscription, OLM is not installed in the cluster")
 		return nil, nil
 	}
 

--- a/controllers/operator/manager.go
+++ b/controllers/operator/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strconv"
@@ -435,6 +436,14 @@ func (m *ODLMOperator) ListOperandRequestsByConfig(ctx context.Context, key type
 // GetSubscription gets Subscription by name and package name
 func (m *ODLMOperator) GetSubscription(ctx context.Context, name, operatorNs, servicesNs, packageName string) (*olmv1alpha1.Subscription, error) {
 	klog.V(3).Infof("Fetch Subscription %s in operatorNamespace %s and servicesNamespace %s", name, operatorNs, servicesNs)
+
+	no_olm := os.Getenv("NO_OLM")
+	klog.Infof("NO_OLM: %s", no_olm)
+	if no_olm == "true" {
+		klog.Info("No subscription, this is NO_OLM deployment")
+		return nil, nil
+	}
+	klog.Infof("NO_OLM: %s", no_olm)
 
 	tenantScope := make(map[string]struct{})
 	for _, ns := range []string{operatorNs, servicesNs} {

--- a/controllers/util/util.go
+++ b/controllers/util/util.go
@@ -36,7 +36,9 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/util/jsonpath"
+	"k8s.io/klog"
 
 	constant "github.com/IBM/operand-deployment-lifecycle-manager/v4/controllers/constant"
 )
@@ -616,5 +618,34 @@ func HasOtherManagers(labels map[string]string, currentBindInfoNs, currentBindIn
 		}
 	}
 
+	return false
+}
+
+// IsOLMInstalled checks if the cluster has OLM installed by checking for the operators.coreos.com/v1alpha1 API
+func IsOLMInstalled(config *rest.Config) bool {
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		klog.Errorf("Failed to create discovery client: %v", err)
+		return false
+	}
+
+	apiGroupList, err := discoveryClient.ServerGroups()
+	if err != nil {
+		klog.Errorf("Failed to get server groups: %v", err)
+		return false
+	}
+
+	for _, apiGroup := range apiGroupList.Groups {
+		if apiGroup.Name == "operators.coreos.com" {
+			for _, version := range apiGroup.Versions {
+				if version.Version == "v1alpha1" {
+					klog.Info("OLM API (operators.coreos.com/v1alpha1) detected in cluster")
+					return true
+				}
+			}
+		}
+	}
+
+	klog.Info("OLM API (operators.coreos.com/v1alpha1) not found in cluster")
 	return false
 }

--- a/main.go
+++ b/main.go
@@ -56,13 +56,18 @@ var (
 )
 
 func init() {
-	utilruntime.Must(olmv1.AddToScheme(scheme))
-	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+	// Only register OLM types if NO_OLM is not set to true
+	noolm := os.Getenv("NO_OLM")
+	if noolm != "true" {
+		utilruntime.Must(olmv1.AddToScheme(scheme))
+		utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+		utilruntime.Must(operatorsv1.AddToScheme(scheme))
+	}
+
 	utilruntime.Must(nssv1.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
 	utilruntime.Must(operatorv1alpha1.AddToScheme(scheme))
-	utilruntime.Must(operatorsv1.AddToScheme(scheme))
 	utilruntime.Must(ocproute.AddToScheme(scheme))
 	// +kubebuilder:scaffold:scheme
 }

--- a/main.go
+++ b/main.go
@@ -100,9 +100,10 @@ func main() {
 
 	isolatedModeEnable := true
 	operatorCheckerDisable := util.GetoperatorCheckerMode()
-	options = k8sutil.NewODLMCache(isolatedModeEnable, options)
+	config := ctrl.GetConfigOrDie()
+	options = k8sutil.NewODLMCache(isolatedModeEnable, options, config)
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), options)
+	mgr, err := ctrl.NewManager(config, options)
 	if err != nil {
 		klog.Errorf("unable to start manager: %v", err)
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -56,14 +56,9 @@ var (
 )
 
 func init() {
-	// Only register OLM types if NO_OLM is not set to true
-	noolm := os.Getenv("NO_OLM")
-	if noolm != "true" {
-		utilruntime.Must(olmv1.AddToScheme(scheme))
-		utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
-		utilruntime.Must(operatorsv1.AddToScheme(scheme))
-	}
-
+	utilruntime.Must(olmv1.AddToScheme(scheme))
+	utilruntime.Must(olmv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(operatorsv1.AddToScheme(scheme))
 	utilruntime.Must(nssv1.AddToScheme(scheme))
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Check if cluster contain OLM api, 
if not exist 
1. stop cache OLM resource
2. return empty in getSubscription function
3. if it is helm installation use getDeployment instead of getSubscription


Fixes #
https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69507

