### PR TITLE
Remove stale operand CR fields when deleted from OperandConfig

### DIFF
--- a/controllers/operandrequest/reconcile_operand.go
+++ b/controllers/operandrequest/reconcile_operand.go
@@ -863,23 +863,10 @@ func (r *Reconciler) updateCustomResource(ctx context.Context, existingCR unstru
 			return false, err
 		}
 
-		existingCRRaw, err := json.Marshal(existingCR.Object["spec"])
-		if err != nil {
-			klog.Error(err)
-			return false, err
-		}
-
-		// Merge spec from ALM example and existing CR
-		updatedExistingCR := util.MergeCR(configFromALMRaw, existingCRRaw)
-
-		updatedExistingCRRaw, err := json.Marshal(updatedExistingCR)
-		if err != nil {
-			klog.Error(err)
-			return false, err
-		}
-
-		// Merge spec from update existing CR and OperandConfig spec
-		updatedCRSpec := util.MergeCR(updatedExistingCRRaw, crConfig)
+		// Merge ALM example spec with OperandConfig spec.
+		// Using the ALM template as the base (not the existing CR) ensures that
+		// fields removed from OperandConfig are not carried forward from the live CR.
+		updatedCRSpec := util.MergeCR(configFromALMRaw, crConfig)
 
 		if equality.Semantic.DeepEqual(existingCR.Object["spec"], updatedCRSpec) && !forceUpdate {
 			return true, nil

--- a/controllers/operandrequestnoolm/reconcile_operand.go
+++ b/controllers/operandrequestnoolm/reconcile_operand.go
@@ -811,23 +811,10 @@ func (r *Reconciler) updateCustomResource(ctx context.Context, existingCR unstru
 			return false, err
 		}
 
-		existingCRRaw, err := json.Marshal(existingCR.Object["spec"])
-		if err != nil {
-			klog.Error(err)
-			return false, err
-		}
-
-		// Merge spec from ALM example and existing CR
-		updatedExistingCR := util.MergeCR(configFromALMRaw, existingCRRaw)
-
-		updatedExistingCRRaw, err := json.Marshal(updatedExistingCR)
-		if err != nil {
-			klog.Error(err)
-			return false, err
-		}
-
-		// Merge spec from update existing CR and OperandConfig spec
-		updatedCRSpec := util.MergeCR(updatedExistingCRRaw, crConfig)
+		// Merge ALM example spec with OperandConfig spec.
+		// Using the ALM template as the base (not the existing CR) ensures that
+		// fields removed from OperandConfig are not carried forward from the live CR.
+		updatedCRSpec := util.MergeCR(configFromALMRaw, crConfig)
 
 		if equality.Semantic.DeepEqual(existingCR.Object["spec"], updatedCRSpec) && !forceUpdate {
 			return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:
**Description**
When fields (e.g. zenFrontDoor: true, ingress.gvk: none) are added to the Common Service CR and propagated through OperandConfig to the Authentication CR, they are applied correctly. However, when those fields are later removed from the Common Service CR (and cs-operator removes them from OperandConfig), the Authentication CR is never updated the removed fields persist indefinitely.

**Root Cause**
In `updateCustomResource`, the spec merge was performed in two steps:
Step 1: merge ALM template onto the live CR
Step 2: merge that result with the current OperandConfig spec

MergeCR it only adds keys from the ALM template into the second existing CR when they are absent; it never removes keys. Because of this, Step 1 always carried the full live-CR state forward. Step 2 then merged the OperandConfig spec on top of a base that already contained the old fields, so `zenFrontDoor` and `gvk`, present in existingCRRaw, were re-added back into the result, even though they had been removed from OperandConfig.


**Fix**
Replace the two-step merge with a single step that uses the ALM template and OperandConfig and skip use existing CR in the cluster.
However, the trade-off is 
Any field on the operand CR that was edited directly (outside of ODLM) and is not present in the ALM template or OperandConfig will be reset to the ALM default on the next reconcile. 

For ticket: https://github.ibm.com/IBMPrivateCloud/roadmap/issues/69985