### PR TITLE
Conditionally enable OpenShift route RBAC based on Keycloak flag

### DIFF
--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -270,6 +270,18 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 {{- end }}
 - apiGroups:
   - operator.ibm.com
@@ -382,20 +394,6 @@ rules:
   - patch
   - update
   - watch
-{{- if ne (toString $.Values.cpfs.enableKeycloak) "false" }}
-- apiGroups:
-  - route.openshift.io
-  resources:
-  - routes
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - patch
-  - update
-  - watch
-{{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -382,6 +382,7 @@ rules:
   - patch
   - update
   - watch
+{{- if ne (toString $.Values.cpfs.enableKeycloak) "false" }}
 - apiGroups:
   - route.openshift.io
   resources:
@@ -394,6 +395,7 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
**What this PR does / why we need it**: Permissions under `route.openshift.io` are now optional based on `values.cpfs.enableKeycloak`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69553
